### PR TITLE
Fix  @Where placeholder cannot be resolved (#790)

### DIFF
--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
@@ -36,6 +36,15 @@ class HibernateQuerySpec extends AbstractQuerySpec {
     @Inject
     AuthorRepository ar
 
+    void "test @Where annotation placehoder"() {
+        given:
+        def size = bookRepository.countNativeByTitleWithPagesGreaterThan("The%", 300)
+        def books = bookRepository.findByTitleStartsWith("The", 300)
+
+        expect:
+        books.size() == size
+    }
+
     void "test native query"() {
         given:
         def books = bookRepository.listNativeBooks("The%")

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
@@ -17,6 +17,7 @@ package io.micronaut.data.hibernate;
 
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.annotation.Where;
 import io.micronaut.data.jpa.annotation.EntityGraph;
 import io.micronaut.data.repository.CrudRepository;
 import io.micronaut.data.tck.entities.Author;
@@ -45,4 +46,10 @@ public abstract class BookRepository extends io.micronaut.data.tck.repositories.
             }
     )
     abstract List<Book> findAllByTitleStartsWith(String text);
+
+    @Where(value = "total_pages > :pages")
+    abstract List<Book> findByTitleStartsWith(String title, int pages);
+
+    @Query(value = "select count(*) from book b where b.title like :title and b.total_pages > :pages", nativeQuery = true)
+    abstract int countNativeByTitleWithPagesGreaterThan(String title, int pages);
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2QuerySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2QuerySpec.groovy
@@ -43,6 +43,15 @@ class H2QuerySpec extends AbstractQuerySpec {
         return ar
     }
 
+    void "test @Where annotation placehoder"() {
+        given:
+        def size = bookRepository.countNativeByTitleWithPagesGreaterThan("The%", 300)
+        def books = bookRepository.findByTitleStartsWith("The", 300)
+
+        expect:
+        books.size() == size
+    }
+
     void "test explicit @Query update methods"() {
         when:
         def r = br.setPages(800, "The Border")

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2BookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2BookRepository.java
@@ -17,6 +17,7 @@ package io.micronaut.data.jdbc.h2;
 
 import io.micronaut.data.annotation.Join;
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.Where;
 import io.micronaut.data.exceptions.EmptyResultException;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.jdbc.runtime.JdbcOperations;
@@ -27,6 +28,7 @@ import io.micronaut.data.tck.entities.Book;
 import javax.transaction.Transactional;
 import java.sql.ResultSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @JdbcRepository(dialect = Dialect.H2)
@@ -64,4 +66,10 @@ public abstract class H2BookRepository extends io.micronaut.data.tck.repositorie
             throw new EmptyResultException();
         });
     }
+
+    @Where(value = "total_pages > :pages")
+    abstract List<Book> findByTitleStartsWith(String title, int pages);
+
+    @Query(value = "select count(*) from book b where b.title like :title and b.total_pages > :pages", nativeQuery = true)
+    abstract int countNativeByTitleWithPagesGreaterThan(String title, int pages);
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -919,19 +919,23 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             buildWhereClauseForCriterion(queryState, criteria, criterionList);
             String whereStr = whereClause.toString();
             final String additionalWhere = buildAdditionalWhereString(queryState.getEntity(), annotationMetadata);
+            final StringBuffer additionalWhereBuilder = new StringBuffer();
+
             Matcher matcher = QueryBuilder.VARIABLE_PATTERN.matcher(additionalWhere);
 
             while (matcher.find()) {
                 String name = matcher.group(2);
                 queryState.addRequiredParameters(name);
                 final Placeholder ph = queryState.newParameter();
-                queryState.getParameters().put(ph.getKey(), ph.getName());
+                queryState.getParameters().put(ph.getKey(), name);
+                matcher.appendReplacement(additionalWhereBuilder, ph.getName());
             }
+            matcher.appendTail(additionalWhereBuilder);
             if (!whereStr.equals(WHERE_CLAUSE + OPEN_BRACKET)) {
                 final StringBuilder queryBuilder = queryState.getQuery();
                 queryBuilder.append(whereStr);
                 if (StringUtils.isNotEmpty(additionalWhere)) {
-                    queryBuilder.append(LOGICAL_AND).append(OPEN_BRACKET).append(additionalWhere).append(CLOSE_BRACKET);
+                    queryBuilder.append(LOGICAL_AND).append(OPEN_BRACKET).append(additionalWhereBuilder).append(CLOSE_BRACKET);
                 }
                 queryBuilder.append(CLOSE_BRACKET);
             }

--- a/data-processor/src/test/groovy/io/micronaut/data/annotation/WhereAnnotationSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/annotation/WhereAnnotationSpec.groovy
@@ -104,7 +104,7 @@ interface TestRepository extends GenericRepository<Person, Long> {
         def parameterBinding = method.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING, int[].class).get()
 
         expect:
-        query == "SELECT COUNT(person_) FROM $Person.name AS person_ WHERE (person_.name like :p1 AND (age > :age))"
+        query == "SELECT COUNT(person_) FROM $Person.name AS person_ WHERE (person_.name like :p1 AND (age >:p2))"
         parameterBinding.length == 2
     }
 


### PR DESCRIPTION
* Specs to reproduce and cover #790 for both JDBC and Hibernate JPA
* AbstractSqlLikeQueryBuilder.buildWhereClause : use matcher to replace placehoder with it's name
* WhereAnnotationSpec."test parameterized @Where declaration" : Updated to match the actual implementation