### PR TITLE
Update docs

### DIFF
--- a/benchmarks/benchmark-gorm-hibernate/gradle.properties
+++ b/benchmarks/benchmark-gorm-hibernate/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/benchmarks/benchmark-micronaut-data-jdbc/gradle.properties
+++ b/benchmarks/benchmark-micronaut-data-jdbc/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/benchmarks/benchmark-micronaut-data-jpa/gradle.properties
+++ b/benchmarks/benchmark-micronaut-data-jpa/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/benchmarks/benchmark-spring-data-jdbc/gradle.properties
+++ b/benchmarks/benchmark-spring-data-jdbc/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/benchmarks/benchmark-spring-data/gradle.properties
+++ b/benchmarks/benchmark-spring-data/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/example-groovy/gradle.properties
+++ b/doc-examples/example-groovy/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/example-hibernate-and-jdbc/gradle.properties
+++ b/doc-examples/example-hibernate-and-jdbc/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/example-java/gradle.properties
+++ b/doc-examples/example-java/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/example-kotlin/gradle.properties
+++ b/doc-examples/example-kotlin/gradle.properties
@@ -1,3 +1,4 @@
 kotlinVersion=1.3.21
 spekVersion=1.1.5
 junitVersion=5.3.1
+skipDocumentation=true

--- a/doc-examples/jdbc-example-groovy/gradle.properties
+++ b/doc-examples/jdbc-example-groovy/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/jdbc-example-java/gradle.properties
+++ b/doc-examples/jdbc-example-java/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/doc-examples/jdbc-example-kotlin/gradle.properties
+++ b/doc-examples/jdbc-example-kotlin/gradle.properties
@@ -1,3 +1,4 @@
 kotlinVersion=1.3.21
 spekVersion=1.1.5
 junitVersion=5.3.1
+skipDocumentation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=1.0.1.BUILD-SNAPSHOT
-micronautDocsVersion=1.0.13
+micronautDocsVersion=1.0.21
 micronautBuildVersion=1.0.0
 micronautVersion=1.2.8
 micronautTestVersion=1.1.2


### PR DESCRIPTION
It updates to the latest Micronaut docs version and also configure `benchmark` and `doc-examples` submodules to skip documentation. 