### PR TITLE
Prevent NPE with empty Spring JPA specifications

### DIFF
--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/CountSpecificationInterceptor.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/CountSpecificationInterceptor.java
@@ -68,7 +68,9 @@ public class CountSpecificationInterceptor extends AbstractQueryInterceptor<Obje
             final CriteriaQuery<Long> query = criteriaBuilder.createQuery(Long.class);
             final Root<?> root = query.from(getRequiredRootEntity(context));
             final Predicate predicate = specification.toPredicate(root, query, criteriaBuilder);
-            query.where(predicate);
+            if (predicate != null) {
+                query.where(predicate);
+            }
             if (query.isDistinct()) {
                 query.select(criteriaBuilder.countDistinct(root));
             } else {

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindAllSpecificationInterceptor.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindAllSpecificationInterceptor.java
@@ -66,7 +66,9 @@ public class FindAllSpecificationInterceptor extends AbstractQueryInterceptor<Ob
             final CriteriaQuery<Object> query = criteriaBuilder.createQuery((Class<Object>) getRequiredRootEntity(context));
             final Root<Object> root = query.from((Class<Object>) getRequiredRootEntity(context));
             final Predicate predicate = specification.toPredicate(root, query, criteriaBuilder);
-            query.where(predicate);
+            if (predicate != null) {
+                query.where(predicate);
+            }
             query.select(root);
 
 

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindOneSpecificationInterceptor.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindOneSpecificationInterceptor.java
@@ -69,7 +69,9 @@ public class FindOneSpecificationInterceptor extends AbstractQueryInterceptor<Ob
             final CriteriaQuery<Object> query = criteriaBuilder.createQuery((Class<Object>) getRequiredRootEntity(context));
             final Root<Object> root = query.from((Class<Object>) getRequiredRootEntity(context));
             final Predicate predicate = specification.toPredicate(root, query, criteriaBuilder);
-            query.where(predicate);
+            if (predicate != null) {
+                query.where(predicate);
+            }
             query.select(root);
 
             final TypedQuery<?> typedQuery = entityManager.createQuery(query);

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindPageSpecificationInterceptor.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindPageSpecificationInterceptor.java
@@ -72,7 +72,9 @@ public class FindPageSpecificationInterceptor extends AbstractQueryInterceptor<O
             final CriteriaQuery<Object> query = criteriaBuilder.createQuery((Class<Object>) getRequiredRootEntity(context));
             final Root<Object> root = query.from((Class<Object>) getRequiredRootEntity(context));
             final Predicate predicate = specification.toPredicate(root, query, criteriaBuilder);
-            query.where(predicate);
+            if (predicate != null) {
+                query.where(predicate);
+            }
             query.select(root);
 
             if (pageableObject instanceof Pageable) {


### PR DESCRIPTION
An empty specification can be built with `Specification.where(null)` and will result in a null predicate, causing a null pointer exception:

```
00:05:51.901 [io-executor-thread-1] ERROR i.m.h.s.netty.RoutingInBoundHandler - Unexpected error occurred: null
java.lang.NullPointerException: null
	at org.hibernate.query.criteria.internal.predicate.BooleanExpressionPredicate.render(BooleanExpressionPredicate.java:48)
	at org.hibernate.query.criteria.internal.predicate.AbstractSimplePredicate.render(AbstractSimplePredicate.java:48)
	at org.hibernate.query.criteria.internal.QueryStructure.renderWhereClause(QueryStructure.java:351)
	at org.hibernate.query.criteria.internal.QueryStructure.render(QueryStructure.java:238)
	at org.hibernate.query.criteria.internal.CriteriaQueryImpl.interpret(CriteriaQueryImpl.java:297)
	at org.hibernate.query.criteria.internal.compile.CriteriaCompiler.compile(CriteriaCompiler.java:165)
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:742)
	at org.hibernate.internal.AbstractSessionImpl.createQuery(AbstractSessionImpl.java:23)
	at io.micronaut.data.spring.jpa.intercept.FindAllSpecificationInterceptor.intercept(FindAllSpecificationInterceptor.java:74)
	at io.micronaut.data.intercept.DataIntroductionAdvice.intercept(DataIntroductionAdvice.java:80)
	at io.micronaut.aop.chain.MethodInterceptorChain.proceed(MethodInterceptorChain.java:82)
	at io.micronaut.validation.ValidatingInterceptor.intercept(ValidatingInterceptor.java:139)
	at io.micronaut.aop.chain.MethodInterceptorChain.proceed(MethodInterceptorChain.java:82)
```

