### PR TITLE
Add DataSourceResolver for transactional proxy

### DIFF
--- a/data-tx/build.gradle
+++ b/data-tx/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api 'jakarta.transaction:jakarta.transaction-api:1.3.3'
 
     // optional dependencies
+    compileOnly "io.micronaut:micronaut-jdbc:$micronautVersion"
     compileOnly "org.springframework:spring-jdbc:5.2.4.RELEASE"
     compileOnly "io.micronaut.test:micronaut-test-core:$micronautTestVersion"
 
@@ -17,6 +18,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-inject-java-test:$micronautVersion"
     testImplementation "com.fasterxml.jackson.core:jackson-databind"
 
+    testImplementation "io.micronaut:micronaut-jdbc:$micronautVersion"
     testRuntimeOnly "com.h2database:h2"
     testRuntimeOnly "io.micronaut.configuration:micronaut-jdbc-tomcat"
 

--- a/data-tx/src/main/java/io/micronaut/transaction/jdbc/DelegatingDataSourceResolver.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/jdbc/DelegatingDataSourceResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.transaction.jdbc;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.jdbc.DataSourceResolver;
+
+import javax.inject.Singleton;
+import javax.sql.DataSource;
+
+/**
+ * Unwraps transactional data source proxies.
+ *
+ * @author Vladimir Kulev
+ * @since 1.0.1
+ */
+@Singleton
+@Internal
+// only enable if spring transaction management is not present
+@Requires(missingClasses = "org.springframework.jdbc.datasource.DataSourceTransactionManager")
+@Requires(classes = DataSourceResolver.class)
+public class DelegatingDataSourceResolver implements DataSourceResolver {
+
+    @Override
+    public DataSource resolve(DataSource dataSource) {
+        return DelegatingDataSource.unwrapDataSource(dataSource);
+    }
+
+}


### PR DESCRIPTION
This will allow to solve a number of issues where normal non-proxied data source is expected.

To name a few:
1. micronaut-flyway #435
2. micronaut-management health indicator
3. micronaut-sql jooq integration (dialect detection at startup)

All those libraries are yet have to be updated to use DataSourceResolver.