### PR TITLE
MySQL Data too long for UUID

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
@@ -239,7 +239,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS> implements Reposit
                             if (DataSettings.QUERY_LOG.isTraceEnabled()) {
                                 DataSettings.QUERY_LOG.trace("Binding value {} to parameter at position: {}", uuid, index);
                             }
-                            if (insert.dialect == Dialect.ORACLE) {
+                            if (insert.dialect == Dialect.MYSQL || insert.dialect == Dialect.ORACLE) {
                                 preparedStatementWriter.setString(
                                         stmt,
                                         index,

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -385,11 +385,6 @@ abstract class AbstractRepositorySpec extends Specification {
     }
 
     void "test query across multiple associations"() {
-        given:"TODO: Figure out why this join fails on mysql"
-        def specName = specificationContext.currentSpec.name
-        if (specName.contains("MySql") || specName.contains("Maria")) {
-            return
-        }
         when:
         def spain = new Country("Spain")
         def france = new Country("France")
@@ -424,12 +419,6 @@ abstract class AbstractRepositorySpec extends Specification {
         cityRepository.countByCountryRegionCountryName("Spain") == 2
         cityRepository.countByCountryRegionCountryName("France") == 1
 
-        when:"A join that uses a join table is executed"
-        def region = regionRepository.findByCitiesName("Bilbao")
-
-        then:"The result is correct"
-        region.name == 'Pais Vasco'
-
         when:"A single level join is executed"
         def results = cityRepository.findByCountryRegionCountryName("Spain")
 
@@ -459,6 +448,17 @@ abstract class AbstractRepositorySpec extends Specification {
         results[1].countryRegion.name == 'Madrid'
         results[1].countryRegion.country.uuid == spain.uuid
         results[1].countryRegion.country.name == "Spain"
+
+        when:"A join that uses a join table is executed"
+        //TODO: Figure out why this join fails on mysql
+        def specName = specificationContext.currentSpec.name
+        if (specName.contains("MySql") || specName.contains("Maria")) {
+            return
+        }
+        def region = regionRepository.findByCitiesName("Bilbao")
+
+        then:"The result is correct"
+        region.name == 'Pais Vasco'
     }
 
     void "test find by name"() {


### PR DESCRIPTION
test ` void "test query across multiple associations"() {` reproduced the error reported here: 

https://github.com/micronaut-projects/micronaut-data/issues/561

which this PR fixes. 

I have just left ignored the part of the test which exercise the failing query. 