### PR TITLE
Note that deleteAll does not cascade.

### DIFF
--- a/src/main/docs/guide/dataUpdates/batchDeletes.adoc
+++ b/src/main/docs/guide/dataUpdates/batchDeletes.adoc
@@ -2,6 +2,8 @@ Batch deletes can be performed in a number of ways. To delete everything (use wi
 
 snippet::example.BookRepository[project-base="doc-examples/example", source="main", tags="deleteall", indent="0"]
 
+NOTE: `deleteAll` does not cascade. Delete all foreign key references first or use `delete` on all individual items.
+
 To delete by ID or by the value of a property you can specify a parameter that matches a property of an entity:
 
 snippet::example.BookRepository[project-base="doc-examples/example", source="main", tags="deleteone", indent="0"]


### PR DESCRIPTION
As mentioned by @graemerocher in https://github.com/micronaut-projects/micronaut-data/issues/684

Feel free to move or change this `NOTE` if it also applies to other batch operations and not only deleteAll.