### PR TITLE
Fix handling of UUID in updates

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/JdbcQueryStatement.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/JdbcQueryStatement.java
@@ -17,6 +17,7 @@ package io.micronaut.data.jdbc.mapper;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.data.exceptions.DataAccessException;
+import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.runtime.mapper.QueryStatement;
 import io.micronaut.data.model.DataType;
 
@@ -33,7 +34,7 @@ import java.util.Date;
 public class JdbcQueryStatement implements QueryStatement<PreparedStatement, Integer> {
 
     @Override
-    public QueryStatement<PreparedStatement, Integer> setDynamic(@NonNull PreparedStatement statement, @NonNull Integer index, @NonNull DataType dataType, Object value) {
+    public QueryStatement<PreparedStatement, Integer> setDynamic(@NonNull PreparedStatement statement, @NonNull Integer index, @NonNull DataType dataType, @NonNull Dialect dialect, Object value) {
         if (value == null) {
             try {
                 switch (dataType) {
@@ -90,7 +91,7 @@ public class JdbcQueryStatement implements QueryStatement<PreparedStatement, Int
                 throw new DataAccessException("Error setting JDBC null value: " + e.getMessage(), e);
             }
         } else {
-            return QueryStatement.super.setDynamic(statement, index, dataType, value);
+            return QueryStatement.super.setDynamic(statement, index, dataType, dialect, value);
         }
     }
 

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
@@ -411,6 +411,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS> implements Reposit
                                     stmt,
                                     index,
                                     type,
+                                    dialect,
                                     value
                             );
                         }
@@ -570,6 +571,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS> implements Reposit
                 preparedStatement,
                 index,
                 dialect.getDataType(dataType),
+                dialect,
                 value);
     }
 

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -437,6 +437,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
         if (StringUtils.isNotEmpty(query) && ArrayUtils.isNotEmpty(params)) {
             final RuntimePersistentEntity<T> persistentEntity =
                     (RuntimePersistentEntity<T>) getEntity(entity.getClass());
+            final Dialect dialect = queryBuilders.getOrDefault(repositoryType, DEFAULT_SQL_BUILDER).dialect();
             return transactionOperations.executeWrite(status -> {
                 try {
                     Connection connection = status.getConnection();
@@ -468,6 +469,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                                         ps,
                                                         index,
                                                         embeddedProp.getDataType(),
+                                                        dialect,
                                                         embeddedValue
                                                 );
                                             }
@@ -503,7 +505,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                                 ps,
                                                 i + 1,
                                                 idReader.getDataType(),
-                                                id
+                                                dialect, id
                                         );
                                         if (association.doesCascade(Relation.Cascade.PERSIST) && !persisted.contains(newValue)) {
                                             final Relation.Kind kind = association.getKind();
@@ -559,6 +561,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                                         ps,
                                                         i + 1,
                                                         idReader.getDataType(),
+                                                        dialect,
                                                         assignedId
                                                 );
                                             }
@@ -569,10 +572,12 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                     if (QUERY_LOG.isTraceEnabled()) {
                                         QUERY_LOG.trace("Binding parameter at position {} to value {}", i + 1, value);
                                     }
+                                    queryBuilders.getOrDefault(repositoryType, DEFAULT_SQL_BUILDER).dialect();
                                     preparedStatementWriter.setDynamic(
                                             ps,
                                             i + 1,
                                             dataType,
+                                            dialect,
                                             value
                                     );
                                 } else {
@@ -583,6 +588,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                             ps,
                                             i + 1,
                                             dataType,
+                                            dialect,
                                             newValue
                                     );
                                 }
@@ -681,6 +687,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
         if (identity != null) {
 
             final RuntimePersistentEntity<T> persistentEntity = (RuntimePersistentEntity<T>) getEntity(entity.getClass());
+            final Dialect dialect = queryBuilders.getOrDefault(repositoryType, DEFAULT_SQL_BUILDER).dialect();
             for (RuntimeAssociation<T> association : persistentEntity.getAssociations()) {
                 if (association.doesCascade(Relation.Cascade.PERSIST)) {
                     final Relation.Kind kind = association.getKind();
@@ -809,6 +816,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                                     ps,
                                                     1,
                                                     persistentEntity.getIdentity().getDataType(),
+                                                    dialect,
                                                     parentId);
                                             if (QUERY_LOG.isTraceEnabled()) {
                                                 QUERY_LOG.trace("Binding parameter at position {} to value {}", 2, childId);
@@ -817,6 +825,7 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                                     ps,
                                                     2,
                                                     associatedId.getDataType(),
+                                                    dialect,
                                                     childId);
                                             ps.addBatch();
                                         }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaDbUUIDSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaDbUUIDSpec.groovy
@@ -1,21 +1,23 @@
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.mariadb
 
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.data.jdbc.mysql.MySqlUuidRepository
+import io.micronaut.data.jdbc.mysql.UuidTest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false)
-class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProvider {
+class MariaDbUUIDSpec extends Specification implements MariaTestPropertyProvider {
 
     @AutoCleanup
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run(properties)
 
     @Shared
-    PostgresUuidRepository repository = applicationContext.getBean(PostgresUuidRepository)
+    MySqlUuidRepository repository = applicationContext.getBean(MySqlUuidRepository)
 
     void 'test insert and update with UUID'() {
         when:
@@ -41,7 +43,7 @@ class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProv
         test.name == "John"
 
         when:
-        test = repository.findById(test.uuid).get()
+        test = repository.findById(test.uuid).orElse(null)
 
         then:
         test.name == "John"

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaRepositorySpec.groovy
@@ -50,7 +50,7 @@ import io.micronaut.data.tck.repositories.RoleRepository
 import io.micronaut.data.tck.repositories.UserRepository
 import io.micronaut.data.tck.repositories.UserRoleRepository
 import io.micronaut.data.tck.tests.AbstractRepositorySpec
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.IgnoreIf
 
 @MicronautTest
@@ -180,6 +180,47 @@ class MariaRepositorySpec extends AbstractRepositorySpec implements MariaTestPro
         // stored as a DATE type without time
 //        retrievedBook.date == book.date
 
+        when: "we update the book"
+        book = basicTypesRepo.update(retrievedBook)
+
+        then: "The ID is assigned"
+        book.myId != null
+
+        when:"A book is found"
+        retrievedBook = basicTypesRepo.findById(book.myId).orElse(null)
+
+        then:"The book is correct"
+        retrievedBook.uuid == book.uuid
+        retrievedBook.bigDecimal == book.bigDecimal
+        retrievedBook.byteArray == book.byteArray
+        retrievedBook.charSequence == book.charSequence
+        retrievedBook.charset == book.charset
+        retrievedBook.primitiveBoolean == book.primitiveBoolean
+        retrievedBook.primitiveByte == book.primitiveByte
+        retrievedBook.primitiveChar == book.primitiveChar
+        retrievedBook.primitiveDouble == book.primitiveDouble
+        retrievedBook.primitiveFloat == book.primitiveFloat
+        retrievedBook.primitiveInteger == book.primitiveInteger
+        retrievedBook.primitiveLong == book.primitiveLong
+        retrievedBook.primitiveShort == book.primitiveShort
+        retrievedBook.wrapperBoolean == book.wrapperBoolean
+        retrievedBook.wrapperByte == book.wrapperByte
+        retrievedBook.wrapperChar == book.wrapperChar
+        retrievedBook.wrapperDouble == book.wrapperDouble
+        retrievedBook.wrapperFloat == book.wrapperFloat
+        retrievedBook.wrapperInteger == book.wrapperInteger
+        retrievedBook.wrapperLong == book.wrapperLong
+        retrievedBook.uri == book.uri
+        retrievedBook.url == book.url
+        retrievedBook.instant == book.instant
+        retrievedBook.localDateTime == book.localDateTime
+        retrievedBook.zonedDateTime == book.zonedDateTime
+        retrievedBook.offsetDateTime == book.offsetDateTime
+        retrievedBook.dateCreated == book.dateCreated
+        retrievedBook.dateUpdated == book.dateUpdated
+
+        cleanup:
+        basicTypesRepo.deleteAll()
     }
     
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlRepositorySpec.groovy
@@ -161,5 +161,46 @@ class MySqlRepositorySpec extends AbstractRepositorySpec implements MySQLTestPro
         // stored as a DATE type without time
 //        retrievedBook.date == book.date
 
+        when: "we update the book"
+        book = basicTypesRepo.update(retrievedBook)
+
+        then: "The ID is assigned"
+        book.myId != null
+
+        when:"A book is found"
+        retrievedBook = basicTypesRepo.findById(book.myId).orElse(null)
+
+        then:"The book is correct"
+        retrievedBook.uuid == book.uuid
+        retrievedBook.bigDecimal == book.bigDecimal
+        retrievedBook.byteArray == book.byteArray
+        retrievedBook.charSequence == book.charSequence
+        retrievedBook.charset == book.charset
+        retrievedBook.primitiveBoolean == book.primitiveBoolean
+        retrievedBook.primitiveByte == book.primitiveByte
+        retrievedBook.primitiveChar == book.primitiveChar
+        retrievedBook.primitiveDouble == book.primitiveDouble
+        retrievedBook.primitiveFloat == book.primitiveFloat
+        retrievedBook.primitiveInteger == book.primitiveInteger
+        retrievedBook.primitiveLong == book.primitiveLong
+        retrievedBook.primitiveShort == book.primitiveShort
+        retrievedBook.wrapperBoolean == book.wrapperBoolean
+        retrievedBook.wrapperByte == book.wrapperByte
+        retrievedBook.wrapperChar == book.wrapperChar
+        retrievedBook.wrapperDouble == book.wrapperDouble
+        retrievedBook.wrapperFloat == book.wrapperFloat
+        retrievedBook.wrapperInteger == book.wrapperInteger
+        retrievedBook.wrapperLong == book.wrapperLong
+        retrievedBook.uri == book.uri
+        retrievedBook.url == book.url
+        retrievedBook.instant == book.instant
+        retrievedBook.localDateTime == book.localDateTime
+        retrievedBook.zonedDateTime == book.zonedDateTime
+        retrievedBook.offsetDateTime == book.offsetDateTime
+        retrievedBook.dateCreated == book.dateCreated
+        retrievedBook.dateUpdated == book.dateUpdated
+
+        cleanup:
+        basicTypesRepo.deleteAll()
     }
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlUUIDSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlUUIDSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.mysql
 
 
 import io.micronaut.context.ApplicationContext
@@ -8,14 +8,14 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false)
-class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProvider {
+class MySqlUUIDSpec extends Specification implements MySQLTestPropertyProvider {
 
     @AutoCleanup
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run(properties)
 
     @Shared
-    PostgresUuidRepository repository = applicationContext.getBean(PostgresUuidRepository)
+    MySqlUuidRepository repository = applicationContext.getBean(MySqlUuidRepository)
 
     void 'test insert and update with UUID'() {
         when:
@@ -41,7 +41,7 @@ class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProv
         test.name == "John"
 
         when:
-        test = repository.findById(test.uuid).get()
+        test = repository.findById(test.uuid).orElse(null)
 
         then:
         test.name == "John"

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
@@ -180,6 +180,45 @@ class OracleXERepositorySpec extends AbstractRepositorySpec implements OracleTes
         retrievedBook.dateCreated == book.dateCreated
         retrievedBook.dateUpdated == book.dateUpdated
 
+        when: "we update the book"
+        book = basicTypesRepo.update(retrievedBook)
+
+        then: "The ID is assigned"
+        book.myId != null
+
+        when:"A book is found"
+        retrievedBook = basicTypesRepo.findById(book.myId).orElse(null)
+
+        then:"The book is correct"
+        retrievedBook.uuid == book.uuid
+        retrievedBook.bigDecimal == book.bigDecimal
+        retrievedBook.byteArray == book.byteArray
+        retrievedBook.charSequence == book.charSequence
+        retrievedBook.charset == book.charset
+        retrievedBook.primitiveBoolean == book.primitiveBoolean
+        retrievedBook.primitiveByte == book.primitiveByte
+        retrievedBook.primitiveChar == book.primitiveChar
+        retrievedBook.primitiveDouble == book.primitiveDouble
+        retrievedBook.primitiveFloat == book.primitiveFloat
+        retrievedBook.primitiveInteger == book.primitiveInteger
+        retrievedBook.primitiveLong == book.primitiveLong
+        retrievedBook.primitiveShort == book.primitiveShort
+        retrievedBook.wrapperBoolean == book.wrapperBoolean
+        retrievedBook.wrapperByte == book.wrapperByte
+        retrievedBook.wrapperChar == book.wrapperChar
+        retrievedBook.wrapperDouble == book.wrapperDouble
+        retrievedBook.wrapperFloat == book.wrapperFloat
+        retrievedBook.wrapperInteger == book.wrapperInteger
+        retrievedBook.wrapperLong == book.wrapperLong
+        retrievedBook.uri == book.uri
+        retrievedBook.url == book.url
+        retrievedBook.instant == book.instant
+        retrievedBook.localDateTime == book.localDateTime
+        retrievedBook.zonedDateTime == book.zonedDateTime
+        retrievedBook.offsetDateTime == book.offsetDateTime
+        retrievedBook.dateCreated == book.dateCreated
+        retrievedBook.dateUpdated == book.dateUpdated
+
         cleanup:
         basicTypesRepo.deleteAll()
     }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEUUIDSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEUUIDSpec.groovy
@@ -1,21 +1,23 @@
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.oraclexe
 
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false)
-class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProvider {
+@Ignore("Fails with: Invalid column type - no idea what's wrong here")
+class OracleXEUUIDSpec extends Specification implements OracleTestPropertyProvider {
 
     @AutoCleanup
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run(properties)
 
     @Shared
-    PostgresUuidRepository repository = applicationContext.getBean(PostgresUuidRepository)
+    OracleXEUuidRepository repository = applicationContext.getBean(OracleXEUuidRepository)
 
     void 'test insert and update with UUID'() {
         when:
@@ -41,7 +43,7 @@ class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProv
         test.name == "John"
 
         when:
-        test = repository.findById(test.uuid).get()
+        test = repository.findById(test.uuid).orElse(null)
 
         then:
         test.name == "John"

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
@@ -178,6 +178,48 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
         // stored as a DATE type without time
 //        retrievedBook.date == book.date
 
+        when: "we update the book"
+        book = basicTypesRepo.update(retrievedBook)
+
+        then: "The ID is assigned"
+        book.myId != null
+
+        when:"A book is found"
+        retrievedBook = basicTypesRepo.findById(book.myId).orElse(null)
+
+        then:"The book is correct"
+        retrievedBook.uuid == book.uuid
+        retrievedBook.bigDecimal == book.bigDecimal
+        retrievedBook.byteArray == book.byteArray
+        retrievedBook.charSequence == book.charSequence
+        retrievedBook.charset == book.charset
+        retrievedBook.primitiveBoolean == book.primitiveBoolean
+        retrievedBook.primitiveByte == book.primitiveByte
+        retrievedBook.primitiveChar == book.primitiveChar
+        retrievedBook.primitiveDouble == book.primitiveDouble
+        retrievedBook.primitiveFloat == book.primitiveFloat
+        retrievedBook.primitiveInteger == book.primitiveInteger
+        retrievedBook.primitiveLong == book.primitiveLong
+        retrievedBook.primitiveShort == book.primitiveShort
+        retrievedBook.wrapperBoolean == book.wrapperBoolean
+        retrievedBook.wrapperByte == book.wrapperByte
+        retrievedBook.wrapperChar == book.wrapperChar
+        retrievedBook.wrapperDouble == book.wrapperDouble
+        retrievedBook.wrapperFloat == book.wrapperFloat
+        retrievedBook.wrapperInteger == book.wrapperInteger
+        retrievedBook.wrapperLong == book.wrapperLong
+        retrievedBook.uri == book.uri
+        retrievedBook.url == book.url
+        retrievedBook.instant == book.instant
+        retrievedBook.localDateTime == book.localDateTime
+        retrievedBook.zonedDateTime == book.zonedDateTime
+        retrievedBook.offsetDateTime == book.offsetDateTime
+        retrievedBook.dateCreated == book.dateCreated
+        retrievedBook.dateUpdated == book.dateUpdated
+
+        cleanup:
+        basicTypesRepo.deleteAll()
+
     }
     void "test CRUD with custom schema and catalog"() {
         given:

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerRepositorySpec.groovy
@@ -162,6 +162,45 @@ class SqlServerRepositorySpec extends AbstractRepositorySpec implements MSSQLTes
         // stored as a DATE type without time
 //        retrievedBook.date == book.date
 
+        when: "we update the book"
+        book = basicTypesRepo.update(retrievedBook)
+
+        then: "The ID is assigned"
+        book.myId != null
+
+        when:"A book is found"
+        retrievedBook = basicTypesRepo.findById(book.myId).orElse(null)
+
+        then:"The book is correct"
+        retrievedBook.uuid == book.uuid
+        retrievedBook.bigDecimal == book.bigDecimal
+        retrievedBook.byteArray == book.byteArray
+        retrievedBook.charSequence == book.charSequence
+        retrievedBook.charset == book.charset
+        retrievedBook.primitiveBoolean == book.primitiveBoolean
+        retrievedBook.primitiveByte == book.primitiveByte
+        retrievedBook.primitiveChar == book.primitiveChar
+        retrievedBook.primitiveDouble == book.primitiveDouble
+        retrievedBook.primitiveFloat == book.primitiveFloat
+        retrievedBook.primitiveInteger == book.primitiveInteger
+        retrievedBook.primitiveLong == book.primitiveLong
+        retrievedBook.primitiveShort == book.primitiveShort
+        retrievedBook.wrapperBoolean == book.wrapperBoolean
+        retrievedBook.wrapperByte == book.wrapperByte
+        retrievedBook.wrapperChar == book.wrapperChar
+        retrievedBook.wrapperDouble == book.wrapperDouble
+        retrievedBook.wrapperFloat == book.wrapperFloat
+        retrievedBook.wrapperInteger == book.wrapperInteger
+        retrievedBook.wrapperLong == book.wrapperLong
+        retrievedBook.uri == book.uri
+        retrievedBook.url == book.url
+        retrievedBook.instant == book.instant
+        retrievedBook.localDateTime == book.localDateTime
+        retrievedBook.zonedDateTime == book.zonedDateTime
+        retrievedBook.offsetDateTime == book.offsetDateTime
+        retrievedBook.dateCreated == book.dateCreated
+        retrievedBook.dateUpdated == book.dateUpdated
+
         cleanup:
         basicTypesRepo.deleteAll()
 

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerUUIDSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerUUIDSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.sqlserver
 
 
 import io.micronaut.context.ApplicationContext
@@ -8,14 +8,14 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false)
-class PostgresUUIDSpec extends Specification implements PostgresTestPropertyProvider {
+class SqlServerUUIDSpec extends Specification implements MSSQLTestPropertyProvider {
 
     @AutoCleanup
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run(properties)
 
     @Shared
-    PostgresUuidRepository repository = applicationContext.getBean(PostgresUuidRepository)
+    SqlServerUuidRepository repository = applicationContext.getBean(SqlServerUuidRepository)
 
     void 'test insert and update with UUID'() {
         when:

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/mysql/MySqlUuidRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/mysql/MySqlUuidRepository.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.jdbc.mysql;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+public interface MySqlUuidRepository extends CrudRepository<UuidTest, UUID> {
+
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/mysql/UuidTest.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/mysql/UuidTest.java
@@ -1,4 +1,4 @@
-package io.micronaut.data.jdbc.postgres;
+package io.micronaut.data.jdbc.mysql;
 
 import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.Id;

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEUuidRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEUuidRepository.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.jdbc.oraclexe;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+public interface OracleXEUuidRepository extends CrudRepository<UuidTest, UUID> {
+
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/UuidTest.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/UuidTest.java
@@ -1,6 +1,7 @@
-package io.micronaut.data.jdbc.postgres;
+package io.micronaut.data.jdbc.oraclexe;
 
 import io.micronaut.data.annotation.AutoPopulated;
+
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.MappedEntity;
 

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/sqlserver/SqlServerUuidRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/sqlserver/SqlServerUuidRepository.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.jdbc.sqlserver;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+public interface SqlServerUuidRepository extends CrudRepository<UuidTest, UUID> {
+
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/sqlserver/UuidTest.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/sqlserver/UuidTest.java
@@ -1,4 +1,4 @@
-package io.micronaut.data.jdbc.postgres;
+package io.micronaut.data.jdbc.sqlserver;
 
 import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.Id;


### PR DESCRIPTION
This is a fix for #821. 

This PR adds missing tests for updating entities with UUID primary keys and simple UUID fields and fixes the error that micronaut data is currenty setting UUIDs as objects eventhough the database (dialect) does not support this.

The `OracleXEUUIDSpec` is currently ignored as I am lacking oracle knowledge to handle the *"Fails with: Invalid column type"* error.