### PR TITLE
issue-766: add null check when converting to json to prevent 'null' string to be persisted instead of null

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
@@ -245,7 +245,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS> implements Reposit
                         if (DataSettings.QUERY_LOG.isTraceEnabled()) {
                             DataSettings.QUERY_LOG.trace("Binding value {} to parameter at position: {}", value, index);
                         }
-                        if (type == DataType.JSON && jsonCodec != null) {
+                        if (type == DataType.JSON && jsonCodec != null && value != null) {
                             value = new String(jsonCodec.encode(value), StandardCharsets.UTF_8);
                         }
                         preparedStatementWriter.setDynamic(

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -569,7 +569,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                             }
                                         }
                                     }
-                                } else if (dataType == DataType.JSON && jsonCodec != null) {
+                                } else if (dataType == DataType.JSON && jsonCodec != null && newValue != null) {
                                     String value = new String(jsonCodec.encode(newValue), StandardCharsets.UTF_8);
                                     if (QUERY_LOG.isTraceEnabled()) {
                                         QUERY_LOG.trace("Binding parameter at position {} to value {}", i + 1, value);


### PR DESCRIPTION
AbstractRepositorySpec ("test date created and last updated") does not work locally for me (with or without the changes) so I figure out there I don't have to fix the issue...  Could be timezone related, I am in Canada Eastern time.

Please do not hesitate to comment if my PR process isn't right (fork, ...) as this is my 1st contribution.