### PR TITLE
Map Instant to java.sql.Timestamp in order to preserve nano-second precision.

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
@@ -52,6 +52,12 @@ class DataInitializer {
         conversionService.addConverter(Instant.class, Date.class, instant ->
                 new Date(instant.toEpochMilli())
         );
+        conversionService.addConverter(Instant.class, Timestamp.class, instant ->
+        {
+            Timestamp timestamp = new Timestamp(instant.toEpochMilli());
+            timestamp.setNanos(instant.getNano());
+            return timestamp;
+        });
         conversionService.addConverter(LocalDateTime.class, Date.class, localDateTime ->
                 new Date(localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
         );
@@ -78,7 +84,12 @@ class DataInitializer {
                 offsetDateTime.toInstant().toEpochMilli()
         );
         conversionService.addConverter(OffsetDateTime.class, Timestamp.class, offsetDateTime ->
-                new Timestamp(offsetDateTime.toInstant().toEpochMilli())
+            {
+                Instant instant = offsetDateTime.toInstant();
+                Timestamp timestamp = new Timestamp(instant.toEpochMilli());
+                timestamp.setNanos(instant.getNano());
+                return timestamp;
+            }
         );
         conversionService.addConverter(OffsetDateTime.class, LocalDateTime.class, OffsetDateTime::toLocalDateTime);
         conversionService.addConverter(OffsetDateTime.class, LocalDate.class, OffsetDateTime::toLocalDate);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
@@ -52,8 +52,7 @@ class DataInitializer {
         conversionService.addConverter(Instant.class, Date.class, instant ->
                 new Date(instant.toEpochMilli())
         );
-        conversionService.addConverter(Instant.class, Timestamp.class, instant ->
-        {
+        conversionService.addConverter(Instant.class, Timestamp.class, instant -> {
             Timestamp timestamp = new Timestamp(instant.toEpochMilli());
             timestamp.setNanos(instant.getNano());
             return timestamp;
@@ -83,8 +82,7 @@ class DataInitializer {
         conversionService.addConverter(OffsetDateTime.class, Long.class, offsetDateTime ->
                 offsetDateTime.toInstant().toEpochMilli()
         );
-        conversionService.addConverter(OffsetDateTime.class, Timestamp.class, offsetDateTime ->
-            {
+        conversionService.addConverter(OffsetDateTime.class, Timestamp.class, offsetDateTime -> {
                 Instant instant = offsetDateTime.toInstant();
                 Timestamp timestamp = new Timestamp(instant.toEpochMilli());
                 timestamp.setNanos(instant.getNano());

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/QueryStatement.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/QueryStatement.java
@@ -102,7 +102,7 @@ public interface QueryStatement<PS, IDX> {
                 } else if (value instanceof Date) {
                     return setTimestamp(statement, index, ((Date) value));
                 } else {
-                    return setTimestamp(statement, index, convertRequired(value, Date.class));
+                    return setTimestamp(statement, index, convertRequired(value, Timestamp.class));
                 }
             case UUID:
                 if (value instanceof CharSequence) {


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-data/issues/676