### PR TITLE
Fix not necessary readonly check

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentProperty.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentProperty.java
@@ -84,7 +84,7 @@ public class RuntimePersistentProperty<T> implements PersistentProperty {
 
     @Override
     public boolean isReadOnly() {
-        return property.isReadOnly() || isGenerated();
+        return property.isReadOnly();
     }
 
     /**

--- a/data-runtime/src/test/groovy/io/micronaut/data/model/query/builder/RuntimePersistentEntitySpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/model/query/builder/RuntimePersistentEntitySpec.groovy
@@ -42,8 +42,8 @@ class RuntimePersistentEntitySpec extends Specification {
         entity.identity.name == 'id'
         entity.persistentProperties
         entity.getPropertyByName("name")
-        !entity.getPropertyByName("name").isReadOnly()
-        entity.getPropertyByName("someId").isReadOnly()
+        !entity.getPropertyByName("name").isGenerated()
+        entity.getPropertyByName("someId").isGenerated()
     }
 
     void "test associations"() {


### PR DESCRIPTION
`isReadOnly` is used in 2 places:

First place:

The  `isReadOnly` is already protected by `prop.isGenerated()` at line 415
https://github.com/micronaut-projects/micronaut-data/blob/f0dcce389efe94c2eee15250445a481651f44c78/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java#L414-L431

Second place:

https://github.com/micronaut-projects/micronaut-data/blob/f0dcce389efe94c2eee15250445a481651f44c78/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java#L349-L362

This second place is causing unmapped entities for `GeneratedValue` such as:

```
  @GeneratedValue
  @ColumnDefault("CURRENT_TIMESTAMP(6)")
  @Column(nullable = false)
  private LocalDateTime createdAt;
```

When the bean is trying to map, the `GeneratedValue` fields are skipped at line 350



