### PR TITLE
R2DBC improvements

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,7 +46,13 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew dependencyUpdates check --no-daemon --parallel --continue
         env:
-           TESTCONTAINERS_RYUK_DISABLED: true        
+           TESTCONTAINERS_RYUK_DISABLED: true
+      - name: Publish Test Report
+        if: always()
+        uses: mikepenz/action-junit-report@v2
+        with:
+           check_name: Java CI / Test Report (${{ matrix.java }})
+           report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Publish to Sonatype Snapshots
         if: success() && github.event_name == 'push' && matrix.java == '8'
         env:

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/DatabaseTestPropertyProvider.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/DatabaseTestPropertyProvider.groovy
@@ -4,6 +4,7 @@ import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.runtime.config.SchemaGenerate
 import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.*
+import org.testcontainers.utility.DockerImageName
 
 trait DatabaseTestPropertyProvider implements TestPropertyProvider {
 
@@ -42,7 +43,9 @@ trait DatabaseTestPropertyProvider implements TestPropertyProvider {
             case "sqlserver":
                 return new MSSQLServerContainer<>()
             case "oracle":
-                return new OracleContainer("registry.gitlab.com/micronaut-projects/micronaut-graal-tests/oracle-database:18.4.0-xe")
+                return new OracleContainer(DockerImageName.parse("gvenzl/oracle-xe:18"))
+                        .withEnv("ORACLE_PASSWORD", "password")
+                        .withPassword("password")
             case "mariadb":
                 return new MariaDBContainer<>("mariadb:10.5")
             case "mysql":

--- a/data-model/src/main/java/io/micronaut/data/exceptions/NonUniqueResultException.java
+++ b/data-model/src/main/java/io/micronaut/data/exceptions/NonUniqueResultException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.exceptions;
+
+/**
+ * The exception represents the error state when one result has been requested by data layer returned multiple results.
+ *
+ * @author Denis Stepanov
+ * @since 2.4.7
+ */
+public class NonUniqueResultException extends DataAccessException {
+
+    public NonUniqueResultException() {
+        super("Query did not return a unique result");
+    }
+
+    public NonUniqueResultException(String message) {
+        super(message);
+    }
+}

--- a/data-r2dbc/build.gradle
+++ b/data-r2dbc/build.gradle
@@ -77,12 +77,7 @@ dependencies {
 
 test {
     systemProperty "oracle.jdbc.timezoneAsRegion", "false"
-    exclude "**/r2dbc/mysql/**"
-    exclude "**/r2dbc/postgres/**"
-    exclude "**/r2dbc/sqlserver/**"
     exclude "**/r2dbc/oraclexe/**"
-//    exclude "**/r2dbc/mariadb/**"
-//    exclude "**/r2dbc/h2/**"
 }
 
 micronautBuild {

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/DatabaseTestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/DatabaseTestPropertyProvider.groovy
@@ -4,6 +4,7 @@ import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.runtime.config.SchemaGenerate
 import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.*
+import org.testcontainers.utility.DockerImageName
 
 trait DatabaseTestPropertyProvider implements TestPropertyProvider {
 
@@ -36,16 +37,16 @@ trait DatabaseTestPropertyProvider implements TestPropertyProvider {
     String getR2dbUrlSuffix(String driverName, JdbcDatabaseContainer container) {
         switch (driverName) {
             case "postgresql":
-                return "localhost:${container.getFirstMappedPort()}/${container.getDatabaseName()}"
+                return "${container.getHost()}:${container.getFirstMappedPort()}/${container.getDatabaseName()}"
             case "h2":
                 return "/testdb"
             case "sqlserver":
-                return "localhost:${container.getFirstMappedPort()}"
+                return "${container.getHost()}:${container.getFirstMappedPort()}"
             case "oracle":
-                return "localhost:${container.getFirstMappedPort()}/xe"
+                return "${container.getHost()}:${container.getFirstMappedPort()}/xe"
             case "mariadb":
             case "mysql":
-                return "${container.getUsername()}:${container.getPassword()}@localhost:${container.getFirstMappedPort()}/${container.getDatabaseName()}"
+                return "${container.getUsername()}:${container.getPassword()}@${container.getHost()}:${container.getFirstMappedPort()}/${container.getDatabaseName()}"
         }
     }
 
@@ -58,11 +59,13 @@ trait DatabaseTestPropertyProvider implements TestPropertyProvider {
             case "sqlserver":
                 return new MSSQLServerContainer<>()
             case "oracle":
-                return new OracleContainer("registry.gitlab.com/micronaut-projects/micronaut-graal-tests/oracle-database:18.4.0-xe")
+                return new OracleContainer(DockerImageName.parse("gvenzl/oracle-xe:18"))
+                        .withEnv("ORACLE_PASSWORD", "password")
+                        .withPassword("password")
             case "mariadb":
                 return new MariaDBContainer<>("mariadb:10.5")
             case "mysql":
-                return new MySQLContainer<>("mysql:8.0.17")
+                return new MySQLContainer<>(DockerImageName.parse("mysql/mysql-server:8.0").asCompatibleSubstituteFor("mysql"))
         }
     }
 

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PlainR2dbcSpec.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.entities.Author
+import io.micronaut.data.tck.repositories.AuthorRepository
+import io.micronaut.transaction.reactive.ReactiveTransactionOperations
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class PlainR2dbcSpec extends Specification {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
+    ConnectionFactory connectionFactory = context.getBean(ConnectionFactory)
+
+    ReactiveTransactionOperations<Connection> reactiveTransactionOperations = context.getBean(ReactiveTransactionOperations)
+
+    protected abstract AuthorRepository getAuthorRepository()
+
+    protected String getInsertQuery() {
+        'INSERT INTO author (name) VALUES ($1)'
+    }
+
+    def "save one"() {
+        when:
+            def author = new Author(name: "Denis")
+            def result = Flux.usingWhen(connectionFactory.create(), connection -> {
+                return Flux.usingWhen(Mono.from(connection.beginTransaction()).then(Mono.just(connection)),
+                        (b) -> {
+                            return Flux.from(connection.createStatement(getInsertQuery())
+                                    .bind(0, author.getName())
+                                    .execute()).flatMap { r -> Mono.from(r.getRowsUpdated()) };
+                        },
+                        (b) -> connection.commitTransaction(),
+                        (b, throwable) -> connection.rollbackTransaction(),
+                        (b) -> connection.commitTransaction())
+
+            }, { it -> it.close() })
+                    .collectList()
+                    .block()
+        then:
+            result.size() == 1
+            result[0] == 1
+            authorRepository.findByNameContains("Denis").size() == 1
+    }
+
+    def "save one - convert flux to mono"() {
+        when:
+            def author = new Author(name: "Zed")
+            def result = Mono.from(Flux.usingWhen(connectionFactory.create(), connection -> {
+                return Flux.usingWhen(Mono.from(connection.beginTransaction()).then(Mono.just(connection)),
+                        (b) -> {
+                            return Flux.from(connection.createStatement(getInsertQuery())
+                                    .bind(0, author.getName())
+                                    .execute()).flatMap { r -> Mono.from(r.getRowsUpdated()) };
+                        },
+                        (b) -> connection.commitTransaction(),
+                        (b, throwable) -> connection.rollbackTransaction(),
+                        (b) -> connection.commitTransaction())
+
+            }, { it -> it.close() })
+            ).block()
+        then:
+            result == 1
+            if (isFailsRandomlyWhenConvertingFluxToMono()) {
+                true
+            } else {
+                authorRepository.findByNameContains("Zed").size() == (isFailsWhenConvertingFluxToMono() ? 0 : 1)
+            }
+    }
+
+    def "save one - reactiveTransactionOperations"() {
+        when:
+            def author = new Author(name: "John")
+            def result = Flux.from(reactiveTransactionOperations.withTransaction { status ->
+                return Flux.from(status.connection.createStatement(getInsertQuery())
+                        .bind(0, author.getName())
+                        .execute()).flatMap { r -> Mono.from(r.getRowsUpdated()) };
+            })
+                    .collectList()
+                    .block()
+        then:
+            result.size() == 1
+            result[0] == 1
+            authorRepository.findByNameContains("John").size() == 1
+    }
+
+    def "save one - reactiveTransactionOperations - convert flux to mono"() {
+        when:
+            def author = new Author(name: "Josh")
+            def result = Mono.from(reactiveTransactionOperations.withTransaction { status ->
+                return Flux.from(status.connection.createStatement(getInsertQuery())
+                        .bind(0, author.getName())
+                        .execute()).flatMap { r -> Mono.from(r.getRowsUpdated()) };
+            }).block()
+        then:
+            result == 1
+        if (isFailsRandomlyWhenConvertingFluxToMono()) {
+            true
+        } else {
+            authorRepository.findByNameContains("Josh").size() == (isFailsWhenConvertingFluxToMono() ? 0 : 1)
+        }
+    }
+
+    boolean isFailsWhenConvertingFluxToMono() {
+        // Override if the driver is not correctly handling `cancel` when Flux is converted to Mono
+        return false
+    }
+
+    boolean isFailsRandomlyWhenConvertingFluxToMono() {
+        return false
+    }
+
+    def "save one - without `getRowsUpdated` call nothing is saved"() {
+        when:
+            def author = new Author(name: "Fred")
+            Flux.usingWhen(connectionFactory.create(), connection -> {
+                return Flux.usingWhen(Mono.from(connection.beginTransaction()).then(Mono.just(connection)),
+                        (b) -> {
+                            return Flux.from(connection.createStatement(getInsertQuery())
+                                    .bind(0, author.getName())
+                                    .execute()).flatMap { r -> Mono.just(1) };
+                        },
+                        (b) -> connection.commitTransaction(),
+                        (b, throwable) -> connection.rollbackTransaction(),
+                        (b) -> connection.commitTransaction())
+
+            }, { it -> it.close() })
+                    .collectList()
+                    .block()
+        then:
+            authorRepository.findByNameContains("Fred").size() == (isFailsToInsertWithoutGetRowsUpdatedCall() ? 0 : 1)
+    }
+
+    boolean isFailsToInsertWithoutGetRowsUpdatedCall() {
+        // Override if the driver is not inserting a record without `getRowsUpdated` call
+        return false
+    }
+
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2PlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2PlainR2dbcSpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.h2
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+
+class H2PlainR2dbcSpec extends PlainR2dbcSpec implements H2TestPropertyProvider {
+
+    @Memoized
+    @Override
+    H2AuthorRepository getAuthorRepository() {
+        return context.getBean(H2AuthorRepository)
+    }
+
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbPlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbPlainR2dbcSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mariadb
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+import io.micronaut.data.r2dbc.mysql.MySqlAuthorRepository
+import io.micronaut.data.tck.repositories.AuthorRepository
+
+class MariaDbPlainR2dbcSpec extends PlainR2dbcSpec implements MariaDbTestPropertyProvider {
+
+    @Memoized
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MySqlAuthorRepository)
+    }
+
+    @Override
+    String getInsertQuery() {
+        return 'INSERT INTO author (name) VALUES (?)'
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbReactiveRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbReactiveRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mariadb
+
+class MariaDbReactiveRepositoryPoolSpec extends MariaDbReactiveRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mariadb
+
+class MariaDbRepositoryPoolSpec extends MariaDbRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbTestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mariadb/MariaDbTestPropertyProvider.groovy
@@ -21,6 +21,6 @@ trait MariaDbTestPropertyProvider implements SharedDatabaseContainerTestProperty
 
     @Override
     int sharedSpecsCount() {
-        return 6
+        return 9
     }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlDbPlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlDbPlainR2dbcSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mysql
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+import io.micronaut.data.tck.repositories.AuthorRepository
+
+class MySqlDbPlainR2dbcSpec extends PlainR2dbcSpec implements MySqlTestPropertyProvider {
+
+    @Memoized
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MySqlAuthorRepository)
+    }
+
+    @Override
+    String getInsertQuery() {
+        return 'INSERT INTO author (name) VALUES (?)'
+    }
+
+    @Override
+    boolean isFailsRandomlyWhenConvertingFluxToMono() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlReactiveRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlReactiveRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mysql
+
+class MySqlReactiveRepositoryPoolSpec extends MySqlReactiveRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mysql
+
+class MySqlRepositoryPoolSpec extends MySqlRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlTestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlTestPropertyProvider.groovy
@@ -17,6 +17,6 @@ trait MySqlTestPropertyProvider implements SharedDatabaseContainerTestPropertyPr
 
     @Override
     int sharedSpecsCount() {
-        return 6
+        return 9
     }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEPlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEPlainR2dbcSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.oraclexe
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+import io.micronaut.data.tck.repositories.AuthorRepository
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ !jvm.isJava11Compatible() })
+class OracleXEPlainR2dbcSpec extends PlainR2dbcSpec implements OracleXETestPropertyProvider {
+
+    @Memoized
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(OracleXEAuthorRepository)
+    }
+
+    @Override
+    String getInsertQuery() {
+        return 'INSERT INTO author (id, name) VALUES (\"AUTHOR_SEQ\".nextval, ?)'
+    }
+
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXERepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXERepositorySpec.groovy
@@ -142,12 +142,6 @@ class OracleXERepositorySpec extends AbstractRepositorySpec implements OracleXET
     }
 
     @Override
-    boolean skipOptimisticLockingTest() {
-        // https://github.com/oracle/oracle-r2dbc/issues/11
-        return true
-    }
-
-    @Override
     protected boolean skipCustomSchemaAndCatalogTest() {
         // ORA-04043: object "FORD"."CARS" does not exist
         return true

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXETestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXETestPropertyProvider.groovy
@@ -12,6 +12,6 @@ trait OracleXETestPropertyProvider implements SharedDatabaseContainerTestPropert
 
     @Override
     int sharedSpecsCount() {
-        return 6
+        return 7
     }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresPlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresPlainR2dbcSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.postgres
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+
+class PostgresPlainR2dbcSpec extends PlainR2dbcSpec implements PostgresTestPropertyProvider {
+
+    @Memoized
+    @Override
+    PostgresAuthorRepository getAuthorRepository() {
+        return context.getBean(PostgresAuthorRepository)
+    }
+
+    @Override
+    boolean isFailsToInsertWithoutGetRowsUpdatedCall() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresReactiveRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresReactiveRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.postgres
+
+class PostgresReactiveRepositoryPoolSpec extends PostgresReactiveRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.postgres
+
+class PostgresRepositoryPoolSpec extends PostgresRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresTestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresTestPropertyProvider.groovy
@@ -12,27 +12,7 @@ trait PostgresTestPropertyProvider implements SharedDatabaseContainerTestPropert
 
     @Override
     int sharedSpecsCount() {
-        return 6
+        return 9
     }
 
-    @Override
-    boolean usePool() {
-        // Enable pool to disable exceptions:
-//        reactor.core.publisher.FluxUsingWhen - Async resource cleanup failed after cancel
-//        io.r2dbc.postgresql.client.ReactorNettyClient$PostgresConnectionClosedException: Connection closed
-//        at io.r2dbc.postgresql.client.ReactorNettyClient.lambda$static$1(ReactorNettyClient.java:102)
-//        at io.r2dbc.postgresql.client.ReactorNettyClient$BackendMessageSubscriber.close(ReactorNettyClient.java:1018)
-//        at io.r2dbc.postgresql.client.ReactorNettyClient.drainError(ReactorNettyClient.java:518)
-//        at io.r2dbc.postgresql.client.ReactorNettyClient.lambda$close$8(ReactorNettyClient.java:191)
-//        at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:44)
-//        at reactor.core.publisher.Mono.subscribe(Mono.java:3987)
-//        at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:173)
-//        at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
-//        at reactor.core.publisher.FluxFromMonoOperator.subscribe(FluxFromMonoOperator.java:83)
-//        at reactor.core.publisher.FluxUsingWhen$UsingWhenSubscriber.cancel(FluxUsingWhen.java:342)
-//        at reactor.core.publisher.FluxUsingWhen$ResourceSubscriber.cancel(FluxUsingWhen.java:253)
-//        at reactor.core.publisher.MonoNext$NextSubscriber.onNext(MonoNext.java:81)
-//        at reactor.core.publisher.FluxUsingWhen$UsingWhenSubscriber.onNext(FluxUsingWhen.java:358){
-        return false
-    }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerPlainR2dbcSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerPlainR2dbcSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.sqlserver
+
+import groovy.transform.Memoized
+import io.micronaut.data.r2dbc.PlainR2dbcSpec
+import io.micronaut.data.tck.repositories.AuthorRepository
+
+class SqlServerPlainR2dbcSpec extends PlainR2dbcSpec implements SqlServerTestPropertyProvider {
+
+    @Memoized
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MSAuthorRepository)
+    }
+
+    @Override
+    String getInsertQuery() {
+        return 'INSERT INTO author (name) VALUES (@name)'
+    }
+
+    @Override
+    boolean isFailsWhenConvertingFluxToMono() {
+        return true
+    }
+
+    @Override
+    boolean isFailsToInsertWithoutGetRowsUpdatedCall() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerReactiveRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerReactiveRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.sqlserver
+
+class SqlServerReactiveRepositoryPoolSpec extends SqlServerReactiveRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerRepositoryPoolSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerRepositoryPoolSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.sqlserver
+
+class SqlServerRepositoryPoolSpec extends SqlServerRepositorySpec {
+
+    @Override
+    boolean usePool() {
+        return true
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerTestPropertyProvider.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerTestPropertyProvider.groovy
@@ -12,13 +12,8 @@ trait SqlServerTestPropertyProvider implements SharedDatabaseContainerTestProper
 
     @Override
     int sharedSpecsCount() {
-        return 6
+        return 9
     }
 
-    @Override
-    boolean usePool() {
-        // SQL server doesn't work without pool
-        return true
-    }
 }
 

--- a/data-r2dbc/src/test/resources/logback.xml
+++ b/data-r2dbc/src/test/resources/logback.xml
@@ -13,4 +13,5 @@
     </root>
     <logger name="io.micronaut.data.query" level="trace" />
     <logger name="io.micronaut.data.r2dbc" level="trace" />
+    <logger name="io.r2dbc.postgresql.QUERY" level="debug" />
 </configuration>

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -1239,6 +1239,8 @@ abstract class AbstractRepositorySpec extends Specification {
 
         cleanup:
         userRepository.deleteAll()
+        roleRepository.deleteAll()
+        userRoleRepository.deleteAll()
     }
 
     void "test finding authors by book"() {

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -1236,6 +1236,9 @@ abstract class AbstractRepositorySpec extends Specification {
 
         then:
         userRoleRepository.count() == 2
+
+        cleanup:
+        userRepository.deleteAll()
     }
 
     void "test finding authors by book"() {

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/UserRoleRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/UserRoleRepository.java
@@ -45,4 +45,6 @@ public interface UserRoleRepository extends GenericRepository<UserRole, UserRole
 
     @Join("role")
     Iterable<Role> findRoleByUser(User user);
+
+    void deleteAll();
 }


### PR DESCRIPTION
It looks like some of the drivers don't correctly support canceling the publisher, that is happening in a case when `Flux` is converted to `Mono`. This PR changes for the code to mostly use `Flux` and use `collectList` which should properly read the full stream.

This PR includes:
- enabling all excluded R2dbc tests except Oracle
- adding tests to test the pool configuration
- changing to use `gvenzl/oracle-xe:18` as Oracle Db container image

BTW: I have tried to upgrade the Oracle r2dbc  but it looks like there are some regressions https://github.com/oracle/oracle-r2dbc/issues/35
