### PR TITLE
Improve to-many-joins. Fixes #401

### DIFF
--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JoinPathSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JoinPathSpec.groovy
@@ -396,8 +396,8 @@ interface MyInterface extends io.micronaut.data.tck.repositories.ShelfRepository
         def query = method.stringValue(Query).get()
 
         expect:
-        query.contains('LEFT JOIN book_page p_book_page_ ON b_."id"=p_book_page_.book_id ')
         query.contains('LEFT JOIN shelf_book b_shelf_book_ ON shelf_."id"=b_shelf_book_.shelf_id ')
-        query.contains('LEFT JOIN "page" p_ ON p_book_page_.page_id=p_."id" ')
+        query.contains('LEFT JOIN "book" b_ ON b_shelf_book_.book_id=b_."id" ')
+        query.contains('LEFT JOIN "page" p_ ON b_."id"=p_."book_id" ')
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
@@ -15,14 +15,14 @@
  */
 package io.micronaut.data.runtime.mapper;
 
+import java.math.BigDecimal;
+import java.util.Date;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.data.exceptions.DataAccessException;
 import io.micronaut.data.model.DataType;
-
-import java.math.BigDecimal;
-import java.util.Date;
 
 /**
  * A result reader is a type that is capable of reading data from the given result set type.
@@ -61,25 +61,6 @@ public interface ResultReader<RS, IDX> {
      */
     @Nullable <T> T getRequiredValue(RS resultSet, IDX name, Class<T> type)
         throws DataAccessException;
-
-    /**
-     * Read the next value dynamically using the result set and the given name and data type.
-     * @param resultSet The result set
-     * @param index The name
-     * @param dataType The data type
-     * @return The value, can be null
-     * @throws DataAccessException if the value cannot be read
-     */
-    default @Nullable Object readNextDynamic(
-            @NonNull RS resultSet,
-            @NonNull IDX index,
-            @NonNull DataType dataType) {
-        if (next(resultSet)) {
-            return readDynamic(resultSet, index, dataType);
-        } else {
-            return null;
-        }
-    }
 
     /**
      * Move the index to the next result if possible.

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -16,35 +16,13 @@
 package io.micronaut.data.tck.tests
 
 import io.micronaut.data.exceptions.EmptyResultException
-import io.micronaut.data.model.Page
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
-import io.micronaut.data.tck.entities.Author
-import io.micronaut.data.tck.entities.Book
-import io.micronaut.data.tck.entities.BookDto
-import io.micronaut.data.tck.entities.City
-import io.micronaut.data.tck.entities.Company
-import io.micronaut.data.tck.entities.Country
-import io.micronaut.data.tck.entities.CountryRegion
-import io.micronaut.data.tck.entities.CountryRegionCity
-import io.micronaut.data.tck.entities.Face
-import io.micronaut.data.tck.entities.Nose
-import io.micronaut.data.tck.entities.Person
-import io.micronaut.data.tck.repositories.AuthorRepository
-import io.micronaut.data.tck.repositories.BookDtoRepository
-import io.micronaut.data.tck.repositories.BookRepository
-import io.micronaut.data.tck.repositories.CityRepository
-import io.micronaut.data.tck.repositories.CompanyRepository
-import io.micronaut.data.tck.repositories.CountryRepository
-import io.micronaut.data.tck.repositories.FaceRepository
-import io.micronaut.data.tck.repositories.NoseRepository
-import io.micronaut.data.tck.repositories.PersonRepository
-import io.micronaut.data.tck.repositories.RegionRepository
-import spock.lang.Ignore
+import io.micronaut.data.tck.entities.*
+import io.micronaut.data.tck.repositories.*
 import spock.lang.Specification
 import spock.lang.Stepwise
 
-import java.time.Instant
 import java.time.LocalDate
 
 @Stepwise
@@ -545,7 +523,68 @@ abstract class AbstractRepositorySpec extends Specification {
         results.first().name == 'Google'
     }
 
+    void "test one-to-many mappedBy"() {
+        when:"a one-to-many is saved"
+        def author = new Author()
+        author.name = "author"
 
+        def book1 = new Book()
+        book1.title = "Book1"
+        def page1 = new io.micronaut.data.tck.entities.Page()
+        page1.num = 1
+        book1.getPages().add(page1)
+
+        def book2 = new Book()
+        book2.title = "Book2"
+        def page21 = new io.micronaut.data.tck.entities.Page()
+        def page22 = new io.micronaut.data.tck.entities.Page()
+        page21.num = 21
+        page22.num = 22
+        book2.getPages().add(page21)
+        book2.getPages().add(page22)
+
+        def book3 = new Book()
+        book3.title = "Book3"
+        def page31 = new io.micronaut.data.tck.entities.Page()
+        def page32 = new io.micronaut.data.tck.entities.Page()
+        def page33 = new io.micronaut.data.tck.entities.Page()
+        page31.num = 31
+        page32.num = 32
+        page33.num = 33
+        book3.getPages().add(page31)
+        book3.getPages().add(page32)
+        book3.getPages().add(page33)
+
+        author.getBooks().add(book1)
+        author.getBooks().add(book2)
+        author.getBooks().add(book3)
+        author = authorRepository.save(author)
+
+        then: "They are saved correctly"
+        println(author)
+        author.id
+
+        when:"retrieving an author"
+        author = authorRepository.findById(author.id).orElse(null)
+
+        then:"the associations are correct"
+        author.getBooks().size() == 3
+
+        def result1 = author.getBooks().find {book -> book.title == "Book1" }
+        result1.pages.size() == 1
+        result1.pages.find {page -> page.num = 1}
+
+        def result2 = author.getBooks().find {book -> book.title == "Book2" }
+        result2.pages.size() == 2
+        result2.pages.find {page -> page.num = 21}
+        result2.pages.find {page -> page.num = 22}
+
+        def result3 = author.getBooks().find {book -> book.title == "Book3" }
+        result3.pages.size() == 3
+        result3.pages.find {page -> page.num = 31}
+        result3.pages.find {page -> page.num = 32}
+        result3.pages.find {page -> page.num = 33}
+    }
 
     void "test one-to-one mappedBy"() {
         when:"when a one-to-one mapped by is saved"

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/Author.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/Author.java
@@ -15,9 +15,15 @@
  */
 package io.micronaut.data.tck.entities;
 
-import javax.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 @Entity
 public class Author {

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/Book.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/Book.java
@@ -15,9 +15,16 @@
  */
 package io.micronaut.data.tck.entities;
 
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 @Entity
 public class Book {
@@ -33,7 +40,7 @@ public class Book {
     @ManyToOne
     private Publisher publisher;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "book")
     private List<Page> pages = new ArrayList<>();
 
     public List<Page> getPages() {
@@ -83,5 +90,4 @@ public class Book {
     public void setPublisher(Publisher publisher) {
         this.publisher = publisher;
     }
-
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/Page.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/Page.java
@@ -3,6 +3,7 @@ package io.micronaut.data.tck.entities;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Page {
@@ -10,6 +11,9 @@ public class Page {
     @Id
     private Long id;
     private long num;
+
+    @ManyToOne
+    private Book book;
 
     public Long getId() {
         return id;
@@ -25,5 +29,13 @@ public class Page {
 
     public void setNum(long num) {
         this.num = num;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
     }
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.tck.repositories;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.Join;
@@ -22,9 +23,18 @@ import io.micronaut.data.repository.CrudRepository;
 import io.micronaut.data.tck.entities.Author;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface AuthorRepository extends CrudRepository<Author, Long> {
+
+    @NonNull
+    @Override
+    @Join(value = "books", alias = "b", type = Join.Type.LEFT_FETCH)
+    @Join(value = "books.pages", alias = "bp", type = Join.Type.LEFT_FETCH)
+    Optional<Author> findById(@NonNull @NotNull Long aLong);
 
     Author findByName(String name);
 


### PR DESCRIPTION
There were two major flaws in the handling of to-many-joins:
* Calling `nextId` didn't read the correct column
* `nextId` didn't take `hasNext` into account

Besides, other small changes:
* Cleanup `SqlResultEntityTypeMapper`
* Remove `readNextDynamic` since it's don't take `hasNext` in `SqlResultEntityTypeMapper` into account
* Add and adapt tests