### PR TITLE
Adding release automation configuration and bots

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: Micronaut Data $NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+  - title: 🚀 Features
+    label: "type: enhancement"
+  - title: 🐛 Bug Fixes
+    label: "type: bug"
+  - title: 🛠 Dependency upgrades
+    label: "type: dependencies"
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,8 +3,8 @@ daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
-#exemptLabels:
-#  - pinned
+exemptLabels:
+ - "type: enhancement"
 #  - security
 # Label to use when marking an issue as stale
 staleLabel: "status: stale"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+#exemptLabels:
+#  - pinned
+#  - security
+# Label to use when marking an issue as stale
+staleLabel: "status: stale"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,28 +7,39 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
         ref: ${{ github.head_ref }}
+    - name: Set the current release version
+      id: release_version
+      run: echo ::set-output name=release_version::${GITHUB_REF:11}
+    - name: Run pre-release
+      uses: micronaut-projects/github-actions/pre-release@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish to Bintray
       env:
          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
       run: ./gradlew bintrayUpload docs
-    - id: release_version
-      run: echo ::set-output name=release_version::${GITHUB_REF:11}
     - name: Publish to Github Pages
       if: success()
       uses: micronaut-projects/github-pages-deploy-action@master
       env:
+        BETA: ${{ contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         BASE_BRANCH: master 
         BRANCH: gh-pages 
         FOLDER: build/docs
         VERSION: ${{ steps.release_version.outputs.release_version }}
+    - name: Run post-release
+      if: success()
+      uses: micronaut-projects/github-actions/post-release@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Synchronize Maven Central
       if: success()
       env:


### PR DESCRIPTION
To enable the stale bot, [install it](https://probot.github.io/apps/stale/) in this repo.

Note that the `BETA` value calculation will only work for versions released from master. Whenever you create a 1.0.x branch, `BETA` should be set to `true` there to prevent older releases to become the latest.