### PR TITLE
Hibernate native query needs to know about the type of the null value

### DIFF
--- a/data-hibernate-jpa/build.gradle
+++ b/data-hibernate-jpa/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     testRuntimeOnly "io.micronaut.sql:micronaut-jdbc-tomcat:$micronautSqlVersion"
     testImplementation("org.codehaus.groovy:groovy-sql")
 
+    testImplementation "org.testcontainers:postgresql:$testContainersVersion"
+    testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 //    compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
 
 //    compileTestJava.options.fork = true

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.hibernate
+
+
+import io.micronaut.data.tck.entities.Book
+import io.micronaut.data.tck.tests.AbstractQuerySpec
+import spock.lang.Shared
+
+import javax.inject.Inject
+
+abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
+
+    @Shared
+    @Inject
+    BookRepository br
+
+    @Shared
+    @Inject
+    AuthorRepository ar
+
+    void "test @Where annotation placehoder"() {
+        given:
+        def size = bookRepository.countNativeByTitleWithPagesGreaterThan("The%", 300)
+        def books = bookRepository.findByTitleStartsWith("The", 300)
+
+        expect:
+        books.size() == size
+    }
+
+    void "test native query"() {
+        given:
+        def books = bookRepository.listNativeBooks("The%")
+
+        expect:
+        books.size() == 3
+        books.every({ it instanceof Book })
+    }
+
+    void "test native query with nullable property"() {
+        when:
+        def books1 = bookRepository.listNativeBooksNullableSearch(null)
+
+        then:
+        books1.size() == 8
+
+        when:
+        def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
+
+        then:
+        books2.size() == 1
+
+        when:
+        def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
+
+        then:
+        books3.size() == 0
+
+        when:
+        def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand"])
+
+        then:
+        books4.size() == 1
+
+        when:
+        def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz"])
+
+        then:
+        books5.size() == 0
+
+        when:
+        def books6 = bookRepository.listNativeBooksNullableListSearch([])
+
+        then:
+        books6.size() == 0
+
+        when:
+        def books7 = bookRepository.listNativeBooksNullableListSearch(null)
+
+        then:
+        books7.size() == 0
+
+        when:
+        def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz"})
+
+        then:
+        books8.size() == 0
+
+        when:
+        def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
+
+        then:
+        books9.size() == 0
+
+        when:
+        def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
+
+        then:
+        books11.size() == 0
+
+        then:
+        def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
+
+        then:
+        books12.size() == 1
+    }
+
+    void "test join on many ended association"() {
+        when:
+        def author = authorRepository.searchByName("Stephen King")
+
+        then:
+        author != null
+        author.books.size() == 2
+    }
+
+    @Override
+    BookRepository getBookRepository() {
+        return br
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return ar
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernatePostgresQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernatePostgresQuerySpec.groovy
@@ -20,6 +20,9 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 
 @MicronautTest(packages = "io.micronaut.data.tck.entities", rollback = false, transactional = false)
 @Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'datasources.default.url', value = 'jdbc:tc:postgresql://localhost/testing')
+@Property(name = 'datasources.default.driverClassName', value = 'org.testcontainers.jdbc.ContainerDatabaseDriver')
 @Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
-class HibernateQuerySpec extends AbstractHibernateQuerySpec {
+@Property(name = 'jpa.default.properties.hibernate.dialect', value = 'org.hibernate.dialect.PostgreSQL95Dialect')
+class HibernatePostgresQuerySpec extends AbstractHibernateQuerySpec {
 }

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
@@ -24,6 +24,7 @@ import io.micronaut.data.tck.entities.Author;
 import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.AuthorRepository;
 
+import javax.annotation.Nullable;
 import javax.transaction.Transactional;
 import java.util.Arrays;
 import java.util.List;
@@ -38,6 +39,15 @@ public abstract class BookRepository extends io.micronaut.data.tck.repositories.
 
     @Query(value = "select * from book b where b.title like :t limit 5", nativeQuery = true)
     abstract List<Book> listNativeBooks(String t);
+
+    @Query(value = "select * from book where CASE WHEN :t is not null THEN title = :t ELSE true END", nativeQuery = true)
+    abstract List<Book> listNativeBooksNullableSearch(@Nullable String t);
+
+    @Query(value = "select * from book where CASE WHEN exists ( select :t ) THEN title in :t ELSE true END", nativeQuery = true)
+    abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> t);
+
+    @Query(value = "select * from book where CASE WHEN exists ( select :t ) THEN title in :t ELSE true END", nativeQuery = true)
+    abstract List<Book> listNativeBooksNullableArraySearch(@Nullable String[] t);
 
     @EntityGraph(
             attributePaths = {

--- a/data-jdbc/build.gradle
+++ b/data-jdbc/build.gradle
@@ -1,6 +1,3 @@
-ext {
-    testContainersVersion = "1.15.0-rc2"
-}
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
     annotationProcessor "io.micronaut:micronaut-graal:$micronautVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ micronautDocsVersion=1.0.24
 micronautBuildVersion=1.1.5
 micronautVersion=2.1.2
 micronautTestVersion=2.2.1
-
+testContainersVersion=1.15.0
 groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
 


### PR DESCRIPTION
In my case, Postgres driver needs to know the type when null is sent and the query is native.

BTW: It would be nice if Micronaut generated:
```sql
WHERE ... CASE WHEN :param is not null THEN db_param = :param ELSE true END ... 
```
When `find(@Nullable String param)`.