### PR TITLE
fix(empty-associations): use a mutable list instance when a join is null

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -338,7 +338,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     }
                 } else {
                     Object newValue = setChildrenAndTriggerPostLoad(null, associationCtx);
-                    newValue = resultReader.convertRequired(newValue == null ? Collections.emptyList() : newValue, beanProperty.getType());
+                    newValue = resultReader.convertRequired(newValue == null ? new ArrayList<>() : newValue, beanProperty.getType());
                     instance = setProperty(beanProperty, instance, newValue);
                 }
             }


### PR DESCRIPTION
This will allow the resulting entity instance to be mutable if required. This is a minor tweak to the changes added in #1004