### PR TITLE
Fix  native queries with simple type (#653)

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -31,6 +31,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.QueryHint;
 import io.micronaut.data.jpa.annotation.EntityGraph;
 import io.micronaut.data.jpa.operations.JpaRepositoryOperations;
+import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
@@ -155,8 +156,13 @@ public class HibernateJpaOperations implements JpaRepositoryOperations, AsyncCap
                 Query<R> q;
 
                 if (preparedQuery.isNative()) {
-                    q = currentSession
-                            .createNativeQuery(query, resultType);
+                    if (DataType.ENTITY.equals(preparedQuery.getResultDataType())) {
+                        q = currentSession
+                                .createNativeQuery(query, resultType);
+                    } else {
+                        q = currentSession
+                                .createNativeQuery(query);
+                    }
                 } else {
                     q = currentSession
                             .createQuery(query, resultType);

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/ScalarProjectionSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/ScalarProjectionSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.data.hibernate.entities.Children
+import io.micronaut.data.hibernate.entities.ChildrenId
+import io.micronaut.test.annotation.MicronautTest
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest(packages = "io.micronaut.data.hibernate.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+class ScalarProjectionSpec extends Specification {
+    @Shared
+    @Inject
+    ChildrenRepository childrenRepository
+
+    void setupSpec() {
+        childrenRepository.saveAll([
+                new Children(new ChildrenId(1, 1)),
+                new Children(new ChildrenId(1, 2)),
+                new Children(new ChildrenId(1, 3)),
+                new Children(new ChildrenId(1, 42)),
+                new Children(new ChildrenId(2, 1)),
+                new Children(new ChildrenId(2, 2))
+        ])
+    }
+
+    void "Native queries with simple type result"() {
+        when:
+        def max = childrenRepository.getMaxNumber(1)
+
+        then:
+        max == 42
+    }
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/ChildrenRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/ChildrenRepository.java
@@ -1,0 +1,16 @@
+package io.micronaut.data.hibernate;
+
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.hibernate.entities.Children;
+import io.micronaut.data.hibernate.entities.ChildrenId;
+import io.micronaut.data.jpa.repository.JpaRepository;
+
+@Repository
+public interface ChildrenRepository extends JpaRepository<Children, ChildrenId> {
+
+    //int findMaxIdNumberByIdParentId(int parentId);
+
+    @Query(nativeQuery = true, value = "SELECT max(c.number) FROM children c WHERE c.parent_id = :parentId")
+    Integer getMaxNumber(int parentId);
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/Children.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/Children.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.hibernate.entities;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+public class Children {
+
+    @EmbeddedId
+    private ChildrenId id;
+
+    @Nullable
+    private String name;
+
+    public Children(ChildrenId id) {
+        this.id = id;
+    }
+
+    public ChildrenId getId() {
+        return id;
+    }
+
+    public void setId(ChildrenId id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/ChildrenId.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/ChildrenId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.hibernate.entities;
+
+import io.micronaut.data.annotation.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class ChildrenId implements Serializable {
+    private final Integer parentId;
+    private final Integer number;
+
+    public ChildrenId(Integer parentId, Integer number) {
+        this.parentId = parentId;
+        this.number = number;
+    }
+}


### PR DESCRIPTION
* Entities and Spec to reproduce #653
* HibernateJpaOperations.findOne: use a native query when result type is not an entity