### PR TITLE
Rework query parameter list expansion

### DIFF
--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
@@ -52,70 +52,88 @@ abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
 
     void "test native query with nullable property"() {
         when:
-        def books1 = bookRepository.listNativeBooksNullableSearch(null)
-
+            def books1 = bookRepository.listNativeBooksNullableSearch(null)
         then:
-        books1.size() == 8
+            books1.size() == 8
 
         when:
-        def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
-
+            def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
         then:
-        books2.size() == 1
+            books2.size() == 1
 
         when:
-        def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
-
+            def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
         then:
-        books3.size() == 0
+            books3.size() == 0
 
         when:
-        def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand"])
-
+            def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand", "FFF"])
         then:
-        books4.size() == 1
+            books4.size() == 1
 
         when:
-        def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz"])
-
+            def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz", "FFF"])
         then:
-        books5.size() == 0
+            books5.size() == 0
+        when:
+            def books6 = bookRepository.listNativeBooksNullableListSearch([])
+        then:
+            books6.size() == 0
 
         when:
-        def books6 = bookRepository.listNativeBooksNullableListSearch([])
-
+            def books7 = bookRepository.listNativeBooksNullableListSearch(null)
         then:
-        books6.size() == 0
+            books7.size() == 0
 
         when:
-        def books7 = bookRepository.listNativeBooksNullableListSearch(null)
-
+            def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz", "Ffff", "zzz"})
         then:
-        books7.size() == 0
+            books8.size() == 0
 
         when:
-        def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz"})
-
+            def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
         then:
-        books8.size() == 0
+            books9.size() == 0
 
         when:
-        def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
+            def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
+        then:
+            books11.size() == 0
 
         then:
-        books9.size() == 0
+            def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
+        then:
+            books12.size() == 1
 
+        then:
+            books12.size() == 1
+    }
+
+    void "test IN queries"() {
         when:
-        def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
-
+            def books1 = bookRepository.listNativeBooksWithTitleInCollection(null)
         then:
-        books11.size() == 0
-
+            books1.size() == 0
+        when:
+            def books2 = bookRepository.listNativeBooksWithTitleInCollection(["The Stand", "Along Came a Spider", "FFF"])
         then:
-        def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
-
+            books2.size() == 2
+        when:
+            def books3 = bookRepository.listNativeBooksWithTitleInCollection([])
         then:
-        books12.size() == 1
+            books3.size() == 0
+        when:
+            def books4 = bookRepository.listNativeBooksWithTitleInArray(null)
+        then:
+            books4.size() == 0
+        when:
+            def books5 = bookRepository.listNativeBooksWithTitleInArray(new String[] {"The Stand", "Along Came a Spider", "FFF"})
+        then:
+            books5.size() == 2
+        when:
+            def books6 = bookRepository.listNativeBooksWithTitleInArray(new String[0])
+        then:
+            books6.size() == 0
     }
 
     void "test join on many ended association"() {

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/BookRepository.java
@@ -37,18 +37,6 @@ public abstract class BookRepository extends io.micronaut.data.tck.repositories.
         super(authorRepository);
     }
 
-    @Query(value = "select * from book b where b.title like :t limit 5", nativeQuery = true)
-    abstract List<Book> listNativeBooks(String t);
-
-    @Query(value = "select * from book where CASE WHEN :t is not null THEN title = :t ELSE true END", nativeQuery = true)
-    abstract List<Book> listNativeBooksNullableSearch(@Nullable String t);
-
-    @Query(value = "select * from book where CASE WHEN exists ( select :t ) THEN title in :t ELSE true END", nativeQuery = true)
-    abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> t);
-
-    @Query(value = "select * from book where CASE WHEN exists ( select :t ) THEN title in :t ELSE true END", nativeQuery = true)
-    abstract List<Book> listNativeBooksNullableArraySearch(@Nullable String[] t);
-
     @EntityGraph(
             attributePaths = {
                     "totalPages",
@@ -62,4 +50,14 @@ public abstract class BookRepository extends io.micronaut.data.tck.repositories.
 
     @Query(value = "select count(*) from book b where b.title like :title and b.total_pages > :pages", nativeQuery = true)
     abstract int countNativeByTitleWithPagesGreaterThan(String title, int pages);
+
+    @Query(value = "select * from book where (CASE WHEN :arg0 is not null THEN title = :arg0 ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableSearch(@Nullable String arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableArraySearch(@Nullable String[] arg0);
+
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
@@ -50,7 +50,7 @@ class OracleXERepositorySpec extends AbstractRepositorySpec implements OracleTes
     }
 
     @Override
-    BookRepository getBookRepository() {
+    OracleXEBookRepository getBookRepository() {
         return context.getBean(OracleXEBookRepository)
     }
 
@@ -182,6 +182,37 @@ class OracleXERepositorySpec extends AbstractRepositorySpec implements OracleTes
 
         cleanup:
         basicTypesRepo.deleteAll()
+    }
+
+    void "test ANY queries"() {
+        given:
+            saveSampleBooks()
+        when:
+            def books1 = bookRepository.listNativeBooksWithTitleAnyCollection(null)
+        then:
+            books1.size() == 0
+        when:
+            def books2 = bookRepository.listNativeBooksWithTitleAnyCollection(["The Stand", "Along Came a Spider", "FFF"])
+        then:
+            books2.size() == 2
+        when:
+            def books3 = bookRepository.listNativeBooksWithTitleAnyCollection([])
+        then:
+            books3.size() == 0
+        when:
+            def books4 = bookRepository.listNativeBooksWithTitleAnyArray(null)
+        then:
+            books4.size() == 0
+        when:
+            def books5 = bookRepository.listNativeBooksWithTitleAnyArray(new String[] {"The Stand", "Along Came a Spider", "FFF"})
+        then:
+            books5.size() == 2
+        when:
+            def books6 = bookRepository.listNativeBooksWithTitleAnyArray(new String[0])
+        then:
+            books6.size() == 0
+        cleanup:
+            cleanupBooks()
     }
 
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
@@ -45,7 +45,7 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
     }
 
     @Override
-    BookRepository getBookRepository() {
+    PostgresBookRepository getBookRepository() {
         return context.getBean(PostgresBookRepository)
     }
 
@@ -210,4 +210,66 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
         then:"It was deleted"
         !carRepo.findById(a5.id).isPresent()
     }
+
+    void "test native query with nullable property"() {
+        given:
+            setupBooks()
+        when:
+            def books1 = bookRepository.listNativeBooksNullableSearch(null)
+        then:
+            books1.size() == 8
+
+        when:
+            def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
+        then:
+            books2.size() == 1
+
+        when:
+            def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
+        then:
+            books3.size() == 0
+
+        when:
+            def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand", "FFF"])
+        then:
+            books4.size() == 1
+
+        when:
+            def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz", "FFF"])
+        then:
+            books5.size() == 0
+        when:
+            def books6 = bookRepository.listNativeBooksNullableListSearch([])
+        then:
+            books6.size() == 0
+
+        when:
+            def books7 = bookRepository.listNativeBooksNullableListSearch(null)
+        then:
+            books7.size() == 0
+
+        when:
+            def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz", "Ffff", "zzz"})
+        then:
+            books8.size() == 0
+
+        when:
+            def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
+        then:
+            books9.size() == 0
+
+        when:
+            def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
+        then:
+            books11.size() == 0
+
+        then:
+            def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
+        then:
+            books12.size() == 1
+
+        cleanup:
+            cleanupBooks()
+    }
+
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEBookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEBookRepository.java
@@ -15,13 +15,26 @@
  */
 package io.micronaut.data.jdbc.oraclexe;
 
+import io.micronaut.data.annotation.Query;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
 
 @JdbcRepository(dialect = Dialect.ORACLE)
 public abstract class OracleXEBookRepository extends BookRepository {
     public OracleXEBookRepository(OracleXEAuthorRepository authorRepository) {
         super(authorRepository);
     }
+
+    @Query(value = "select * from book b where b.title = any (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleAnyCollection(@Nullable Collection<String> arg0);
+
+    @Query(value = "select * from book b where b.title = ANY (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleAnyArray(@Nullable String[] arg0);
+
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
@@ -15,13 +15,27 @@
  */
 package io.micronaut.data.jdbc.postgres;
 
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 @JdbcRepository(dialect = Dialect.POSTGRES)
 public abstract class PostgresBookRepository extends BookRepository {
     public PostgresBookRepository(PostgresAuthorRepository authorRepository) {
         super(authorRepository);
     }
+
+    @Query(value = "select * from book where (CASE WHEN :arg0 is not null THEN title = :arg0 ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableSearch(@Nullable String arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableArraySearch(@Nullable String[] arg0);
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
@@ -51,6 +51,7 @@ public interface QueryBuilder {
     /**
      * A pattern used to find in queries in a query string.
      */
+    @Deprecated
     Pattern IN_VARIABLES_PATTERN = Pattern.compile("(?<singleGroup>:[a-zA-Z0-9]+)|(?<inGroup>IN\\((:[a-zA-Z0-9]+)\\))");
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -55,7 +55,6 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
     /**
      * The start of an IN expression.
      */
-    public static final String IN_EXPRESSION_START = " ?$IN(";
     public static final String DEFAULT_POSITIONAL_PARAMETER_MARKER = "?";
     /**
      * Annotation used to represent join tables.
@@ -907,14 +906,6 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
                     Collections.emptySet()
             );
         }
-    }
-
-    @Override
-    protected void encodeInExpression(StringBuilder whereClause, Placeholder placeholder) {
-        whereClause
-                .append(IN_EXPRESSION_START)
-                .append(placeholder.getKey())
-                .append(CLOSE_BRACKET);
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
@@ -51,6 +51,7 @@ public interface StoredQuery<E, R> extends Named, StoredDataOperation<R> {
      * Does the query contain an in expression.
      * @return True if it does
      */
+    @Deprecated
     boolean hasInExpression();
 
     /**

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -512,15 +512,6 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
     private String replaceNamedParameters(QueryBuilder queryEncoder, String query) {
         if (queryEncoder instanceof SqlQueryBuilder && StringUtils.isNotEmpty(query)) {
-            Matcher inMatcher = IN_VARIABLES_PATTERN.matcher(query);
-            StringBuffer sb = new StringBuffer();
-            for (int i = 1; inMatcher.find(); i++) {
-                if (inMatcher.group("inGroup") != null) {
-                    inMatcher.appendReplacement(sb, "\\?\\$IN(" + i + ")");
-                }
-            }
-            inMatcher.appendTail(sb);
-            query = sb.toString();
             Matcher matcher = VARIABLE_PATTERN.matcher(query);
             query = matcher.replaceAll("$1?"); // left first group as it is and replace second group with question mark
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
@@ -833,7 +833,6 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
         private final DataType[] indexedDataTypes;
         private final String[] parameterNames;
         private final boolean hasResultConsumer;
-        private boolean hasIn;
         private Map<String, Object> queryHints;
         private Set<JoinPath> joinFetchPaths = null;
         private TransactionDefinition transactionDefinition = null;
@@ -871,7 +870,6 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
             } else {
                 this.query = method.stringValue(Query.class, DataMethod.META_MEMBER_RAW_QUERY).orElse(query);
             }
-            this.hasIn = isNumericPlaceHolder && this.query.contains(SqlQueryBuilder.IN_EXPRESSION_START);
             this.method = method;
             this.lastUpdatedProp = method.stringValue(PREDATOR_ANN_NAME, TypeRole.LAST_UPDATED_PROPERTY).orElse(null);
             this.isDto = method.isTrue(PREDATOR_ANN_NAME, DataMethod.META_MEMBER_DTO);
@@ -1085,8 +1083,9 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
          * @return True if it does
          */
         @Override
+        @Deprecated
         public boolean hasInExpression() {
-            return hasIn;
+            return false;
         }
 
         @Override
@@ -1309,6 +1308,7 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
         }
 
         @Override
+        @Deprecated
         public boolean hasInExpression() {
             return storedQuery.hasInExpression();
         }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -981,6 +981,37 @@ abstract class AbstractRepositorySpec extends Specification {
         cleanupMeals()
     }
 
+    void "test IN queries"() {
+        given:
+            setupBooks()
+        when:
+            def books1 = bookRepository.listNativeBooksWithTitleInCollection(null)
+        then:
+            books1.size() == 0
+        when:
+            def books2 = bookRepository.listNativeBooksWithTitleInCollection(["The Stand", "Along Came a Spider", "FFF"])
+        then:
+            books2.size() == 2
+        when:
+            def books3 = bookRepository.listNativeBooksWithTitleInCollection([])
+        then:
+            books3.size() == 0
+        when:
+            def books4 = bookRepository.listNativeBooksWithTitleInArray(null)
+        then:
+            books4.size() == 0
+        when:
+            def books5 = bookRepository.listNativeBooksWithTitleInArray(new String[] {"The Stand", "Along Came a Spider", "FFF"})
+        then:
+            books5.size() == 2
+        when:
+            def books6 = bookRepository.listNativeBooksWithTitleInArray(new String[0])
+        then:
+            books6.size() == 0
+        cleanup:
+            cleanupBooks()
+    }
+
     private GregorianCalendar getYearMonthDay(Date dateCreated) {
         def cal = dateCreated.toCalendar()
         def localDate = LocalDate.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH))

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
@@ -16,8 +16,10 @@
 package io.micronaut.data.tck.repositories;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.Parameter;
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.Join;
+import io.micronaut.data.annotation.Query;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.repository.PageableRepository;
@@ -26,7 +28,9 @@ import io.micronaut.data.tck.entities.AuthorBooksDto;
 import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.entities.BookDto;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -65,6 +69,21 @@ public abstract class BookRepository implements PageableRepository<Book, Long> {
     public abstract Book findByTitle(String title);
 
     public abstract Author findAuthorById(@Id Long id);
+
+    @Query(value = "select * from book b where b.title like :arg0 limit 5", nativeQuery = true)
+    public abstract List<Book> listNativeBooks(String arg0);
+
+    @Query(value = "select * from book b where b.title in (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleInCollection(@Nullable Collection<String> arg0);
+
+    @Query(value = "select * from book b where b.title IN (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleInArray(@Nullable String[] arg0);
+
+    @Query(value = "select * from book b where b.title = any (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleAnyCollection(@Nullable Collection<String> arg0);
+
+    @Query(value = "select * from book b where b.title = ANY (:arg0)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksWithTitleAnyArray(@Nullable String[] arg0);
 
     public void saveAuthorBooks(List<AuthorBooksDto> authorBooksDtos) {
         List<Author> authors = new ArrayList<>();


### PR DESCRIPTION
This PR changes how parameters list expansion works, previous implementation only allowed `IN (?) to IN(?,?,?)` expansion, but SQL allows the use of `ANY (?,?)` and also ` SELECT (?,?,?)` etc. depends on the database.
New implementation removes compile-time detection for `IN (` and expands `(?)` into `(?,?,?)` during runtime for collections and arrays in the same way as Hibernate native query does it.

- (?) expands to (null) if a collection or an array is empty or null
- (?) remains the same for 1 item collection or array
- (?) expands to (?, ?... N) for N size collection or array
