### PR TITLE
allow access to app ctx from RepositoryOperations

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.hibernate.operations;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -130,6 +131,11 @@ public class HibernateJpaOperations implements JpaRepositoryOperations, AsyncCap
         this.sessionFactory = sessionFactory;
         this.transactionOperations = transactionOperations;
         this.executorService = executorService;
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return runtimeEntityRegistry.getApplicationContext();
     }
 
     @NonNull

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/annotation/JoinColumns.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/annotation/JoinColumns.java
@@ -33,7 +33,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface JoinColumns {
 
     /**
-     * The join columns that map the relationship.
+     * @return The join columns that map the relationship.
      */
     JoinColumn[] value();
 

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.jdbc.operations;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.BeanContext;

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.data.jdbc.operations;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.BeanContext;

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Inherited;
  * @since 1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Internal
 @Inherited
 public @interface DataMethod {

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeEntityRegistry.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeEntityRegistry.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.model.runtime;
 
+import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.Experimental;
@@ -26,7 +27,7 @@ import io.micronaut.data.event.EntityEventListener;
  * @author graemerocher
  * @since 2.3.0
  */
-public interface RuntimeEntityRegistry {
+public interface RuntimeEntityRegistry extends ApplicationContextProvider {
     /**
      * @return The primary entity event listener
      */

--- a/data-model/src/main/java/io/micronaut/data/operations/RepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/RepositoryOperations.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.operations;
 
+import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Page;
@@ -34,7 +35,7 @@ import java.util.stream.Stream;
  * @author graemerocher
  * @since 1.0
  */
-public interface RepositoryOperations {
+public interface RepositoryOperations extends ApplicationContextProvider {
 
     /**
      * Retrieves the entity for the given type.

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
@@ -503,6 +503,18 @@ public final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositor
         }
     }
 
+    private static <R> Mono<R> toSingleResult(Flux<R> flux) {
+        return flux.collectList().flatMap(result -> {
+            if (result.isEmpty()) {
+                return Mono.empty();
+            }
+            if (result.size() > 1) {
+                return Mono.error(new NonUniqueResultException());
+            }
+            return Mono.just(result.get(0));
+        });
+    }
+
     /**
      * Represents the current reactive transaction status.
      */
@@ -541,18 +553,6 @@ public final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositor
         public boolean isCompleted() {
             return completed;
         }
-    }
-
-    private static <R> Mono<R> toSingleResult(Flux<R> flux) {
-        return flux.collectList().flatMap(result -> {
-            if (result.isEmpty()) {
-                return Mono.empty();
-            }
-            if (result.size() > 1) {
-                return Mono.error(new NonUniqueResultException());
-            }
-            return Mono.just(result.get(0));
-        });
     }
 
     /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSqlRepositoryOperations.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.data.runtime.operations.internal;
 
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -109,7 +111,7 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("FileLength")
 @Internal
-public abstract class AbstractSqlRepositoryOperations<Cnt, RS, PS, Exc extends Exception> {
+public abstract class AbstractSqlRepositoryOperations<Cnt, RS, PS, Exc extends Exception> implements ApplicationContextProvider {
     protected static final Logger QUERY_LOG = DataSettings.QUERY_LOG;
     protected static final SqlQueryBuilder DEFAULT_SQL_BUILDER = new SqlQueryBuilder();
     @SuppressWarnings("WeakerAccess")
@@ -160,9 +162,15 @@ public abstract class AbstractSqlRepositoryOperations<Cnt, RS, PS, Exc extends E
                 dateTimeProvider,
                 new DefaultRuntimeEntityRegistry(
                         new EntityEventRegistry(beanContext),
-                        (Collection) beanContext.getBeanRegistrations(PropertyAutoPopulator.class)),
+                        (Collection) beanContext.getBeanRegistrations(PropertyAutoPopulator.class),
+                        (ApplicationContext) beanContext),
                 beanContext
         );
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return runtimeEntityRegistry.getApplicationContext();
     }
 
     /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSqlRepositoryOperations.java
@@ -168,11 +168,6 @@ public abstract class AbstractSqlRepositoryOperations<Cnt, RS, PS, Exc extends E
         );
     }
 
-    @Override
-    public ApplicationContext getApplicationContext() {
-        return runtimeEntityRegistry.getApplicationContext();
-    }
-
     /**
      * Default constructor.
      *
@@ -211,6 +206,11 @@ public abstract class AbstractSqlRepositoryOperations<Cnt, RS, PS, Exc extends E
                 queryBuilders.put(beanType, queryBuilder);
             }
         }
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return runtimeEntityRegistry.getApplicationContext();
     }
 
     private MediaTypeCodec resolveJsonCodec(List<MediaTypeCodec> codecs) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.data.runtime.support;
 
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.core.annotation.Internal;
@@ -41,19 +43,22 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Singleton
 @Internal
-public class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry {
+public class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, ApplicationContextProvider {
     private final Map<Class, RuntimePersistentEntity> entities = new ConcurrentHashMap<>(10);
     private final Map<Class<? extends Annotation>, PropertyAutoPopulator<?>> propertyPopulators;
     private final EntityEventRegistry eventRegistry;
+    private final ApplicationContext applicationContext;
 
     /**
      * Default constructor.
      * @param eventRegistry The event registry
      * @param propertyPopulators The property populators
+     * @param applicationContext The application context
      */
     public DefaultRuntimeEntityRegistry(
             EntityEventRegistry eventRegistry,
-            Collection<BeanRegistration<PropertyAutoPopulator<?>>> propertyPopulators) {
+            Collection<BeanRegistration<PropertyAutoPopulator<?>>> propertyPopulators,
+            ApplicationContext applicationContext) {
         this.eventRegistry = eventRegistry;
         this.propertyPopulators = new HashMap<>(propertyPopulators.size());
         for (BeanRegistration<PropertyAutoPopulator<?>> propertyPopulator : propertyPopulators) {
@@ -69,6 +74,7 @@ public class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry {
                 }
             }
         }
+        this.applicationContext = applicationContext;
     }
 
     @Override
@@ -156,5 +162,10 @@ public class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry {
                 return hasPostPersistEventListeners;
             }
         };
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
     }
 }


### PR DESCRIPTION
Currently there is no way to lookup beans from a `DataInterceptor`, this resolves that by making `RepositoryOperations` implement `ApplicationContextProvider`