### PR TITLE
Improve error messages for update methods with invalid return types

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -462,8 +462,12 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
             this.failing = true;
 
-            String messageStart = matchContext.getUnableToImplementMessage();
-            context.fail(messageStart + "No possible implementations found.", element);
+            if (matchContext.isPossiblyFailing()) {
+                matchContext.logPossibleFailures();
+            } else {
+                String messageStart = matchContext.getUnableToImplementMessage();
+                context.fail(messageStart + "No possible implementations found.", element);
+            }
         }
     }
 

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/ProjectionMethodExpression.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/ProjectionMethodExpression.java
@@ -21,7 +21,6 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.data.model.Association;
-import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.query.QueryModel;
 import io.micronaut.data.processor.model.SourcePersistentEntity;
 import io.micronaut.data.processor.model.SourcePersistentProperty;
@@ -32,7 +31,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 
 /**
  * Method expression for performing a projection of some sort.

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateByMethod.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateByMethod.java
@@ -55,7 +55,15 @@ public class UpdateByMethod extends DynamicFinder {
 
     @Override
     public boolean isMethodMatch(MethodElement methodElement, MatchContext matchContext) {
-        return super.isMethodMatch(methodElement, matchContext) && TypeUtils.isValidBatchUpdateReturnType(methodElement);
+        boolean isMatch = super.isMethodMatch(methodElement, matchContext);
+        if (isMatch) {
+            if (!TypeUtils.isValidBatchUpdateReturnType(methodElement)) {
+                matchContext.possiblyFail("Update methods only support void or number based return types");
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateMethod.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateMethod.java
@@ -61,10 +61,17 @@ public class UpdateMethod extends AbstractPatternBasedMethod {
 
     @Override
     public boolean isMethodMatch(MethodElement methodElement, MatchContext matchContext) {
-        return super.isMethodMatch(methodElement, matchContext) &&
+        boolean isMatch = super.isMethodMatch(methodElement, matchContext) &&
                 methodElement.getParameters().length > 1 &&
-                TypeUtils.isValidBatchUpdateReturnType(methodElement) &&
                 hasIdParameter(methodElement.getParameters());
+        if (isMatch) {
+            if (!TypeUtils.isValidBatchUpdateReturnType(methodElement)) {
+                matchContext.possiblyFail("Update methods only support void or number based return types");
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean hasIdParameter(ParameterElement[] parameters) {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildUpdateSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildUpdateSpec.groovy
@@ -155,4 +155,23 @@ interface PersonRepository extends CrudRepository<Person, Long> {
         expect:
         updateQuery == 'UPDATE `person` SET `name`=? WHERE (`id` = ?)'
     }
+
+    void "test error message for update method with invalid return type"() {
+        when:
+        buildRepository('test.PersonRepository', """
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.entities.Person;
+
+@JdbcRepository(dialect= Dialect.MYSQL)
+interface PersonRepository extends CrudRepository<Person, Long> {
+
+    Person updatePerson(@Id Long id, String name);
+}
+""")
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message.contains("Update methods only support void or number based return types")
+    }
 }


### PR DESCRIPTION
This allows for error messages for specific issues to be logged instead of the generic message