### PR TITLE
Add getter for AbstractRepositorySpec#context

### DIFF
--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -871,4 +871,9 @@ abstract class AbstractRepositorySpec extends Specification {
         GregorianCalendar calendar = new GregorianCalendar(localDate.year, localDate.month.value, localDate.dayOfMonth)
         calendar
     }
+
+    protected ApplicationContext getApplicationContext() {
+        return context;
+    }
+
 }


### PR DESCRIPTION
I'm trying to setup some test for ignite-data using data-tck but I'm only able to retrieve the context from the compiled groovy code. The property itself is defined as `this.$spock_sharedField_context` and `get$spock_sharedField_context()`. I added a `getApplicationContext()` to avoid this. 


```
class IgniteRepositorySpec extends AbstractRepositorySpec implements IgniteTestPropertyProvider{

    @Shared
    IgnitePersonRepository pr =  $spock_sharedField_context.getBean(IgnitePersonRepository)
...
```

Here is the java defined from the class when I use data.tck
```
public abstract class AbstractRepositorySpec extends Specification implements GroovyObject {
    @AutoCleanup
    @Shared
    @FieldMetadata(
        line = 50,
        name = "context",
        ordinal = 0,
        initializer = true
    )
    protected volatile ApplicationContext $spock_sharedField_context;

    @Generated
    public AbstractRepositorySpec() {
        CallSite[] var1 = $getCallSiteArray();
        super();
        MetaClass var2 = this.$getStaticMetaClass();
        this.metaClass = var2;
    }

```

https://github.com/micronaut-projects/micronaut-ignite/pull/29