### PR TITLE
Entity events

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/annotation/AutoPopulated.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/AutoPopulated.java
@@ -34,6 +34,8 @@ public @interface AutoPopulated {
      */
     String NAME = AutoPopulated.class.getName();
 
+    String UPDATEABLE = "updateable";
+
     /**
      * @return Whether the property can be updated following an insert
      */

--- a/data-model/src/main/java/io/micronaut/data/annotation/MappedEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/MappedEntity.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.data.annotation;
 
-import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.data.model.naming.NamingStrategies;
 import io.micronaut.data.model.naming.NamingStrategy;
@@ -41,7 +40,6 @@ import java.lang.annotation.*;
         @Introspected.IndexedAnnotation(annotation = MappedProperty.class, member = "value")
     }
 )
-@Prototype
 public @interface MappedEntity {
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/annotation/MappedEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/MappedEntity.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.annotation;
 
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.data.model.naming.NamingStrategies;
 import io.micronaut.data.model.naming.NamingStrategy;
@@ -40,6 +41,7 @@ import java.lang.annotation.*;
         @Introspected.IndexedAnnotation(annotation = MappedProperty.class, member = "value")
     }
 )
+@Prototype
 public @interface MappedEntity {
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/EntityLifecycleEventMapping.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/EntityLifecycleEventMapping.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import io.micronaut.context.annotation.Executable;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marker annotation of entity lifecycle event handler.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
+@Executable
+public @interface EntityLifecycleEventMapping {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PostLoad.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PostLoad.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a post load event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PostLoad}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PostLoad {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PostPersist.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PostPersist.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a post persist event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PostPersist}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PostPersist {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PostRemove.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PostRemove.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a post remove event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PostRemove}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PostRemove {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PostUpdate.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PostUpdate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a post update event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PostUpdate}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PostUpdate {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PrePersist.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PrePersist.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a pre persist event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PrePersist}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PrePersist {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PreRemove.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PreRemove.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a post remove event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PreRemove}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PreRemove {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/event/PreUpdate.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/event/PreUpdate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation.event;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates method that is representing a pre update event listener. Typically not used
+ * directly but instead mapped to via annotation such as {@code javax.persistence.PreUpdate}.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Target({METHOD})
+@Retention(RUNTIME)
+@EntityLifecycleEventMapping
+public @interface PreUpdate {
+}

--- a/data-model/src/main/java/io/micronaut/data/autopopulated/EntityAutoPopulatedPropertyProvider.java
+++ b/data-model/src/main/java/io/micronaut/data/autopopulated/EntityAutoPopulatedPropertyProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.autopopulated;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.data.model.runtime.RuntimePersistentProperty;
+
+/**
+ * The interface representing an auto-populated property provider.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Indexed(EntityAutoPopulatedPropertyProvider.class)
+public interface EntityAutoPopulatedPropertyProvider extends Ordered {
+
+    /**
+     * Auto-populating the property.
+     *
+     * @param property the property to auto-populate
+     * @param previousValue the previous value
+     * @return new value
+     */
+    Object autoPopulate(RuntimePersistentProperty<?> property, @Nullable Object previousValue);
+
+    /**
+     * Does supports auto-populating the property.
+     *
+     * @param property the property to check
+     * @return true if provider supports the property
+     */
+    boolean supports(RuntimePersistentProperty<?> property);
+}

--- a/data-model/src/main/java/io/micronaut/data/event/EntityListener.java
+++ b/data-model/src/main/java/io/micronaut/data/event/EntityListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.event;
+
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.order.Ordered;
+
+import java.util.EventListener;
+
+/**
+ * The interface representing an entity event listener.
+ *
+ * @param <T> the entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Indexed(EntityListener.class)
+public interface EntityListener<T> extends EventListener, Ordered  {
+}

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
@@ -78,6 +78,11 @@ public @interface DataMethod {
     String META_MEMBER_PARAMETER_BINDING_PATHS = META_MEMBER_PARAMETER_BINDING + "Paths";
 
     /**
+     * The member name that holds parameter auto populated property paths.
+     */
+    String META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS = META_MEMBER_PARAMETER_BINDING + "AutoPopulatedPropertyPaths";
+
+    /**
      * The ID type.
      */
     String META_MEMBER_ID_TYPE = "idType";

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
@@ -102,7 +102,25 @@ public interface QueryBuilder {
      * @param propertiesToUpdate The property names to update
      * @return The encoded query
      */
-    QueryResult buildUpdate(@NonNull AnnotationMetadata annotationMetadata, @NonNull QueryModel query, @NonNull List<String> propertiesToUpdate);
+    QueryResult buildUpdate(@NonNull AnnotationMetadata annotationMetadata,
+                            @NonNull QueryModel query,
+                            @NonNull List<String> propertiesToUpdate);
+
+    /**
+     * Encode the given query into the encoded query instance.
+     *
+     * @param annotationMetadata The annotation metadata
+     * @param query The query
+     * @param propertiesToUpdate The property names to update
+     * @param autoPopulatePropertiesToUpdate The property names to update
+     * @return The encoded query
+     */
+    default QueryResult buildUpdate(@NonNull AnnotationMetadata annotationMetadata,
+                                    @NonNull QueryModel query,
+                                    @NonNull List<String> propertiesToUpdate,
+                                    @NonNull List<String> autoPopulatePropertiesToUpdate) {
+        return buildUpdate(annotationMetadata, query, propertiesToUpdate);
+    }
 
     /**
      * Encode the given query into the encoded query instance.

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/BatchOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/BatchOperation.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.data.model.runtime;
 
-import java.util.List;
-
 /**
  * A batch operation is an operation performed on one or more entities of the same type.
  *
@@ -33,9 +31,4 @@ public interface BatchOperation<E> extends EntityOperation<E>, Iterable<E>, Prep
         return false;
     }
 
-    /**
-     * Split the batch operation into individual inserts.
-     * @return The separated inserts.
-     */
-    List<InsertOperation<E>> split();
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteAllOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteAllOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.runtime;
+
+/**
+ * A delete all operation that deletes all entity entries.
+ *
+ * @param <E> The entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public interface DeleteAllOperation<E> extends EntityOperation<E> {
+}
+

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteBatchOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteBatchOperation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.runtime;
+
+import java.util.List;
+
+/**
+ * A delete batch operation is an operation performed on one or more entities of the same type.
+ *
+ * @param <E> The entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public interface DeleteBatchOperation<E> extends BatchOperation<E> {
+
+    /**
+     * Split the batch operation into individual deletes.
+     *
+     * @return The separated deletes.
+     */
+    List<DeleteOperation<E>> split();
+}

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/DeleteOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.runtime;
+
+/**
+ * A delete operation that updates the given entity.
+ *
+ * @param <E> The entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public interface DeleteOperation<E> extends EntityInstanceOperation<E> {
+}
+

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/EntityInstanceOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/EntityInstanceOperation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.runtime;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An entity operation with an instance.
+ *
+ * @param <E> The entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public interface EntityInstanceOperation<E> extends EntityOperation<E> {
+
+    /**
+     * @return The entity to insert.
+     */
+    @NonNull E getEntity();
+
+}
+

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/InsertBatchOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/InsertBatchOperation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.runtime;
+
+import java.util.List;
+
+/**
+ * An insert batch operation is an operation performed on one or more entities of the same type.
+ *
+ * @param <E> The entity type
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public interface InsertBatchOperation<E> extends BatchOperation<E> {
+
+    /**
+     * Split the batch operation into individual inserts.
+     * @return The separated inserts.
+     */
+    List<InsertOperation<E>> split();
+}

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/InsertOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/InsertOperation.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.data.model.runtime;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
  * An insert operation that inserts a record.
  *
@@ -24,11 +22,5 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @author graemerocher
  * @since 1.0.0
  */
-public interface InsertOperation<E> extends EntityOperation<E>, PreparedDataOperation<E> {
-
-    /**
-     * @return The entity to insert.
-     */
-    @NonNull E getEntity();
-
+public interface InsertOperation<E> extends EntityInstanceOperation<E>, PreparedDataOperation<E> {
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/PreparedQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/PreparedQuery.java
@@ -52,11 +52,6 @@ public interface PreparedQuery<E, R> extends PagedQuery<E>, StoredQuery<E, R>, P
      */
     Argument[] getArguments();
 
-    /**
-     * @return The last updated type.
-     */
-    Class<?> getLastUpdatedType();
-
     @NonNull
     @Override
     default Map<String, Object> getQueryHints() {

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -48,6 +48,7 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
 
     /**
      * Default constructor.
+     *
      * @param type The type
      */
     public RuntimePersistentEntity(@NonNull Class<T> type) {
@@ -56,6 +57,7 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
 
     /**
      * Default constructor.
+     *
      * @param introspection The introspection
      */
     public RuntimePersistentEntity(@NonNull BeanIntrospection<T> introspection) {
@@ -183,6 +185,16 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
             }
         }
         return property;
+    }
+
+    /**
+     * Return a property for a dot separated property path such as {@code foo.bar.prop}.
+     *
+     * @param path The path
+     * @return The property
+     */
+    public Optional<RuntimePersistentProperty<T>> getRuntimePropertyByPath(String path) {
+        return (Optional) super.getPropertyByPath(path);
     }
 
     @NonNull

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
@@ -16,7 +16,6 @@
 package io.micronaut.data.model.runtime;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
@@ -193,12 +192,12 @@ public interface StoredQuery<E, R> extends Named, StoredDataOperation<R> {
     }
 
     /**
-     * The name of the last updated property on the entity if any.
+     * The mapping between query parameters and auto populated properties that the parameter represents.
      *
-     * @return The last updated property
+     * @return The auto populated properties.
      */
-    default @Nullable String getLastUpdatedProperty() {
-        return null;
+    default String[] getIndexedParameterAutoPopulatedPropertyPaths() {
+        return StringUtils.EMPTY_STRING_ARRAY;
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/UpdateOperation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/UpdateOperation.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.data.model.runtime;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
  * An update operation that updates the given entity.
  *
@@ -24,12 +22,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @author graemerocher
  * @since 1.0.0
  */
-public interface UpdateOperation<E> extends EntityOperation<E> {
-
-    /**
-     * @return The entity to insert.
-     */
-    @NonNull E getEntity();
-
+public interface UpdateOperation<E> extends EntityInstanceOperation<E> {
 }
 

--- a/data-model/src/main/java/io/micronaut/data/operations/RepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/RepositoryOperations.java
@@ -20,10 +20,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.runtime.*;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -150,7 +152,11 @@ public interface RepositoryOperations {
      * @param <T> The generic type
      * @return The entities, possibly mutated
      */
-    @NonNull <T> Iterable<T> persistAll(@NonNull BatchOperation<T> operation);
+    default @NonNull <T> Iterable<T> persistAll(@NonNull InsertBatchOperation<T> operation) {
+        return operation.split().stream()
+                        .map(this::persist)
+                        .collect(Collectors.toList());
+    }
 
     /**
      * Executes an update for the given query and parameter values. If it is possible to
@@ -175,12 +181,21 @@ public interface RepositoryOperations {
     }
 
     /**
+     * Deletes the entity.
+     *
+     * @param operation The operation
+     * @param <T> The generic type
+     * @return The number of entities deleted
+     */
+    <T> int delete(@NonNull DeleteOperation<T> operation);
+
+    /**
      * Deletes all the entities of the given type.
      * @param operation The operation
      * @param <T> The generic type
      * @return The number of entities deleted
      */
-    <T> Optional<Number> deleteAll(@NonNull BatchOperation<T> operation);
+    <T> Optional<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation);
 
     /**
      * Obtain any custom query hints for this method and repository implementation.

--- a/data-model/src/main/java/io/micronaut/data/operations/async/AsyncRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/async/AsyncRepositoryOperations.java
@@ -138,7 +138,7 @@ public interface AsyncRepositoryOperations {
      * @param <T> The generic type
      * @return The entities, possibly mutated
      */
-    @NonNull <T> CompletionStage<Iterable<T>> persistAll(@NonNull BatchOperation<T> operation);
+    @NonNull <T> CompletionStage<Iterable<T>> persistAll(@NonNull InsertBatchOperation<T> operation);
 
     /**
      * Executes an update for the given query and parameter values. If it is possible to
@@ -152,12 +152,20 @@ public interface AsyncRepositoryOperations {
     );
 
     /**
+     * Deletes the entity.
+     * @param operation The batch operation
+     * @param <T> The generic type
+     * @return A completion that emits the number of entities deleted
+     */
+    @NonNull <T> CompletionStage<Number> delete(@NonNull DeleteOperation<T> operation);
+
+    /**
      * Deletes all the entities of the given type.
      * @param operation The batch operation
      * @param <T> The generic type
-     * @return A completion that emits a boolean true if successful
+     * @return A completion that emits the number of entities deleted
      */
-    @NonNull <T> CompletionStage<Number> deleteAll(@NonNull BatchOperation<T> operation);
+    @NonNull <T> CompletionStage<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation);
 
     /**
      * Find a page for the given entity and pageable.

--- a/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactiveRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactiveRepositoryOperations.java
@@ -139,7 +139,7 @@ public interface ReactiveRepositoryOperations {
      * @param <T> The generic type
      * @return The entities, possibly mutated
      */
-    @NonNull <T> Publisher<T> persistAll(@NonNull BatchOperation<T> operation);
+    @NonNull <T> Publisher<T> persistAll(@NonNull InsertBatchOperation<T> operation);
 
     /**
      * Executes an update for the given query and parameter values. If it is possible to
@@ -154,14 +154,24 @@ public interface ReactiveRepositoryOperations {
     );
 
     /**
-     * Deletes all the entities of the given type.
+     * Deletes the entity.
      * @param operation The batch operation
      * @param <T> The generic type
-     * @return A publisher that emits a boolean true if the update was successful
+     * @return A publisher that emits the number of entities deleted
      */
     @SingleResult
     @NonNull
-    <T> Publisher<Number> deleteAll(BatchOperation<T> operation);
+    <T> Publisher<Number> delete(@NonNull DeleteOperation<T> operation);
+
+    /**
+     * Deletes all the entities of the given type.
+     * @param operation The batch operation
+     * @param <T> The generic type
+     * @return A publisher that emits the number of entities deleted
+     */
+    @SingleResult
+    @NonNull
+    <T> Publisher<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation);
 
     /**
      * Find a page for the given entity and pageable.

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/EntityAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/EntityAnnotationMapper.java
@@ -41,7 +41,6 @@ public final class EntityAnnotationMapper implements NamedAnnotationMapper {
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-
         return Arrays.asList(
                 MappedEntityMapper.buildIntrospectionConfiguration(),
                 AnnotationValue.builder(MappedEntity.class).build()

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostLoadAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostLoadAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PostLoad} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PostLoadAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PostLoad";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PostLoad.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostPersistAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostPersistAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PostPersist} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PostPersistAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PostPersist";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PostPersist.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostRemoveAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostRemoveAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PostRemove} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PostRemoveAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PostRemove";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PostRemove.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostUpdateAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PostUpdateAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PostUpdate} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PostUpdateAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PostUpdate";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PostUpdate.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PrePersistAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PrePersistAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PrePersist} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PrePersistAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PrePersist";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PrePersist.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PreRemoveAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PreRemoveAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PreRemove} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PreRemoveAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PreRemove";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PreRemove.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PreUpdateAnnotationMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/jpa/event/PreUpdateAnnotationMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.mappers.jpa.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps JPA's {@code PreUpdate} annotation to Micronaut's.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public final class PreUpdateAnnotationMapper implements NamedAnnotationMapper {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "javax.persistence.PreUpdate";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(io.micronaut.data.annotation.event.PreUpdate.class)
+                        .build()
+        );
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -56,7 +56,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.data.model.query.builder.AbstractSqlLikeQueryBuilder.AUTO_POPULATED_PARAMETER_PREFIX;
-import static io.micronaut.data.model.query.builder.QueryBuilder.IN_VARIABLES_PATTERN;
 import static io.micronaut.data.model.query.builder.QueryBuilder.VARIABLE_PATTERN;
 
 /**

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/MethodMatchInfo.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/MethodMatchInfo.java
@@ -39,6 +39,7 @@ public class MethodMatchInfo {
     private final ClassElement interceptor;
     private final OperationType operationType;
     private final String[] updateProperties;
+    private final String[] autoPopulateForUpdateProperties;
 
     private Map<String, String> parameterRoles = new HashMap<>(2);
     private boolean dto;
@@ -78,19 +79,37 @@ public class MethodMatchInfo {
      * @param query The query, can be null for interceptors that don't execute queries.
      * @param interceptor The interceptor type to execute at runtime
      * @param operationType The operation type
+     */
+    public MethodMatchInfo(
+            @Nullable TypedElement resultType,
+            @Nullable QueryModel query,
+            @Nullable ClassElement interceptor,
+            @NonNull OperationType operationType) {
+        this(resultType, query, interceptor, operationType, null, null);
+    }
+
+    /**
+     * Creates a method info.
+     * @param resultType The result type, can be null for void etc.
+     * @param query The query, can be null for interceptors that don't execute queries.
+     * @param interceptor The interceptor type to execute at runtime
+     * @param operationType The operation type
      * @param updateProperties the update properties
+     * @param autoPopulateForUpdateProperties the auto-populate properties
      */
     public MethodMatchInfo(
             @Nullable TypedElement resultType,
             @Nullable QueryModel query,
             @Nullable ClassElement interceptor,
             @NonNull OperationType operationType,
-            String... updateProperties) {
+            String[] updateProperties,
+            String[] autoPopulateForUpdateProperties) {
         this.query = query;
         this.interceptor = interceptor;
         this.operationType = operationType;
         this.resultType = resultType;
         this.updateProperties = updateProperties;
+        this.autoPopulateForUpdateProperties = autoPopulateForUpdateProperties;
     }
 
     /**
@@ -131,6 +150,17 @@ public class MethodMatchInfo {
     }
 
     /**
+     * @return The properties to auto-populate for an update operation.
+     */
+    @NonNull public List<String> getAutoPopulateForUpdateProperties() {
+        if (autoPopulateForUpdateProperties == null) {
+            return Collections.emptyList();
+        } else {
+            return Arrays.asList(autoPopulateForUpdateProperties);
+        }
+    }
+
+    /**
      * The computed result type.
      * @return The result type.
      */
@@ -163,6 +193,7 @@ public class MethodMatchInfo {
     public OperationType getOperationType() {
         return operationType;
     }
+
 
     /**
      * Describes the operation type.

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateEntityMethod.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/UpdateEntityMethod.java
@@ -127,7 +127,8 @@ public class UpdateEntityMethod extends AbstractPatternBasedMethod implements Me
                                 queryModel,
                                 getInterceptorElement(matchContext, interceptor),
                                 MethodMatchInfo.OperationType.UPDATE,
-                                updateProperties
+                                updateProperties,
+                                null
                         );
                     }
 

--- a/data-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/data-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -24,3 +24,10 @@ io.micronaut.data.processor.mappers.spring.SpringTransientMapper
 io.micronaut.data.processor.mappers.spring.SpringVersionMapper
 io.micronaut.data.processor.mappers.spring.SpringTransactionalEventListenerMapper
 io.micronaut.data.processor.mappers.spring.SpringRepositoryMapper
+io.micronaut.data.processor.mappers.jpa.event.PostLoadAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PrePersistAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PostPersistAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PreUpdateAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PostUpdateAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PreRemoveAnnotationMapper
+io.micronaut.data.processor.mappers.jpa.event.PostRemoveAnnotationMapper

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
@@ -49,11 +49,13 @@ interface CompanyRepository extends io.micronaut.data.tck.repositories.CompanyRe
 }
 """)
         def updateMethod = repository.findPossibleMethods("update").findFirst().get()
-        def updatePaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Paths", String[].class).get()
+        def updatePaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING_PATHS, String[].class).get()
+        def autoPopulatedPropertyPaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS, String[].class).get()
 
         expect:"The repository compiles"
         repository != null
-        updatePaths == ['', "lastUpdated", ""] as String[]
+        updatePaths == ['', "", ""] as String[]
+        autoPopulatedPropertyPaths == ['', "lastUpdated", ""] as String[]
     }
 
     void "test compile repository"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/SqlParameterBindingSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/SqlParameterBindingSpec.groovy
@@ -107,10 +107,12 @@ interface CompanyRepository extends io.micronaut.data.tck.repositories.CompanyRe
 }
 """)
         def updateMethod = repository.findPossibleMethods("update").findFirst().get()
-        def updatePaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Paths", String[].class).get()
+        def updatePaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING_PATHS, String[].class).get()
+        def autoPopulatedPropertyPaths = updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS, String[].class).get()
 
         expect:"The repository compiles"
         repository != null
-        updatePaths == ['', "lastUpdated", ""] as String[]
+        updatePaths == ['', "", ""] as String[]
+        autoPopulatedPropertyPaths == ['', "lastUpdated", ""] as String[]
     }
 }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JpaUpdateSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JpaUpdateSpec.groovy
@@ -120,13 +120,15 @@ interface MyInterface extends GenericRepository<Company, Long> {
         updateQuery.value() == "UPDATE $Company.name ${alias} SET ${alias}.name=:p1,${alias}.lastUpdated=:p2 WHERE (${alias}.myId = :p3)"
         updateAnn.id() == 'myId'
         updateMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Names") == ['p1', 'p2', 'p3'] as String[]
-        updateMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Paths") == ['', 'lastUpdated', ''] as String[]
+        updateMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING_PATHS) == ['', '', ''] as String[]
+        updateMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS) == ['', 'lastUpdated', ''] as String[]
         updateMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING, int[].class).get() == [1,-1,0] as int[]
 
         updateByAnn.interceptor() == UpdateInterceptor
         updateByQuery.value() == "UPDATE $Company.name ${alias} SET ${alias}.name=:p1,${alias}.lastUpdated=:p2 WHERE (${alias}.name = :p3)"
         updateByMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Names") == ['p1', 'p2', 'p3'] as String[]
-        updateByMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING + "Paths") == ['', 'lastUpdated', ''] as String[]
+        updateByMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING_PATHS) == ['', '', ''] as String[]
+        updateByMethod.stringValues(DataMethod, DataMethod.META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS) == ['', 'lastUpdated', ''] as String[]
         updateByMethod.getValue(DataMethod, DataMethod.META_MEMBER_PARAMETER_BINDING, int[].class).get() == [1,-1,0] as int[]
     }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/autopopulated/DateCreatedUpdatedAutoPopulatedListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/autopopulated/DateCreatedUpdatedAutoPopulatedListener.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.autopopulated;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.data.annotation.DateCreated;
+import io.micronaut.data.annotation.DateUpdated;
+import io.micronaut.data.annotation.event.PrePersist;
+import io.micronaut.data.annotation.event.PreUpdate;
+import io.micronaut.data.autopopulated.EntityAutoPopulatedPropertyProvider;
+import io.micronaut.data.event.EntityListener;
+import io.micronaut.data.model.runtime.RuntimePersistentProperty;
+import io.micronaut.data.runtime.date.DateTimeProvider;
+
+import javax.inject.Singleton;
+
+/**
+ * Setter of {@link DateCreated} and {@link DateUpdated} auto populated properties.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Singleton
+class DateCreatedUpdatedAutoPopulatedListener implements EntityListener<Object>, EntityAutoPopulatedPropertyProvider {
+
+    private final DateTimeProvider<Object> dateTimeProvider;
+
+    public DateCreatedUpdatedAutoPopulatedListener(DateTimeProvider<Object> dateTimeProvider) {
+        this.dateTimeProvider = dateTimeProvider;
+    }
+
+    @PrePersist
+    void onPrePersist(Object entity) {
+        Object now = dateTimeProvider.getNow();
+        // We should set the same date for created and updated
+        BeanIntrospection<Object> introspection = BeanIntrospection.getIntrospection((Class<Object>) entity.getClass());
+        for (BeanProperty<Object, Object> bp : introspection.getBeanProperties()) {
+            if (bp.hasAnnotation(DateCreated.class) || bp.hasAnnotation(DateUpdated.class)) {
+                bp.convertAndSet(entity, now);
+            }
+        }
+    }
+
+    @PreUpdate
+    void onPreUpdate(Object entity) {
+        BeanIntrospection<Object> introspection = BeanIntrospection.getIntrospection((Class<Object>) entity.getClass());
+        for (BeanProperty<Object, Object> bp : introspection.getBeanProperties()) {
+            if (bp.hasAnnotation(DateUpdated.class)) {
+                bp.convertAndSet(entity, dateTimeProvider.getNow());
+            }
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public Object autoPopulate(RuntimePersistentProperty<?> property, Object previousValue) {
+        return ConversionService.SHARED.convertRequired(dateTimeProvider.getNow(), property.getArgument());
+    }
+
+    @Override
+    public boolean supports(RuntimePersistentProperty<?> property) {
+        return property.isAnnotationPresent(DateUpdated.class);
+    }
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/autopopulated/UUIDAutoPopulatedListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/autopopulated/UUIDAutoPopulatedListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.autopopulated;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.data.annotation.event.PrePersist;
+import io.micronaut.data.event.EntityListener;
+
+import javax.inject.Singleton;
+import java.util.UUID;
+
+/**
+ * Setter of UUID auto populated properties.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+@Singleton
+class UUIDAutoPopulatedListener implements EntityListener<Object> {
+
+    @PrePersist
+    void onPrePersist(Object entity) {
+        for (BeanProperty<Object, Object> bp : BeanIntrospection.getIntrospection((Class<Object>) entity.getClass()).getBeanProperties()) {
+            if (UUID.class.isAssignableFrom(bp.getType())) {
+                bp.convertAndSet(entity, UUID.randomUUID());
+            }
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return HIGHEST_PRECEDENCE;
+    }
+
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/EntityLifecycleEventService.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/EntityLifecycleEventService.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.event;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.data.annotation.event.PostLoad;
+import io.micronaut.data.annotation.event.PostPersist;
+import io.micronaut.data.annotation.event.PostRemove;
+import io.micronaut.data.annotation.event.PostUpdate;
+import io.micronaut.data.annotation.event.PrePersist;
+import io.micronaut.data.annotation.event.PreRemove;
+import io.micronaut.data.annotation.event.PreUpdate;
+import io.micronaut.data.event.EntityListener;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.qualifiers.Qualifiers;
+
+import javax.validation.constraints.NotNull;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.micronaut.core.order.OrderUtil.getOrder;
+
+/**
+ * The service to trigger entity events.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.0
+ */
+public class EntityLifecycleEventService {
+
+    private final BeanContext beanContext;
+
+    /**
+     * The constructor.
+     *
+     * @param beanContext the bean context
+     */
+    public EntityLifecycleEventService(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    /**
+     * Triggers pre persist event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPrePersist(@NotNull Object entity) {
+        triggerInternalEvent(PrePersist.class, entity);
+    }
+
+    /**
+     * Triggers post persist event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPostPersist(@NotNull Object entity) {
+        triggerInternalEvent(PostPersist.class, entity);
+    }
+
+    /**
+     * Triggers pre persist event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPreUpdate(@NotNull Object entity) {
+        triggerInternalEvent(PreUpdate.class, entity);
+    }
+
+    /**
+     * Triggers post update event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPostUpdate(@NotNull Object entity) {
+        triggerInternalEvent(PostUpdate.class, entity);
+    }
+
+    /**
+     * Triggers pre remove event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPreRemove(@NotNull Object entity) {
+        triggerInternalEvent(PreRemove.class, entity);
+    }
+
+    /**
+     * Triggers post remove event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPostRemove(@NotNull Object entity) {
+        triggerInternalEvent(PostRemove.class, entity);
+    }
+
+    /**
+     * Triggers post load event.
+     *
+     * @param entity the entity instance
+     */
+    public void onPostLoad(@NotNull Object entity) {
+        triggerInternalEvent(PostLoad.class, entity);
+    }
+
+    private void triggerInternalEvent(Class<? extends Annotation> annotation, @NotNull Object entity) {
+        Collection<BeanDefinition<EntityListener>> beanDefinitions = beanContext.getBeanDefinitions(EntityListener.class, Qualifiers.byTypeArguments(entity.getClass()));
+        Collection<EntityEventHandler> handlers = new ArrayList<>(beanDefinitions.size());
+
+        for (BeanDefinition<?> bd : beanDefinitions) {
+            List<ExecutableMethod<Object, Object>> methods = new ArrayList<>(5);
+            for (ExecutableMethod<?, ?> m : bd.getExecutableMethods()) {
+                if (m.hasAnnotation(annotation)) {
+                    methods.add((ExecutableMethod<Object, Object>) m);
+                }
+            }
+            if (!methods.isEmpty()) {
+                handlers.add(new EntityEventHandler((BeanDefinition<Object>) bd, methods, beanContext.getBean(bd)));
+            }
+        }
+
+        handlers = handlers.stream().sorted((o1, o2) -> {
+            int order1 = getOrder(o1.instance);
+            int order2 = getOrder(o2.instance);
+            return Integer.compare(order1, order2);
+        }).collect(Collectors.toList());
+
+        for (EntityEventHandler handler : handlers) {
+            for (ExecutableMethod<Object, Object> executableMethod : handler.executableMethods) {
+                executableMethod.invoke(handler.instance, entity);
+            }
+        }
+
+        BeanDefinition<Object> beanDefinition = beanContext.findBeanDefinition((Class<Object>) entity.getClass()).orElse(null);
+        if (beanDefinition == null) {
+            return;
+        }
+        for (ExecutableMethod<Object, ?> m : beanDefinition.getExecutableMethods()) {
+            if (m.hasAnnotation(annotation)) {
+                m.invoke(entity);
+            }
+        }
+    }
+
+    private static class EntityEventHandler {
+        final BeanDefinition<Object> beanDefinition;
+        final List<ExecutableMethod<Object, Object>> executableMethods;
+        final Object instance;
+
+        EntityEventHandler(BeanDefinition<Object> beanDefinition,
+                           List<ExecutableMethod<Object, Object>> executableMethods,
+                           Object instance) {
+            this.beanDefinition = beanDefinition;
+            this.executableMethods = executableMethods;
+            this.instance = instance;
+        }
+    }
+
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultDeleteAllInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultDeleteAllInterceptor.java
@@ -15,23 +15,22 @@
  */
 package io.micronaut.data.runtime.intercept;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.aop.MethodInvocationContext;
-import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.DeleteAllInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
-import io.micronaut.data.model.Embedded;
-import io.micronaut.data.model.runtime.BatchOperation;
-import io.micronaut.data.model.runtime.RuntimePersistentProperty;
+import io.micronaut.data.model.runtime.DeleteBatchOperation;
+import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import io.micronaut.data.model.runtime.PreparedQuery;
+import java.util.Collections;
 
 /**
  * Default implementation of {@link DeleteAllInterceptor}.
+ *
  * @param <T> The declaring type
  * @author graemerocher
  * @since 1.0.0
@@ -40,6 +39,7 @@ public class DefaultDeleteAllInterceptor<T> extends AbstractQueryInterceptor<T, 
 
     /**
      * Default constructor.
+     *
      * @param datastore The operations
      */
     protected DefaultDeleteAllInterceptor(@NonNull RepositoryOperations datastore) {
@@ -50,48 +50,28 @@ public class DefaultDeleteAllInterceptor<T> extends AbstractQueryInterceptor<T, 
     public Number intercept(RepositoryMethodKey methodKey, MethodInvocationContext<T, Number> context) {
         Argument<Number> resultType = context.getReturnType().asArgument();
         Object[] parameterValues = context.getParameterValues();
-        final boolean isBatch = parameterValues.length == 1 && parameterValues[0] instanceof Iterable;
-        if (context.hasAnnotation(Query.class)) {
-            PreparedQuery<?, Number> preparedQuery = (PreparedQuery<?, Number>) prepareQuery(methodKey, context);
-            if (isBatch) {
-                final RuntimePersistentProperty<?> identity = operations.getEntity(preparedQuery.getRootEntity()).getIdentity();
-                if (identity instanceof Embedded) {
-                    Iterable iterable = (Iterable) parameterValues[0];
-                    int deleteCount = 0;
-                    final BeanProperty idProp = identity.getProperty();
-                    for (Object o : iterable) {
-                        final Object idValue = idProp.get(o);
-                        if (idValue == null) {
-                            throw new IllegalStateException("Cannot delete an entity with null ID: " + o);
-                        }
-                        preparedQuery.getParameterArray()[0] = idValue;
-                        operations.executeDelete(preparedQuery);
-                        deleteCount++;
-                    }
-                    return convertIfNecessary(resultType, deleteCount);
-                } else {
-                    Number result = operations.executeDelete(preparedQuery).orElse(0);
-                    return convertIfNecessary(resultType, result);
-                }
-
-            } else {
-                Number result = operations.executeDelete(preparedQuery).orElse(0);
-                return convertIfNecessary(resultType, result);
-            }
-        } else {
-            Class<?> rootEntity = getRequiredRootEntity(context);
-            if (isBatch) {
-                Iterable iterable = (Iterable) parameterValues[0];
-                BatchOperation<?> batchOperation = getBatchOperation(context, rootEntity, iterable);
+        if (parameterValues.length == 1) {
+            Object value = parameterValues[0];
+            if (value instanceof Iterable) {
+                DeleteBatchOperation<?> batchOperation = getDeleteBatchOperation(context, (Iterable) value);
                 Number deleted = operations.deleteAll(batchOperation).orElse(0);
                 return convertIfNecessary(resultType, deleted);
-            } else if (parameterValues.length == 0) {
-                BatchOperation<?> batchOperation = getBatchOperation(context, rootEntity);
-                Number result = operations.deleteAll(batchOperation).orElse(0);
-                return convertIfNecessary(resultType, result);
             } else {
-                throw new IllegalArgumentException("Unexpected argument types received to deleteAll method");
+                if (context.hasAnnotation(Query.class)) {
+                    PreparedQuery<?, Number> preparedQuery = (PreparedQuery<?, Number>) prepareQuery(methodKey, context);
+                    Number deleted = operations.executeDelete(preparedQuery).orElse(0);
+                    return convertIfNecessary(resultType, deleted);
+                } else {
+                    DeleteBatchOperation<?> batchOperation = getDeleteBatchOperation(context, Collections.singleton(value));
+                    Number deleted = operations.deleteAll(batchOperation).orElse(0);
+                    return convertIfNecessary(resultType, deleted);
+                }
             }
+        } else if (parameterValues.length == 0) {
+            Number result = operations.deleteAll(getDeleteAllBatchOperation(context)).orElse(0);
+            return convertIfNecessary(resultType, result);
+        } else {
+            throw new IllegalArgumentException("Unexpected argument types received to deleteAll method");
         }
     }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultDeleteOneInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultDeleteOneInterceptor.java
@@ -15,24 +15,17 @@
  */
 package io.micronaut.data.runtime.intercept;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.aop.MethodInvocationContext;
-import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.DeleteOneInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
-import io.micronaut.data.model.Embedded;
-import io.micronaut.data.model.runtime.BatchOperation;
-import io.micronaut.data.model.runtime.PreparedQuery;
-import io.micronaut.data.model.runtime.RuntimePersistentEntity;
-import io.micronaut.data.model.runtime.RuntimePersistentProperty;
+import io.micronaut.data.model.runtime.DeleteBatchOperation;
 import io.micronaut.data.operations.RepositoryOperations;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Collections;
 
 /**
  * The default implementation of {@link DeleteOneInterceptor}.
+ *
  * @param <T> The declaring type
  * @author graemerocher
  * @since 1.0.0
@@ -41,6 +34,7 @@ public class DefaultDeleteOneInterceptor<T> extends AbstractQueryInterceptor<T, 
 
     /**
      * Default constructor.
+     *
      * @param datastore The operations
      */
     protected DefaultDeleteOneInterceptor(@NonNull RepositoryOperations datastore) {
@@ -52,57 +46,35 @@ public class DefaultDeleteOneInterceptor<T> extends AbstractQueryInterceptor<T, 
         Object[] parameterValues = context.getParameterValues();
         if (parameterValues.length == 1) {
             Object o = parameterValues[0];
-            if (context.hasAnnotation(Query.class)) {
-                PreparedQuery<?, Number> preparedQuery = (PreparedQuery<?, Number>) prepareQuery(methodKey, context);
-                final Class<?> rootEntity = preparedQuery.getRootEntity();
-                if (rootEntity.isInstance(o)) {
-                    final RuntimePersistentEntity<?> entity = operations.getEntity(rootEntity);
-                    final RuntimePersistentProperty<?> identity = entity.getIdentity();
-                    if (identity != null) {
-                        if (identity instanceof Embedded) {
-                            final BeanProperty idProp = identity.getProperty();
-                            final Object idValue = idProp.get(o);
-                            if (idValue == null) {
-                                throw new IllegalStateException("Cannot delete an entity with null ID: " + o);
-                            }
-                            preparedQuery.getParameterArray()[0] = idValue;
-                        }
-                        final Number result = operations.executeDelete(preparedQuery).orElse(0);
-                        final Class<Object> returnType = context.getReturnType().getType();
-                        if (returnType.equals(rootEntity)) {
-                            if (result.longValue() > 0) {
-                                return o;
-                            } else {
-                                return null;
-                            }
-                        } else if (Number.class.isAssignableFrom(returnType)) {
-                            return ConversionService.SHARED.convertRequired(result, returnType);
-                        } else  {
-                            return result;
-                        }
-                    } else {
-                        throw new IllegalStateException("Cannot delete an entity which defines no ID: " + rootEntity.getName());
-                    }
-                } else {
-                    if (o == null) {
-                        throw new IllegalArgumentException("Entity to delete cannot be null");
-                    } else {
-                        throw new IllegalArgumentException("Entity argument must be an instance of " + rootEntity.getName());
-                    }
-                }
+            Number deleted;
+            final Class<Object> returnType = context.getReturnType().getType();
+            if (o instanceof Iterable) {
+                DeleteBatchOperation<?> batchOperation = getDeleteBatchOperation(context, (Iterable) o);
+                deleted = operations.deleteAll(batchOperation).orElse(null);
             } else {
-
-                BatchOperation<Object> batchOperation = getBatchOperation(context, Collections.singletonList(o));
-                if (o != null) {
-                    operations.deleteAll(batchOperation);
-                } else {
+                if (o == null) {
                     throw new IllegalArgumentException("Entity to delete cannot be null");
                 }
+                Class<?> rootEntity = getRequiredRootEntity(context);
+                if (!rootEntity.isInstance(o)) {
+                    throw new IllegalArgumentException("Entity argument must be an instance of " + rootEntity.getName());
+                }
+                deleted = operations.delete(getDeleteOperation(context, o));
+                if (returnType.equals(rootEntity)) {
+                    if (deleted.intValue() > 0) {
+                        return o;
+                    } else {
+                        return null;
+                    }
+                }
             }
+            if (Number.class.isAssignableFrom(returnType)) {
+                return ConversionService.SHARED.convertRequired(deleted, returnType);
+            }
+            return null;
         } else {
             throw new IllegalStateException("Expected exactly one argument");
         }
-
-        return null;
     }
+
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultSaveAllInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultSaveAllInterceptor.java
@@ -48,7 +48,7 @@ public class DefaultSaveAllInterceptor<T, R> extends AbstractQueryInterceptor<T,
         if (ArrayUtils.isNotEmpty(parameterValues) && parameterValues[0] instanceof Iterable) {
             //noinspection unchecked
             Iterable<R> iterable = (Iterable<R>) parameterValues[0];
-            Iterable<R> rs = operations.persistAll(getBatchOperation(context, iterable));
+            Iterable<R> rs = operations.persistAll(getInsertBatchOperation(context, iterable));
             ReturnType<Iterable<R>> rt = context.getReturnType();
             if (!rt.getType().isInstance(rs)) {
                 return ConversionService.SHARED.convert(rs, rt.asArgument())

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/async/DefaultDeleteOneAsyncInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/async/DefaultDeleteOneAsyncInterceptor.java
@@ -18,11 +18,9 @@ package io.micronaut.data.runtime.intercept.async;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.data.intercept.RepositoryMethodKey;
-import io.micronaut.data.model.runtime.BatchOperation;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.intercept.async.DeleteOneAsyncInterceptor;
 
-import java.util.Collections;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -49,8 +47,7 @@ public class DefaultDeleteOneAsyncInterceptor<T> extends AbstractAsyncIntercepto
         if (parameterValues.length == 1) {
             Object o = parameterValues[0];
             if (o != null) {
-                BatchOperation<Object> batchOperation = getBatchOperation(context, Collections.singletonList(o));
-                return asyncDatastoreOperations.deleteAll(batchOperation)
+                return asyncDatastoreOperations.delete(getDeleteOperation(context, o))
                         .thenApply(n -> convertNumberArgumentIfNecessary(n, context.getReturnType().asArgument()));
             } else {
                 throw new IllegalArgumentException("Entity to delete cannot be null");

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/async/DefaultSaveAllAsyncInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/async/DefaultSaveAllAsyncInterceptor.java
@@ -19,7 +19,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.data.intercept.RepositoryMethodKey;
-import io.micronaut.data.model.runtime.BatchOperation;
+import io.micronaut.data.model.runtime.InsertBatchOperation;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.intercept.async.SaveAllAsyncInterceptor;
 
@@ -46,7 +46,7 @@ public class DefaultSaveAllAsyncInterceptor<T> extends AbstractAsyncInterceptor<
         Object[] parameterValues = context.getParameterValues();
         if (ArrayUtils.isNotEmpty(parameterValues) && parameterValues[0] instanceof Iterable) {
             //noinspection unchecked
-            BatchOperation<Object> batchOperation = getBatchOperation(context, (Iterable<Object>) parameterValues[0]);
+            InsertBatchOperation<Object> batchOperation = getInsertBatchOperation(context, (Iterable<Object>) parameterValues[0]);
             return asyncDatastoreOperations.persistAll(batchOperation);
         } else {
             throw new IllegalArgumentException("First argument should be an iterable");

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultDeleteOneReactiveInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultDeleteOneReactiveInterceptor.java
@@ -20,11 +20,8 @@ import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.intercept.reactive.DeleteOneReactiveInterceptor;
-import io.micronaut.data.model.runtime.BatchOperation;
 import io.micronaut.data.operations.RepositoryOperations;
 import org.reactivestreams.Publisher;
-
-import java.util.Collections;
 
 /**
  * Default implementation of {@link DeleteOneReactiveInterceptor}.
@@ -45,11 +42,9 @@ public class DefaultDeleteOneReactiveInterceptor extends AbstractReactiveInterce
     public Object intercept(RepositoryMethodKey methodKey, MethodInvocationContext<Object, Object> context) {
         Object[] parameterValues = context.getParameterValues();
         if (parameterValues.length == 1) {
-            Class<Object> rootEntity = (Class<Object>) getRequiredRootEntity(context);
             Object o = parameterValues[0];
             if (o != null) {
-                BatchOperation<Object> batchOperation = getBatchOperation(context, rootEntity, Collections.singletonList(o));
-                Publisher<Number> publisher = reactiveOperations.deleteAll(batchOperation);
+                Publisher<Number> publisher = reactiveOperations.delete(getDeleteOperation(context, o));
                 return Publishers.convertPublisher(
                         publisher,
                         context.getReturnType().getType()

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultSaveAllReactiveInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultSaveAllReactiveInterceptor.java
@@ -21,7 +21,7 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.intercept.reactive.SaveAllReactiveInterceptor;
-import io.micronaut.data.model.runtime.BatchOperation;
+import io.micronaut.data.model.runtime.InsertBatchOperation;
 import io.micronaut.data.operations.RepositoryOperations;
 import org.reactivestreams.Publisher;
 
@@ -46,7 +46,7 @@ public class DefaultSaveAllReactiveInterceptor extends AbstractReactiveIntercept
         Object[] parameterValues = context.getParameterValues();
         if (ArrayUtils.isNotEmpty(parameterValues) && parameterValues[0] instanceof Iterable) {
             //noinspection unchecked
-            BatchOperation<Object> batchOperation = getBatchOperation(context, (Iterable<Object>) parameterValues[0]);
+            InsertBatchOperation<Object> batchOperation = getInsertBatchOperation(context, (Iterable<Object>) parameterValues[0]);
             Publisher<Object> publisher = reactiveOperations.persistAll(batchOperation);
             return Publishers.convertPublisher(publisher, context.getReturnType().getType());
         } else {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
@@ -155,7 +155,7 @@ public class ExecutorAsyncOperations implements AsyncRepositoryOperations {
 
     @NonNull
     @Override
-    public <T> CompletableFuture<Iterable<T>> persistAll(@NonNull BatchOperation<T> operation) {
+    public <T> CompletableFuture<Iterable<T>> persistAll(@NonNull InsertBatchOperation<T> operation) {
         return CompletableFuture.supplyAsync(() -> datastore.persistAll(operation), executor);
     }
 
@@ -167,7 +167,15 @@ public class ExecutorAsyncOperations implements AsyncRepositoryOperations {
 
     @NonNull
     @Override
-    public <T> CompletableFuture<Number> deleteAll(@NonNull BatchOperation<T> operation) {
+    public <T> CompletableFuture<Number> delete(@NonNull DeleteOperation<T> operation) {
+        return CompletableFuture.supplyAsync(() ->
+                datastore.delete(operation), executor
+        );
+    }
+
+    @NonNull
+    @Override
+    public <T> CompletableFuture<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation) {
         return CompletableFuture.supplyAsync(() ->
                 datastore.deleteAll(operation).orElse(0),
                 executor

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorReactiveOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorReactiveOperations.java
@@ -163,7 +163,7 @@ public class ExecutorReactiveOperations implements ReactiveRepositoryOperations 
 
     @NonNull
     @Override
-    public <T> Publisher<T> persistAll(@NonNull BatchOperation<T> operation) {
+    public <T> Publisher<T> persistAll(@NonNull InsertBatchOperation<T> operation) {
         return Flowable.fromPublisher(Publishers.fromCompletableFuture(() ->
                 asyncOperations.persistAll(operation)
         )).flatMap(Flowable::fromIterable);
@@ -179,7 +179,15 @@ public class ExecutorReactiveOperations implements ReactiveRepositoryOperations 
 
     @NonNull
     @Override
-    public <T> Publisher<Number> deleteAll(BatchOperation<T> operation) {
+    public <T> Publisher<Number> delete(@NonNull DeleteOperation<T> operation) {
+        return Publishers.map(Publishers.fromCompletableFuture(() ->
+                asyncOperations.delete(operation)
+        ), number -> convertNumberArgumentIfNecessary(number, operation.getResultArgument()));
+    }
+
+    @NonNull
+    @Override
+    public <T> Publisher<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation) {
         return Publishers.map(Publishers.fromCompletableFuture(() ->
                 asyncOperations.deleteAll(operation)
         ), number -> convertNumberArgumentIfNecessary(number, operation.getResultArgument()));

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -748,14 +748,33 @@ abstract class AbstractRepositorySpec extends Specification {
         author = authorRepository.save(author)
 
         then: "They are saved correctly"
-        println(author)
         author.id
+        book1.prePersist == 1
+        book1.postPersist == 1
+        book2.prePersist == 1
+        book2.postPersist == 1
+        book3.prePersist == 1
+        book3.postPersist == 1
+        book3.preUpdate == 0
+        book3.postUpdate == 0
+        book3.preRemove == 0
+        book3.postRemove == 0
+        book3.postLoad == 0
 
         when:"retrieving an author"
         author = authorRepository.findById(author.id).orElse(null)
 
         then:"the associations are correct"
         author.getBooks().size() == 3
+        author.getBooks()[0].postLoad == 1
+        author.getBooks()[1].postLoad == 1
+        author.getBooks()[2].postLoad == 1
+        author.getBooks()[0].prePersist == 0
+        author.getBooks()[0].postPersist == 0
+        author.getBooks()[0].preUpdate == 0
+        author.getBooks()[0].postUpdate == 0
+        author.getBooks()[0].preRemove == 0
+        author.getBooks()[0].postRemove == 0
 
         def result1 = author.getBooks().find {book -> book.title == "Book1" }
         result1.pages.size() == 1
@@ -771,6 +790,18 @@ abstract class AbstractRepositorySpec extends Specification {
         result3.pages.find {page -> page.num = 31}
         result3.pages.find {page -> page.num = 32}
         result3.pages.find {page -> page.num = 33}
+
+        when:
+        authorRepository.delete(author)
+        then:
+        author.getBooks().size() == 3
+        author.getBooks()[0].postLoad == 1
+        author.getBooks()[0].prePersist == 0
+        author.getBooks()[0].postPersist == 0
+        author.getBooks()[0].preUpdate == 0
+        author.getBooks()[0].postUpdate == 0
+        author.getBooks()[0].preRemove == 1
+        author.getBooks()[0].postRemove == 1
 
         cleanup:
         bookRepository.deleteAll()

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/Book.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/Book.java
@@ -37,6 +37,60 @@ public class Book {
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "book")
     private List<Page> pages = new ArrayList<>();
 
+    @Transient
+    public int prePersist, postPersist, preUpdate, postUpdate, preRemove, postRemove, postLoad;
+
+    @PrePersist
+    protected void onPrePersist() {
+        prePersist++;
+    }
+// Hibernate doesn't support multiple pre persist
+//    @PrePersist
+//    protected void onPrePersist2() {
+//    }
+
+    @PostPersist
+    protected void onPostPersist() {
+        postPersist++;
+    }
+
+    @PreUpdate
+    protected void onPreUpdate() {
+        preUpdate++;
+    }
+
+    @PostUpdate
+    protected void onPostUpdate() {
+        postUpdate++;
+    }
+
+    @PreRemove
+    protected void onPreRemove() {
+        preRemove++;
+    }
+
+    @PostRemove
+    protected void onPostRemove() {
+        postRemove++;
+    }
+
+    @PostLoad
+    protected void onPostLoad() {
+        postLoad++;
+    }
+
+    @Transient
+    public void resetEventCounters() {
+        prePersist = 0;
+        postPersist = 0;
+        preUpdate = 0;
+        postUpdate = 0;
+        preRemove = 0;
+        postRemove = 0;
+        postLoad = 0;
+    }
+
+
     public List<Page> getPages() {
         return pages;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=2.2.5-SNAPSHOT
 micronautDocsVersion=1.0.24
 micronautBuildVersion=1.1.5
-micronautVersion=2.2.2
+micronautVersion=2.3.0
 micronautTestVersion=2.2.1
 testContainersVersion=1.15.0
 groovyVersion=3.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,4 +32,4 @@ githubCoreBranch=2.2.x
 bomProperty=micronautDataVersion
 bomProperties=postgresDriverVersion,mysqlDriverVersion,mariadbDriverVersion,mssqlDriverVersion,oracleDriverVersion
 
-org.gradle.caching=true
+org.gradle.caching=false


### PR DESCRIPTION
This PR introduces basic entity events API.

The implementation of the event listeners is based on JPA API annotation, there are a few problems with how to actually implement it. I choose not to use `@Adapter` because the annotation can be used in different places by the spec: entity instance listener (no parameters) and external entity listener (one method parameter). The only way I came up was to annotate the entity with `@Prototype` to be able to access executable methods. I think here Micronaut can be improved to support accessing executable methods in introspected classes.
There is a use case of implementing JPA's `EntityListeners` which defines a list of external entity listeners, the best way would be to support something like this:

```java
public @interface EntityListeners {

    @AliasFor(annotation = Introspected.class, member = "classes")
    Class[] value();
}
```
And be able to access the executable methods of the class.

Auto-populated listeners are now ordinary JPA listeners:

```java
    @PrePersist
    void onPrePersist(Object entity) {
        Object now = dateTimeProvider.getNow();
        // We should set the same date for created and updated
        BeanIntrospection<Object> introspection = BeanIntrospection.getIntrospection((Class<Object>) entity.getClass());
        for (BeanProperty<Object, Object> bp : introspection.getBeanProperties()) {
            if (bp.hasAnnotation(DateCreated.class) || bp.hasAnnotation(DateUpdated.class)) {
                bp.convertAndSet(entity, now);
            }
        }
    }
```
This API can be more flexible e.g `onPrePersist` can receive contextual parameters like `Connection` etc. `EntityLifecycleEventService` probably needs to have some caching.


I have introduced a separate delete operation to trigger delete events, this also led to some refactoring of the code around `BatchOperation`. This should also be the right way to delete an entity in Hibernate if somebody wants to use optimistic locking. 

There is also some modification to prevent collision of parameter names.

PR contains non-backward-compatible changes and got a bit bigger than I wanted.



