### PR TITLE
Allow pagination default size smaller that the maximum size #134

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
@@ -19,13 +19,15 @@ public class DataConfiguration implements DataSettings {
      */
     @ConfigurationProperties(PageableConfiguration.PREFIX)
     public static class PageableConfiguration {
+        public static final int    DEFAULT_MAX_PAGE_SIZE = 100;
+        public static final boolean DEFAULT_SORT_IGNORE_CASE = false;
         public static final String DEFAULT_SORT_PARAMETER = "sort";
         public static final String DEFAULT_SIZE_PARAMETER = "size";
         public static final String DEFAULT_PAGE_PARAMETER = "page";
         public static final String PREFIX = "pageable";
-        private int maxPageSize = 100;
+        private int maxPageSize = DEFAULT_MAX_PAGE_SIZE;
         private int defaultPageSize = maxPageSize;
-        private boolean sortIgnoreCase = false;
+        private boolean sortIgnoreCase = DEFAULT_SORT_IGNORE_CASE;
         private String sortParameterName = DEFAULT_SORT_PARAMETER;
         private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
         private String pageParameterName = DEFAULT_PAGE_PARAMETER;
@@ -78,7 +80,7 @@ public class DataConfiguration implements DataSettings {
 
         /**
          * @return the page size to use when binding {@link io.micronaut.data.model.Pageable}
-         * objects and no size parameter is used.
+         * objects and no size parameter is used. By default is set to the same vale as {@link #maxPageSize}
          */
         public int getDefaultPageSize() {
             return defaultPageSize;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
@@ -24,6 +24,7 @@ public class DataConfiguration implements DataSettings {
         public static final String DEFAULT_PAGE_PARAMETER = "page";
         public static final String PREFIX = "pageable";
         private int maxPageSize = 100;
+        private int defaultPageSize = maxPageSize;
         private boolean sortIgnoreCase = false;
         private String sortParameterName = DEFAULT_SORT_PARAMETER;
         private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
@@ -73,6 +74,24 @@ public class DataConfiguration implements DataSettings {
          */
         public void setMaxPageSize(int maxPageSize) {
             this.maxPageSize = maxPageSize;
+        }
+
+        /**
+         * @return the page size to use when binding {@link io.micronaut.data.model.Pageable}
+         * objects and no size parameter is used.
+         */
+        public int getDefaultPageSize() {
+            return defaultPageSize;
+        }
+
+        /**
+         * Sets the default page size when binding {@link io.micronaut.data.model.Pageable} objects and no size
+         * parameter is used. Should be smaller or equal than {@link #maxPageSize}.
+         *
+         * @param defaultPageSize The default page size
+         */
+        public void setDefaultPageSize(int defaultPageSize) {
+            this.defaultPageSize = defaultPageSize;
         }
 
         /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
@@ -26,7 +26,7 @@ public class DataConfiguration implements DataSettings {
         public static final String DEFAULT_PAGE_PARAMETER = "page";
         public static final String PREFIX = "pageable";
         private int maxPageSize = DEFAULT_MAX_PAGE_SIZE;
-        private int defaultPageSize = maxPageSize;
+        private Integer defaultPageSize = null; // When is not specified the maxPageSize should be used
         private boolean sortIgnoreCase = DEFAULT_SORT_IGNORE_CASE;
         private String sortParameterName = DEFAULT_SORT_PARAMETER;
         private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
@@ -83,7 +83,7 @@ public class DataConfiguration implements DataSettings {
          * objects and no size parameter is used. By default is set to the same vale as {@link #maxPageSize}
          */
         public int getDefaultPageSize() {
-            return defaultPageSize;
+            return defaultPageSize == null ? maxPageSize : defaultPageSize;
         }
 
         /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/http/PageableRequestArgumentBinder.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/http/PageableRequestArgumentBinder.java
@@ -65,8 +65,9 @@ public class PageableRequestArgumentBinder implements TypedRequestArgumentBinder
         int page = Math.max(parameters.getFirst(configuration.getPageParameterName(), Integer.class)
                         .orElse(0), 0);
         final int configuredMaxSize = configuration.getMaxPageSize();
+        final int defaultSize = configuration.getDefaultPageSize();
         int size = Math.min(parameters.getFirst(configuration.getSizeParameterName(), Integer.class)
-                       .orElse(configuredMaxSize), configuredMaxSize);
+                       .orElse(defaultSize), configuredMaxSize);
         String sortParameterName = configuration.getSortParameterName();
         boolean hasSort = parameters.contains(sortParameterName);
         Pageable pageable;
@@ -84,7 +85,7 @@ public class PageableRequestArgumentBinder implements TypedRequestArgumentBinder
             if (page == 0 && configuredMaxSize < 1 && sort == null) {
                 pageable = Pageable.UNPAGED;
             } else {
-                pageable = Pageable.from(page, configuredMaxSize, sort);
+                pageable = Pageable.from(page, defaultSize, sort);
             }
         } else {
             pageable = Pageable.from(page, size, sort);

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
@@ -10,6 +10,7 @@ class PageableConfigSpec extends Specification {
         given:
         def context = ApplicationContext.run(
                 'micronaut.data.pageable.max-page-size': 30,
+                'micronaut.data.pageable.default-page-size': 10,
                 'micronaut.data.pageable.sort-parameter-name': 's',
                 'micronaut.data.pageable.page-parameter-name': 'index',
                 'micronaut.data.pageable.size-parameter-name': 'max'
@@ -18,6 +19,7 @@ class PageableConfigSpec extends Specification {
 
         expect:
         configuration.maxPageSize == 30
+        configuration.defaultPageSize == 10
         configuration.sortParameterName == 's'
         configuration.pageParameterName == 'index'
         configuration.sizeParameterName == 'max'

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
@@ -27,4 +27,13 @@ class PageableConfigSpec extends Specification {
         cleanup:
         context.close()
     }
+
+    void 'defaultPageSize is equal to maxPageSize if not set '(){
+        given:
+           def configuration = new DataConfiguration.PageableConfiguration()
+           configuration.maxPageSize = 50
+
+        expect:
+            configuration.defaultPageSize == 50
+    }
 }


### PR DESCRIPTION
This will add the new property _micronaut.data.pageable.default-page-size_  with the default pagination size. The PageableRequestArgumentBinder is modified to use this new property.

A new test case was added and another modified to check the new property. 

Also, I added constants for a pair of default configuration values as its value was not documented in javadoc. 