### PR TITLE
Support DB arrays for JDBC

### DIFF
--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
@@ -55,22 +55,18 @@ abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
             def books1 = bookRepository.listNativeBooksNullableSearch(null)
         then:
             books1.size() == 8
-
         when:
             def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
         then:
             books2.size() == 1
-
         when:
             def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
         then:
             books3.size() == 0
-
         when:
             def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand", "FFF"])
         then:
             books4.size() == 1
-
         when:
             def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz", "FFF"])
         then:
@@ -79,32 +75,24 @@ abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
             def books6 = bookRepository.listNativeBooksNullableListSearch([])
         then:
             books6.size() == 0
-
         when:
             def books7 = bookRepository.listNativeBooksNullableListSearch(null)
         then:
             books7.size() == 0
-
         when:
             def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz", "Ffff", "zzz"})
         then:
             books8.size() == 0
-
         when:
             def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
         then:
             books9.size() == 0
-
         when:
             def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
         then:
             books11.size() == 0
-
         then:
             def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
-        then:
-            books12.size() == 1
-
         then:
             books12.size() == 1
     }

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/JdbcQueryStatement.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/JdbcQueryStatement.java
@@ -83,7 +83,11 @@ public class JdbcQueryStatement implements QueryStatement<PreparedStatement, Int
                         return this;
 
                     default:
-                        statement.setNull(index, Types.NULL);
+                        if (dataType.isArray()) {
+                            statement.setNull(index, Types.ARRAY);
+                        } else {
+                            statement.setNull(index, Types.NULL);
+                        }
                         return this;
                 }
             } catch (SQLException e) {
@@ -118,6 +122,8 @@ public class JdbcQueryStatement implements QueryStatement<PreparedStatement, Int
                 statement.setClob(index, (Clob) value);
             } else if (value instanceof Blob) {
                 statement.setBlob(index, (Blob) value);
+            } else if (value instanceof Array) {
+                statement.setArray(index, (Array) value);
             } else if (value != null) {
                 if (value.getClass().isEnum()) {
                     statement.setString(index, ((Enum) value).name());
@@ -264,6 +270,23 @@ public class JdbcQueryStatement implements QueryStatement<PreparedStatement, Int
     public QueryStatement<PreparedStatement, Integer> setBytes(PreparedStatement statement, Integer name, byte[] bytes) {
         try {
             statement.setBytes(name, bytes);
+        } catch (SQLException e) {
+            throw newDataAccessException(e);
+        }
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public QueryStatement<PreparedStatement, Integer> setArray(PreparedStatement statement, Integer name, Object array) {
+        try {
+            if (array == null) {
+                statement.setNull(name, Types.ARRAY);
+            } else if (array instanceof Array) {
+                statement.setArray(name, (Array) array);
+            } else {
+                statement.setObject(name, array);
+            }
         } catch (SQLException e) {
             throw newDataAccessException(e);
         }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2ArraysSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2ArraysSpec.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2
+
+
+import io.micronaut.data.tck.repositories.ArraysEntityRepository
+import io.micronaut.data.tck.tests.AbstractArraysSpec
+
+class H2ArraysSpec extends AbstractArraysSpec implements H2TestPropertyProvider {
+
+    @Override
+    ArraysEntityRepository getArraysEntityRepository() {
+        return context.getBean(H2ArraysEntityRepository)
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
@@ -167,6 +167,11 @@ class H2RepositorySpec extends AbstractRepositorySpec implements H2TestPropertyP
         return foodRepo
     }
 
+    @Override
+    boolean isSupportsArrays() {
+        return true
+    }
+
     void "test total dto"() {
         given:
         savePersons(["Jeff", "James"])

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresArraysSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresArraysSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.postgres
+
+
+import io.micronaut.data.tck.entities.MultiArrayEntity
+import io.micronaut.data.tck.repositories.ArraysEntityRepository
+import io.micronaut.data.tck.repositories.MultiArrayEntityRepository
+import io.micronaut.data.tck.tests.AbstractArraysSpec
+
+class PostgresArraysSpec extends AbstractArraysSpec implements PostgresTestPropertyProvider {
+
+    @Override
+    ArraysEntityRepository getArraysEntityRepository() {
+        return context.getBean(PostgresArraysEntityRepository)
+    }
+
+    MultiArrayEntityRepository getMultiArrayEntityRepository() {
+        return context.getBean(PostgresMultiArrayEntityRepository)
+    }
+
+    def "should insert and update an entity with multi array"() {
+        given:
+            MultiArrayEntity entity = new MultiArrayEntity()
+            entity.stringMultiArray = [["AAA", "BBB"], ["CCC", "DDD"], ["EEE", "FFF"]] as String[][]
+        when:
+            multiArrayEntityRepository.save(entity)
+            MultiArrayEntity entityStored = multiArrayEntityRepository.findById(entity.id).get()
+        then:
+            entityStored == entity
+        when:
+            entity.stringMultiArray = [["XXX", "ZZZ"], ["CCC", "DDD"], ["EEE", "FFF"]] as String[][]
+            multiArrayEntityRepository.update(entity)
+            entityStored = multiArrayEntityRepository.findById(entity.id).get()
+        then:
+            entityStored == entity
+//        when:
+//            multiArrayEntityRepository.update(entityStored.id,
+//                    [["OOO", "ZZZ"], ["CCC", "DDD"], ["123", "456"]] as String[][]
+//            )
+//            entityStored = multiArrayEntityRepository.findById(entity.id).get()
+//        then:
+//            entityStored.stringMultiArray == [["OOO", "ZZZ"], ["CCC", "DDD"], ["123", "456"]] as String[][]
+    }
+
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
@@ -23,7 +23,6 @@ import io.micronaut.data.tck.repositories.UserRepository
 import io.micronaut.data.tck.entities.Author
 import io.micronaut.data.tck.entities.Car
 import io.micronaut.data.tck.repositories.BookDtoRepository
-import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.CityRepository
 import io.micronaut.data.tck.repositories.CompanyRepository
 import io.micronaut.data.tck.repositories.CountryRegionCityRepository
@@ -117,6 +116,11 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
     @Override
     FoodRepository getFoodRepository() {
         return context.getBean(PostgresFoodRepository)
+    }
+
+    @Override
+    boolean isSupportsArrays() {
+        return true
     }
 
     void "test save and fetch author with no books"() {
@@ -218,22 +222,18 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
             def books1 = bookRepository.listNativeBooksNullableSearch(null)
         then:
             books1.size() == 8
-
         when:
             def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
         then:
             books2.size() == 1
-
         when:
             def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
         then:
             books3.size() == 0
-
         when:
             def books4 = bookRepository.listNativeBooksNullableListSearch(["The Stand", "FFF"])
         then:
             books4.size() == 1
-
         when:
             def books5 = bookRepository.listNativeBooksNullableListSearch(["Xyz", "FFF"])
         then:
@@ -242,34 +242,29 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
             def books6 = bookRepository.listNativeBooksNullableListSearch([])
         then:
             books6.size() == 0
-
         when:
             def books7 = bookRepository.listNativeBooksNullableListSearch(null)
         then:
             books7.size() == 0
-
         when:
             def books8 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"Xyz", "Ffff", "zzz"})
         then:
             books8.size() == 0
-
         when:
             def books9 = bookRepository.listNativeBooksNullableArraySearch(new String[] {})
         then:
             books9.size() == 0
-
         when:
             def books11 = bookRepository.listNativeBooksNullableArraySearch(null)
         then:
             books11.size() == 0
-
         then:
             def books12 = bookRepository.listNativeBooksNullableArraySearch(new String[] {"The Stand"})
         then:
             books12.size() == 1
-
         cleanup:
             cleanupBooks()
     }
+
 
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2ArraysEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2ArraysEntityRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.ArraysEntityRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2ArraysEntityRepository extends ArraysEntityRepository {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEBookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEBookRepository.java
@@ -16,7 +16,9 @@
 package io.micronaut.data.jdbc.oraclexe;
 
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
@@ -35,6 +37,6 @@ public abstract class OracleXEBookRepository extends BookRepository {
     public abstract List<Book> listNativeBooksWithTitleAnyCollection(@Nullable Collection<String> arg0);
 
     @Query(value = "select * from book b where b.title = ANY (:arg0)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksWithTitleAnyArray(@Nullable String[] arg0);
+    public abstract List<Book> listNativeBooksWithTitleAnyArray(@TypeDef(type = DataType.STRING) @Nullable String[] arg0);
 
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresArraysEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresArraysEntityRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.postgres;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.ArraysEntityRepository;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface PostgresArraysEntityRepository extends ArraysEntityRepository {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
@@ -16,6 +16,8 @@
 package io.micronaut.data.jdbc.postgres;
 
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
 import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
@@ -31,11 +33,11 @@ public abstract class PostgresBookRepository extends BookRepository {
     }
 
     @Query(value = "select * from book where (CASE WHEN :arg0 is not null THEN title = :arg0 ELSE true END)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksNullableSearch(@Nullable String arg0);
+    public abstract List<Book> listNativeBooksNullableSearch(@TypeDef(type = DataType.STRING) @Nullable String arg0);
 
     @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
     public abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> arg0);
 
     @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksNullableArraySearch(@Nullable String[] arg0);
+    public abstract List<Book> listNativeBooksNullableArraySearch(@TypeDef(type = DataType.STRING) @Nullable String[] arg0);
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresMultiArrayEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresMultiArrayEntityRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.postgres;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.MultiArrayEntityRepository;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface PostgresMultiArrayEntityRepository extends MultiArrayEntityRepository {
+}

--- a/data-model/src/main/java/io/micronaut/data/model/DataType.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DataType.java
@@ -53,7 +53,7 @@ public enum DataType {
     /**
      * A byte array. Often stored as binary.
      */
-    BYTE_ARRAY(byte[].class),
+    BYTE_ARRAY(true, byte[].class),
     /**
      * A character.
      */
@@ -105,7 +105,39 @@ public enum DataType {
     /**
      * The UUID type.
      */
-    UUID(java.util.UUID.class);
+    UUID(java.util.UUID.class),
+    /**
+     * A string array.
+     */
+    STRING_ARRAY(true, String[].class),
+    /**
+     * A short array.
+     */
+    SHORT_ARRAY(true, short[].class, Short[].class),
+    /**
+     * An integer array.
+     */
+    INTEGER_ARRAY(true, int[].class, Integer[].class),
+    /**
+     * A long array.
+     */
+    LONG_ARRAY(true, long[].class, Long[].class),
+    /**
+     * A long array.
+     */
+    FLOAT_ARRAY(true, float[].class, Float[].class),
+    /**
+     * A double array.
+     */
+    DOUBLE_ARRAY(true, double[].class, Double[].class),
+    /**
+     * A character array.
+     */
+    CHARACTER_ARRAY(true, char[].class, Character[].class),
+    /**
+     * A boolean array.
+     */
+    BOOLEAN_ARRAY(true, boolean[].class, Boolean[].class);
 
     /**
      * Empty array of data types.
@@ -123,13 +155,33 @@ public enum DataType {
     }
 
     private final Set<Class<?>> javaTypes;
+    private final boolean isArray;
 
     /**
      * Default constructor.
      * @param javaTypes Associated data types.
      */
     DataType(Class<?>...javaTypes) {
+        this(false, javaTypes);
+    }
+
+    /**
+     * Default constructor.
+     * @param isArray Is an array type.
+     * @param javaTypes Associated data types.
+     */
+    DataType(boolean isArray, Class<?>...javaTypes) {
+        this.isArray = isArray;
         this.javaTypes = CollectionUtils.setOf(javaTypes);
+    }
+
+    /**
+     * Is an array type.
+     *
+     * @return true if an array type
+     */
+    public boolean isArray() {
+        return isArray;
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
@@ -28,46 +28,42 @@ public enum Dialect {
     /**
      * H2 database.
      */
-    H2,
+    H2(true, false, true),
     /**
      * MySQL 5.5 or above.
      */
-    MYSQL(false, true),
+    MYSQL(false, true, false),
     /**
      * Postgres 9.5 or later.
      */
-    POSTGRES,
+    POSTGRES(true, false, true),
     /**
      * SQL server 2012 or above.
      */
-    SQL_SERVER(false, false),
+    SQL_SERVER(false, false, false),
     /**
      * Oracle 12c or above.
      */
-    ORACLE(true, true),
+    ORACLE(true, true, false),
     /**
      * Ansi compliant SQL.
      */
-    ANSI;
+    ANSI(true, false, true);
 
     private final boolean supportsBatch;
     private final boolean stringUUID;
-
-    /**
-     * Default constructor.
-     */
-    Dialect() {
-        this(true, false);
-    }
+    private final boolean supportsArrays;
 
     /**
      * Allows customization of batch support.
      * @param supportsBatch If batch is supported
      * @param stringUUID Does the dialect require a string UUID
+     * @param supportsArrays Does the dialect supports arrays
      */
-    Dialect(boolean supportsBatch, boolean stringUUID) {
+    Dialect(boolean supportsBatch, boolean stringUUID, boolean supportsArrays) {
         this.supportsBatch = supportsBatch;
         this.stringUUID = stringUUID;
+        this.supportsArrays = supportsArrays;
     }
 
     /**
@@ -76,6 +72,14 @@ public enum Dialect {
      */
     public final boolean allowBatch() {
         return supportsBatch;
+    }
+
+    /**
+     * Some databases support arrays and the use of {@link java.sql.Connection#createArrayOf(String, Object[])}.
+     * @return True if arrays are supported.
+     */
+    public final boolean supportsArrays() {
+        return supportsArrays;
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -1264,7 +1264,6 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
         if (definition != null) {
             return column + " " + definition;
         }
-
         switch (dataType) {
             case STRING:
                 column += " VARCHAR(255)";
@@ -1422,6 +1421,85 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
                     default:
                         column += " JSON";
                         break;
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case STRING_ARRAY:
+            case CHARACTER_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else {
+                    column += " VARCHAR(255) ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case SHORT_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else if (dialect == Dialect.POSTGRES) {
+                    column += " SMALLINT ARRAY";
+                } else {
+                    column += " TINYINT ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case INTEGER_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else if (dialect == Dialect.POSTGRES) {
+                    column += " INTEGER ARRAY";
+                } else {
+                    column += " INT ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case LONG_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else {
+                    column += " BIGINT ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case FLOAT_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else if (dialect == Dialect.POSTGRES) {
+                    column += " REAL ARRAY";
+                } else {
+                    column += " FLOAT ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case DOUBLE_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else if (dialect == Dialect.POSTGRES) {
+                    column += " DOUBLE PRECISION ARRAY";
+                } else {
+                    column += " DOUBLE ARRAY";
+                }
+                if (required) {
+                    column += " NOT NULL";
+                }
+                break;
+            case BOOLEAN_ARRAY:
+                if (dialect == Dialect.H2) {
+                    column += " ARRAY";
+                } else {
+                    column += " BOOLEAN ARRAY";
                 }
                 if (required) {
                     column += " NOT NULL";

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/TypeUtils.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/TypeUtils.java
@@ -256,15 +256,11 @@ public class TypeUtils {
             if (type.isPrimitive() || typeName.startsWith("java.lang")) {
                 Class primitiveType = ClassUtils.getPrimitiveType(type.getName()).orElse(null);
                 if (primitiveType != null && primitiveType != void.class) {
-                    String wrapperName = ReflectionUtils.getWrapperType(primitiveType).getSimpleName();
-                    DataType dt = DataType.valueOf(wrapperName.toUpperCase(Locale.ENGLISH));
-                    if (type.isArray()) {
-                        if (dt == DataType.BYTE) {
-                            return DataType.BYTE_ARRAY;
-                        }
-                    } else {
-                        return dt;
+                    String wrapperName = ReflectionUtils.getWrapperType(primitiveType).getSimpleName().toUpperCase(Locale.ENGLISH);
+                    if (type.isArray())   {
+                        wrapperName += "_ARRAY";
                     }
+                    return DataType.valueOf(wrapperName);
                 }
             }
 
@@ -279,6 +275,33 @@ public class TypeUtils {
 
             if (type.hasStereotype(MappedEntity.class)) {
                 return DataType.ENTITY;
+            }
+
+            if (type.isArray()) {
+                if (type.isAssignable(String.class)) {
+                    return DataType.STRING_ARRAY;
+                }
+                if (type.isAssignable(Short.class)) {
+                    return DataType.SHORT_ARRAY;
+                }
+                if (type.isAssignable(Integer.class)) {
+                    return DataType.INTEGER_ARRAY;
+                }
+                if (type.isAssignable(Long.class)) {
+                    return DataType.LONG_ARRAY;
+                }
+                if (type.isAssignable(Float.class)) {
+                    return DataType.FLOAT_ARRAY;
+                }
+                if (type.isAssignable(Double.class)) {
+                    return DataType.DOUBLE_ARRAY;
+                }
+                if (type.isAssignable(Character.class)) {
+                    return DataType.CHARACTER_ARRAY;
+                }
+                if (type.isAssignable(Boolean.class)) {
+                    return DataType.BOOLEAN_ARRAY;
+                }
             }
 
             try {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataInitializer.java
@@ -21,6 +21,7 @@ import io.micronaut.core.convert.ConversionService;
 import java.sql.Timestamp;
 import java.time.*;
 import java.time.chrono.ChronoLocalDate;
+import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;
 
@@ -44,6 +45,254 @@ class DataInitializer {
             Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate());
         conversionService.addConverter(ChronoLocalDate.class, Date.class, localDate ->
             new Date(localDate.atTime(LocalTime.MIDNIGHT).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+
+        // Arrays
+        conversionService.addConverter(String[].class, Character[].class, values -> {
+            Character[] chars = new Character[values.length];
+            for (int i = 0; i < values.length; i++) {
+                String value = values[i];
+                chars[i] = value.length() == 0 ? Character.MIN_VALUE : value.charAt(0);
+            }
+            return chars;
+        });
+        conversionService.addConverter(String[].class, char[].class, values -> {
+            char[] chars = new char[values.length];
+            for (int i = 0; i < values.length; i++) {
+                String value = values[i];
+                chars[i] = value.length() == 0 ? Character.MIN_VALUE : value.charAt(0);
+            }
+            return chars;
+        });
+        conversionService.addConverter(Character[].class, String[].class, values -> {
+            String[] strings = new String[values.length];
+            for (int i = 0; i < values.length; i++) {
+                strings[i] = values[i].toString();
+            }
+            return strings;
+        });
+        conversionService.addConverter(char[].class, String[].class, values -> {
+            String[] strings = new String[values.length];
+            for (int i = 0; i < values.length; i++) {
+                strings[i] = String.valueOf(values[i]);
+            }
+            return strings;
+        });
+        conversionService.addConverter(Collection.class, Character[].class, collection -> {
+            Character[] chars = new Character[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                chars[i++] = asCharacter(value);
+            }
+            return chars;
+        });
+        conversionService.addConverter(Collection.class, char[].class, collection -> {
+            char[] chars = new char[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                chars[i++] = asCharacter(value);
+            }
+            return chars;
+        });
+        conversionService.addConverter(Character[].class, char[].class, values -> {
+            char[] chars = new char[values.length];
+            for (int i = 0; i < values.length; i++) {
+                chars[i] = values[i];
+            }
+            return chars;
+        });
+        conversionService.addConverter(char[].class, Character[].class, values -> {
+            Character[] chars = new Character[values.length];
+            for (int i = 0; i < values.length; i++) {
+                chars[i] = values[i];
+            }
+            return chars;
+        });
+
+        conversionService.addConverter(Collection.class, Short[].class, collection -> {
+            Short[] shorts = new Short[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                shorts[i++] = asShort(value);
+            }
+            return shorts;
+        });
+        conversionService.addConverter(Collection.class, short[].class, collection -> {
+            short[] shorts = new short[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                shorts[i++] = asShort(value);
+            }
+            return shorts;
+        });
+        conversionService.addConverter(Short[].class, short[].class, values -> {
+            short[] shorts = new short[values.length];
+            for (int i = 0; i < values.length; i++) {
+                shorts[i] = values[i];
+            }
+            return shorts;
+        });
+        conversionService.addConverter(short[].class, Short[].class, values -> {
+            Short[] shorts = new Short[values.length];
+            for (int i = 0; i < values.length; i++) {
+                shorts[i] = values[i];
+            }
+            return shorts;
+        });
+
+        conversionService.addConverter(Collection.class, Float[].class, collection -> {
+            Float[] floats = new Float[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                floats[i++] = asFloat(value);
+            }
+            return floats;
+        });
+        conversionService.addConverter(Collection.class, float[].class, collection -> {
+            float[] floats = new float[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                floats[i++] = asFloat(value);
+            }
+            return floats;
+        });
+        conversionService.addConverter(Float[].class, float[].class, values -> {
+            float[] floats = new float[values.length];
+            for (int i = 0; i < values.length; i++) {
+                floats[i] = values[i];
+            }
+            return floats;
+        });
+        conversionService.addConverter(float[].class, Float[].class, values -> {
+            Float[] floats = new Float[values.length];
+            for (int i = 0; i < values.length; i++) {
+                floats[i] = values[i];
+            }
+            return floats;
+        });
+
+        conversionService.addConverter(Collection.class, Integer[].class, collection -> {
+            Integer[] ints = new Integer[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                ints[i++] = asInteger(value);
+            }
+            return ints;
+        });
+        conversionService.addConverter(Collection.class, int[].class, collection -> {
+            int[] ints = new int[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                ints[i++] = asInteger(value);
+            }
+            return ints;
+        });
+        conversionService.addConverter(Integer[].class, int[].class, values -> {
+            int[] ints = new int[values.length];
+            for (int i = 0; i < values.length; i++) {
+                ints[i] = values[i];
+            }
+            return ints;
+        });
+        conversionService.addConverter(int[].class, Integer[].class, values -> {
+            Integer[] ints = new Integer[values.length];
+            for (int i = 0; i < values.length; i++) {
+                ints[i] = values[i];
+            }
+            return ints;
+        });
+
+        conversionService.addConverter(Collection.class, Long[].class, collection -> {
+            Long[] longs = new Long[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                longs[i++] = asLong(value);
+            }
+            return longs;
+        });
+        conversionService.addConverter(Collection.class, long[].class, collection -> {
+            long[] longs = new long[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                longs[i++] = asLong(value);
+            }
+            return longs;
+        });
+        conversionService.addConverter(Long[].class, long[].class, values -> {
+            long[] longs = new long[values.length];
+            for (int i = 0; i < values.length; i++) {
+                longs[i] = values[i];
+            }
+            return longs;
+        });
+        conversionService.addConverter(long[].class, Long[].class, values -> {
+            Long[] longs = new Long[values.length];
+            for (int i = 0; i < values.length; i++) {
+                longs[i] = values[i];
+            }
+            return longs;
+        });
+
+        conversionService.addConverter(Collection.class, Double[].class, collection -> {
+            Double[] doubles = new Double[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                doubles[i++] = asDouble(value);
+            }
+            return doubles;
+        });
+        conversionService.addConverter(Collection.class, double[].class, collection -> {
+            double[] doubles = new double[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                doubles[i++] = asDouble(value);
+            }
+            return doubles;
+        });
+        conversionService.addConverter(Double[].class, double[].class, values -> {
+            double[] doubles = new double[values.length];
+            for (int i = 0; i < values.length; i++) {
+                doubles[i] = values[i];
+            }
+            return doubles;
+        });
+        conversionService.addConverter(double[].class, Double[].class, values -> {
+            Double[] doubles = new Double[values.length];
+            for (int i = 0; i < values.length; i++) {
+                doubles[i] = values[i];
+            }
+            return doubles;
+        });
+
+        conversionService.addConverter(Collection.class, Boolean[].class, collection -> {
+            Boolean[] booleans = new Boolean[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                booleans[i++] = asBoolean(value);
+            }
+            return booleans;
+        });
+        conversionService.addConverter(Collection.class, boolean[].class, collection -> {
+            boolean[] booleans = new boolean[collection.size()];
+            int i = 0;
+            for (Object value : collection) {
+                booleans[i++] = asBoolean(value);
+            }
+            return booleans;
+        });
+        conversionService.addConverter(Boolean[].class, boolean[].class, values -> {
+            boolean[] booleans = new boolean[values.length];
+            for (int i = 0; i < values.length; i++) {
+                booleans[i] = values[i];
+            }
+            return booleans;
+        });
+        conversionService.addConverter(boolean[].class, Boolean[].class, values -> {
+            Boolean[] booleans = new Boolean[values.length];
+            for (int i = 0; i < values.length; i++) {
+                booleans[i] = values[i];
+            }
+            return booleans;
+        });
 
         // Instant
         conversionService.addConverter(Instant.class, Date.class, Date::from);
@@ -82,5 +331,69 @@ class DataInitializer {
         conversionService.addConverter(OffsetDateTime.class, LocalDateTime.class, OffsetDateTime::toLocalDateTime);
         conversionService.addConverter(OffsetDateTime.class, Long.class, offsetDateTime ->
             offsetDateTime.toInstant().toEpochMilli());
+    }
+
+    private Integer asInteger(Object value) {
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return ConversionService.SHARED.convertRequired(value, Integer.class);
+    }
+
+    private Long asLong(Object value) {
+        if (value instanceof Long) {
+            return (Long) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return ConversionService.SHARED.convertRequired(value, Long.class);
+    }
+
+    private Double asDouble(Object value) {
+        if (value instanceof Double) {
+            return (Double) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        return ConversionService.SHARED.convertRequired(value, Double.class);
+    }
+
+    private Boolean asBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return ConversionService.SHARED.convertRequired(value, Boolean.class);
+    }
+
+    private Float asFloat(Object value) {
+        if (value instanceof Float) {
+            return (Float) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).floatValue();
+        }
+        return ConversionService.SHARED.convertRequired(value, Float.class);
+    }
+
+    private Short asShort(Object value) {
+        if (value instanceof Short) {
+            return (Short) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).shortValue();
+        }
+        return ConversionService.SHARED.convertRequired(value, Short.class);
+    }
+
+    private Character asCharacter(Object value) {
+        if (value instanceof Character) {
+            return (Character) value;
+        }
+        return ConversionService.SHARED.convertRequired(value, Character.class);
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.data.runtime.mapper.sql;
 
+import java.sql.Array;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -538,6 +540,13 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             DataType dataType) {
         Class<?> propertyType = rpp.getType();
         final Object r;
+        if (v instanceof Array) {
+            try {
+                v = ((Array) v).getArray();
+            } catch (SQLException e) {
+                throw new DataAccessException("Error getting an array value: " + e.getMessage(), e);
+            }
+        }
         if (propertyType.isInstance(v)) {
             r = v;
         } else {

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractArraysSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractArraysSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.tests
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.entities.ArraysEntity
+import io.micronaut.data.tck.repositories.ArraysEntityRepository
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class AbstractArraysSpec extends Specification {
+
+    abstract ArraysEntityRepository getArraysEntityRepository()
+
+    abstract Map<String, String> getProperties()
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
+    def "should insert and update an entity with arrays"() {
+        given:
+            ArraysEntity entity = new ArraysEntity()
+            entity.stringArray = ["XYZ", "123", "ABC"]
+            entity.stringArrayCollection = ["XYZ", "123", "ABC"]
+            entity.shortArray = [1, 2, 3]
+            entity.shortPrimitiveArray = [1, 2, 3]
+            entity.shortArrayCollection = [(short)1, (short)2, (short)3]
+            entity.integerArray = [1, 2, 3]
+            entity.integerPrimitiveArray = [1, 2, 3]
+            entity.integerArrayCollection = [1, 2, 3]
+            entity.longArray = [1, 2, 3]
+            entity.longPrimitiveArray = [1, 2, 3]
+            entity.longArrayCollection = [1L, 2L, 3L]
+            entity.floatArray = [1, 2, 3]
+            entity.floatPrimitiveArray = [1, 2, 3]
+            entity.floatArrayCollection = [1f, 2f, 3f]
+            entity.doubleArray = [1, 2, 3]
+            entity.doublePrimitiveArray = [1, 2, 3]
+            entity.doubleArrayCollection = [1d, 2d, 3d]
+            entity.characterArray = ['a', 'b', 'c'] as char[]
+            entity.characterPrimitiveArray = ['a', 'b', 'c'] as char[]
+            entity.characterArrayCollection = ['a', 'b', 'c'] as char[]
+            entity.booleanArray = [true, false, true, false]
+            entity.booleanPrimitiveArray = [true, false, true, false]
+            entity.booleanArrayCollection = [true, false, true, false]
+        when:
+            arraysEntityRepository.save(entity)
+            ArraysEntity entityStored = arraysEntityRepository.findById(entity.someId).get()
+        then:
+            entityStored == entity
+        when:
+            entity.stringArray = ["ABC", "123", "XYZ"]
+            entity.stringArrayCollection = ["ABC", "123", "XYZ"]
+            entity.shortArray = [3, 2, 1]
+            entity.shortPrimitiveArray = [3, 2, 1]
+            entity.shortArrayCollection = [(short)3, (short)2, (short)1]
+            entity.integerArray = [3, 2, 1]
+            entity.integerPrimitiveArray = [3, 2, 1]
+            entity.integerArrayCollection = [3, 2, 1]
+            entity.longArray = [3, 2, 1]
+            entity.longPrimitiveArray = [3, 2, 1]
+            entity.longArrayCollection = [3L, 2L, 1L]
+            entity.floatArray = [3, 2, 1]
+            entity.floatPrimitiveArray = [3, 2, 1]
+            entity.floatArrayCollection = [3f, 2f, 1f]
+            entity.doubleArray = [3, 2, 1]
+            entity.doublePrimitiveArray = [3, 2, 1]
+            entity.doubleArrayCollection = [3d, 2d, 1d]
+            entity.characterArray = ['c', 'b', 'a'] as char[]
+            entity.characterPrimitiveArray = ['c', 'b', 'a'] as char[]
+            entity.characterArrayCollection = ['c', 'b', 'a'] as char[]
+            entity.booleanArray = [false, false, true, true]
+            entity.booleanPrimitiveArray = [false, true, true, false]
+            entity.booleanArrayCollection = [false, false, true, false]
+            arraysEntityRepository.update(entity)
+            entityStored = arraysEntityRepository.findById(entity.someId).get()
+        then:
+            entityStored == entity
+        when:
+            arraysEntityRepository.update(entityStored.someId,
+                    ["111", "222", "333"] as String[],
+                    ["AAA"],
+                    [1, 2, 3, 4, 5] as Short[],
+                    [100] as short[],
+                    [], null, null, null
+            )
+            entityStored = arraysEntityRepository.findById(entity.someId).get()
+        then:
+            entityStored.stringArray == ["111", "222", "333"] as String[]
+            entityStored.stringArrayCollection == ["AAA"]
+            entityStored.shortArray == [1, 2, 3, 4, 5] as Short[]
+            entityStored.shortPrimitiveArray == [100]  as short[]
+            entityStored.shortArrayCollection == []
+            entityStored.integerArray == null
+            entityStored.integerPrimitiveArray == null
+            entityStored.integerArrayCollection == null
+    }
+
+    void cleanup() {
+        arraysEntityRepository?.deleteAll()
+    }
+}

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -65,6 +65,10 @@ abstract class AbstractRepositorySpec extends Specification {
         return false
     }
 
+    boolean isSupportsArrays() {
+        return false
+    }
+
     protected void savePersons(List<String> names) {
         personRepository.saveAll(names.collect { new Person(name: it) })
     }
@@ -1008,6 +1012,48 @@ abstract class AbstractRepositorySpec extends Specification {
             def books6 = bookRepository.listNativeBooksWithTitleInArray(new String[0])
         then:
             books6.size() == 0
+        cleanup:
+            cleanupBooks()
+    }
+
+    void "test string array data type"() {
+        if (!isSupportsArrays()) {
+            return
+        }
+        given:
+            setupBooks()
+        when:
+            def books4 = bookRepository.listNativeBooksNullableListAsStringArray(["The Stand", "FFF"])
+        then:
+            books4.size() == 1
+        when:
+            def books5 = bookRepository.listNativeBooksNullableListAsStringArray(["Xyz", "FFF"])
+        then:
+            books5.size() == 0
+        when:
+            def books6 = bookRepository.listNativeBooksNullableListAsStringArray([])
+        then:
+            books6.size() == 0
+        when:
+            def books7 = bookRepository.listNativeBooksNullableListAsStringArray(null)
+        then:
+            books7.size() == 0
+        when:
+            def books8 = bookRepository.listNativeBooksNullableArrayAsStringArray(new String[] {"Xyz", "Ffff", "zzz"})
+        then:
+            books8.size() == 0
+        when:
+            def books9 = bookRepository.listNativeBooksNullableArrayAsStringArray(new String[] {})
+        then:
+            books9.size() == 0
+        when:
+            def books11 = bookRepository.listNativeBooksNullableArrayAsStringArray(null)
+        then:
+            books11.size() == 0
+        then:
+            def books12 = bookRepository.listNativeBooksNullableArrayAsStringArray(new String[] {"The Stand"})
+        then:
+            books12.size() == 1
         cleanup:
             cleanupBooks()
     }

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/ArraysEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/ArraysEntity.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+@MappedEntity
+public class ArraysEntity {
+    @GeneratedValue
+    @Id
+    private Long someId;
+
+    private String[] stringArray;
+    @TypeDef(type = DataType.STRING_ARRAY)
+    private Collection<String> stringArrayCollection;
+    private Short[] shortArray;
+    private short[] shortPrimitiveArray;
+    @TypeDef(type = DataType.SHORT_ARRAY)
+    private Collection<Short> shortArrayCollection;
+    @Nullable
+    private Integer[] integerArray;
+    @Nullable
+    private int[] integerPrimitiveArray;
+    @Nullable
+    @TypeDef(type = DataType.INTEGER_ARRAY)
+    private Collection<Integer> integerArrayCollection;
+    private Long[] longArray;
+    private long[] longPrimitiveArray;
+    @TypeDef(type = DataType.LONG_ARRAY)
+    private Collection<Long> longArrayCollection;
+    private Float[] floatArray;
+    private float[] floatPrimitiveArray;
+    @TypeDef(type = DataType.FLOAT_ARRAY)
+    private Collection<Float> floatArrayCollection;
+    private Double[] doubleArray;
+    private double[] doublePrimitiveArray;
+    @TypeDef(type = DataType.DOUBLE_ARRAY)
+    private Collection<Double> doubleArrayCollection;
+    private Character[] characterArray;
+    private char[] characterPrimitiveArray;
+    @TypeDef(type = DataType.CHARACTER_ARRAY)
+    private Collection<Character> characterArrayCollection;
+    private Boolean[] booleanArray;
+    private boolean[] booleanPrimitiveArray;
+    @TypeDef(type = DataType.BOOLEAN_ARRAY)
+    private Collection<Boolean> booleanArrayCollection;
+
+    public Long getSomeId() {
+        return someId;
+    }
+
+    public void setSomeId(Long someId) {
+        this.someId = someId;
+    }
+
+    public String[] getStringArray() {
+        return stringArray;
+    }
+
+    public void setStringArray(String[] stringArray) {
+        this.stringArray = stringArray;
+    }
+
+    public Collection<String> getStringArrayCollection() {
+        return stringArrayCollection;
+    }
+
+    public void setStringArrayCollection(Collection<String> stringArrayCollection) {
+        this.stringArrayCollection = stringArrayCollection;
+    }
+
+    public Short[] getShortArray() {
+        return shortArray;
+    }
+
+    public void setShortArray(Short[] shortArray) {
+        this.shortArray = shortArray;
+    }
+
+    public short[] getShortPrimitiveArray() {
+        return shortPrimitiveArray;
+    }
+
+    public void setShortPrimitiveArray(short[] shortPrimitiveArray) {
+        this.shortPrimitiveArray = shortPrimitiveArray;
+    }
+
+    public Collection<Short> getShortArrayCollection() {
+        return shortArrayCollection;
+    }
+
+    public void setShortArrayCollection(Collection<Short> shortArrayCollection) {
+        this.shortArrayCollection = shortArrayCollection;
+    }
+
+    @Nullable
+    public Integer[] getIntegerArray() {
+        return integerArray;
+    }
+
+    public void setIntegerArray(@Nullable Integer[] integerArray) {
+        this.integerArray = integerArray;
+    }
+
+    @Nullable
+    public int[] getIntegerPrimitiveArray() {
+        return integerPrimitiveArray;
+    }
+
+    public void setIntegerPrimitiveArray(@Nullable int[] integerPrimitiveArray) {
+        this.integerPrimitiveArray = integerPrimitiveArray;
+    }
+
+    @Nullable
+    public Collection<Integer> getIntegerArrayCollection() {
+        return integerArrayCollection;
+    }
+
+    public void setIntegerArrayCollection(@Nullable Collection<Integer> integerArrayCollection) {
+        this.integerArrayCollection = integerArrayCollection;
+    }
+
+    public Long[] getLongArray() {
+        return longArray;
+    }
+
+    public void setLongArray(Long[] longArray) {
+        this.longArray = longArray;
+    }
+
+    public long[] getLongPrimitiveArray() {
+        return longPrimitiveArray;
+    }
+
+    public void setLongPrimitiveArray(long[] longPrimitiveArray) {
+        this.longPrimitiveArray = longPrimitiveArray;
+    }
+
+    public Collection<Long> getLongArrayCollection() {
+        return longArrayCollection;
+    }
+
+    public void setLongArrayCollection(Collection<Long> longArrayCollection) {
+        this.longArrayCollection = longArrayCollection;
+    }
+
+    public Float[] getFloatArray() {
+        return floatArray;
+    }
+
+    public void setFloatArray(Float[] floatArray) {
+        this.floatArray = floatArray;
+    }
+
+    public float[] getFloatPrimitiveArray() {
+        return floatPrimitiveArray;
+    }
+
+    public void setFloatPrimitiveArray(float[] floatPrimitiveArray) {
+        this.floatPrimitiveArray = floatPrimitiveArray;
+    }
+
+    public Collection<Float> getFloatArrayCollection() {
+        return floatArrayCollection;
+    }
+
+    public void setFloatArrayCollection(Collection<Float> floatArrayCollection) {
+        this.floatArrayCollection = floatArrayCollection;
+    }
+
+    public Double[] getDoubleArray() {
+        return doubleArray;
+    }
+
+    public void setDoubleArray(Double[] doubleArray) {
+        this.doubleArray = doubleArray;
+    }
+
+    public double[] getDoublePrimitiveArray() {
+        return doublePrimitiveArray;
+    }
+
+    public void setDoublePrimitiveArray(double[] doublePrimitiveArray) {
+        this.doublePrimitiveArray = doublePrimitiveArray;
+    }
+
+    public Collection<Double> getDoubleArrayCollection() {
+        return doubleArrayCollection;
+    }
+
+    public void setDoubleArrayCollection(Collection<Double> doubleArrayCollection) {
+        this.doubleArrayCollection = doubleArrayCollection;
+    }
+
+    public Character[] getCharacterArray() {
+        return characterArray;
+    }
+
+    public void setCharacterArray(Character[] characterArray) {
+        this.characterArray = characterArray;
+    }
+
+    public char[] getCharacterPrimitiveArray() {
+        return characterPrimitiveArray;
+    }
+
+    public void setCharacterPrimitiveArray(char[] characterPrimitiveArray) {
+        this.characterPrimitiveArray = characterPrimitiveArray;
+    }
+
+    public Collection<Character> getCharacterArrayCollection() {
+        return characterArrayCollection;
+    }
+
+    public void setCharacterArrayCollection(Collection<Character> characterArrayCollection) {
+        this.characterArrayCollection = characterArrayCollection;
+    }
+
+    public Boolean[] getBooleanArray() {
+        return booleanArray;
+    }
+
+    public void setBooleanArray(Boolean[] booleanArray) {
+        this.booleanArray = booleanArray;
+    }
+
+    public boolean[] getBooleanPrimitiveArray() {
+        return booleanPrimitiveArray;
+    }
+
+    public void setBooleanPrimitiveArray(boolean[] booleanPrimitiveArray) {
+        this.booleanPrimitiveArray = booleanPrimitiveArray;
+    }
+
+    public Collection<Boolean> getBooleanArrayCollection() {
+        return booleanArrayCollection;
+    }
+
+    public void setBooleanArrayCollection(Collection<Boolean> booleanArrayCollection) {
+        this.booleanArrayCollection = booleanArrayCollection;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArraysEntity)) return false;
+        ArraysEntity that = (ArraysEntity) o;
+        return Objects.equals(someId, that.someId) &&
+                Arrays.equals(stringArray, that.stringArray) &&
+                Objects.equals(stringArrayCollection, that.stringArrayCollection) &&
+                Arrays.equals(shortArray, that.shortArray) &&
+                Arrays.equals(shortPrimitiveArray, that.shortPrimitiveArray) &&
+                Objects.equals(shortArrayCollection, that.shortArrayCollection) &&
+                Arrays.equals(integerArray, that.integerArray) &&
+                Arrays.equals(integerPrimitiveArray, that.integerPrimitiveArray) &&
+                Objects.equals(integerArrayCollection, that.integerArrayCollection) &&
+                Arrays.equals(longArray, that.longArray) &&
+                Arrays.equals(longPrimitiveArray, that.longPrimitiveArray) &&
+                Objects.equals(longArrayCollection, that.longArrayCollection) &&
+                Arrays.equals(floatArray, that.floatArray) &&
+                Arrays.equals(floatPrimitiveArray, that.floatPrimitiveArray) &&
+                Objects.equals(floatArrayCollection, that.floatArrayCollection) &&
+                Arrays.equals(doubleArray, that.doubleArray) &&
+                Arrays.equals(doublePrimitiveArray, that.doublePrimitiveArray) &&
+                Objects.equals(doubleArrayCollection, that.doubleArrayCollection) &&
+                Arrays.equals(characterArray, that.characterArray) &&
+                Arrays.equals(characterPrimitiveArray, that.characterPrimitiveArray) &&
+                Objects.equals(characterArrayCollection, that.characterArrayCollection) &&
+                Arrays.equals(booleanArray, that.booleanArray) &&
+                Arrays.equals(booleanPrimitiveArray, that.booleanPrimitiveArray) &&
+                Objects.equals(booleanArrayCollection, that.booleanArrayCollection);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(someId, stringArrayCollection, shortArrayCollection, integerArrayCollection, longArrayCollection, floatArrayCollection, doubleArrayCollection, characterArrayCollection, booleanArrayCollection);
+        result = 31 * result + Arrays.hashCode(stringArray);
+        result = 31 * result + Arrays.hashCode(shortArray);
+        result = 31 * result + Arrays.hashCode(shortPrimitiveArray);
+        result = 31 * result + Arrays.hashCode(integerArray);
+        result = 31 * result + Arrays.hashCode(integerPrimitiveArray);
+        result = 31 * result + Arrays.hashCode(longArray);
+        result = 31 * result + Arrays.hashCode(longPrimitiveArray);
+        result = 31 * result + Arrays.hashCode(floatArray);
+        result = 31 * result + Arrays.hashCode(floatPrimitiveArray);
+        result = 31 * result + Arrays.hashCode(doubleArray);
+        result = 31 * result + Arrays.hashCode(doublePrimitiveArray);
+        result = 31 * result + Arrays.hashCode(characterArray);
+        result = 31 * result + Arrays.hashCode(characterPrimitiveArray);
+        result = 31 * result + Arrays.hashCode(booleanArray);
+        result = 31 * result + Arrays.hashCode(booleanPrimitiveArray);
+        return result;
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/MultiArrayEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/MultiArrayEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.MappedProperty;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@MappedEntity
+public class MultiArrayEntity {
+    @GeneratedValue
+    @Id
+    private Long id;
+    @MappedProperty(definition = "text[][]")
+    private String[][] stringMultiArray;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String[][] getStringMultiArray() {
+        return stringMultiArray;
+    }
+
+    public void setStringMultiArray(String[][] stringMultiArray) {
+        this.stringMultiArray = stringMultiArray;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MultiArrayEntity)) return false;
+        MultiArrayEntity that = (MultiArrayEntity) o;
+        return Objects.equals(id, that.id) &&
+                Arrays.deepEquals(stringMultiArray, that.stringMultiArray);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(id);
+        result = 31 * result + Arrays.hashCode(stringMultiArray);
+        return result;
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/ArraysEntityRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/ArraysEntityRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.ArraysEntity;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public interface ArraysEntityRepository extends CrudRepository<ArraysEntity, Long> {
+
+    void update(@Id Long id,
+                @Parameter("stringArray") String[] stringArray,
+                @Parameter("stringArrayCollection") Collection<String> stringArrayCollection,
+                @Parameter("shortArray") Short[] shortArray,
+                @Parameter("shortPrimitiveArray") short[] shortPrimitiveArray,
+                @Parameter("shortArrayCollection") Collection<Short> shortArrayCollection,
+                @Parameter("integerArray") @Nullable Integer[] integerArray,
+                @Parameter("integerPrimitiveArray") @Nullable int[] integerPrimitiveArray,
+                @Parameter("integerArrayCollection") @Nullable Collection<Integer> integerArrayCollection
+    );
+
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
@@ -20,6 +20,8 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.Join;
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.repository.PageableRepository;
@@ -77,13 +79,19 @@ public abstract class BookRepository implements PageableRepository<Book, Long> {
     public abstract List<Book> listNativeBooksWithTitleInCollection(@Nullable Collection<String> arg0);
 
     @Query(value = "select * from book b where b.title IN (:arg0)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksWithTitleInArray(@Nullable String[] arg0);
+    public abstract List<Book> listNativeBooksWithTitleInArray(@TypeDef(type = DataType.STRING) @Nullable String[] arg0);
 
     @Query(value = "select * from book b where b.title = any (:arg0)", nativeQuery = true)
     public abstract List<Book> listNativeBooksWithTitleAnyCollection(@Nullable Collection<String> arg0);
 
     @Query(value = "select * from book b where b.title = ANY (:arg0)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksWithTitleAnyArray(@Nullable String[] arg0);
+    public abstract List<Book> listNativeBooksWithTitleAnyArray(@TypeDef(type = DataType.STRING) @Nullable String[] arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title = ANY (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableListAsStringArray(@Nullable @TypeDef(type = DataType.STRING_ARRAY) List<String> arg0);
+
+    @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title = ANY (:arg0) ELSE true END)", nativeQuery = true)
+    public abstract List<Book> listNativeBooksNullableArrayAsStringArray(@Nullable @TypeDef(type = DataType.STRING_ARRAY) String[] arg0);
 
     public void saveAuthorBooks(List<AuthorBooksDto> authorBooksDtos) {
         List<Author> authors = new ArrayList<>();

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/MultiArrayEntityRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/MultiArrayEntityRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.MultiArrayEntity;
+
+public interface MultiArrayEntityRepository extends CrudRepository<MultiArrayEntity, Long> {
+
+//    void update(@Id Long id, @Parameter("stringMultiArray") String[][] stringMultiArray);
+//    This triggers:
+//    Caused by: java.lang.UnsupportedOperationException
+//    at io.micronaut.asm.Type.getOpcode(Type.java:802)
+//    at io.micronaut.asm.commons.GeneratorAdapter.loadInsn(GeneratorAdapter.java:481)
+//    at io.micronaut.asm.commons.GeneratorAdapter.loadArg(GeneratorAdapter.java:508)
+
+}


### PR DESCRIPTION
Only supported by Postgres and H2, it could be used as an alternative to the parameters list expansion which in this case doesn't need to modify the query.

Looks like the Micronaut annotation processor doesn't support multi-dimension arrays added in `MultiArrayEntityRepository`.

BTW I think it's better to have `DataType.BINARY` instead of `BYTE_ARRAY`