### PR TITLE
Fix EntityGraph generation from attributeNames and named entity graph

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -175,8 +175,12 @@ public class HibernateJpaOperations implements JpaRepositoryOperations, AsyncCap
         AnnotationMetadata annotationMetadata = storedQuery.getAnnotationMetadata();
         if (annotationMetadata.hasAnnotation(EntityGraph.class)) {
             String hint = annotationMetadata.stringValue(EntityGraph.class, "hint").orElse(ENTITY_GRAPH_FETCH);
+            String graphName = annotationMetadata.stringValue(EntityGraph.class).orElse(null);
             String[] paths = annotationMetadata.stringValues(EntityGraph.class, "attributePaths");
-            if (ArrayUtils.isNotEmpty(paths)) {
+            // If the graphName is set, it takes precedence over the attributeNames
+            if (graphName != null) {
+                return Collections.singletonMap(hint, graphName);
+            } else if (ArrayUtils.isNotEmpty(paths)) {
                 return Collections.singletonMap(hint, paths);
             }
         }

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RatingRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RatingRepository.java
@@ -1,0 +1,25 @@
+package io.micronaut.data.hibernate;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.hibernate.entities.Rating;
+import io.micronaut.data.jpa.annotation.EntityGraph;
+import io.micronaut.data.repository.CrudRepository;
+import org.jetbrains.annotations.NotNull;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@Transactional
+public interface RatingRepository extends CrudRepository<Rating, UUID> {
+    @NotNull
+    @EntityGraph("RatingEntityGraph")
+    Optional<Rating> findById(@NotNull UUID id);
+
+    @EntityGraph(attributePaths = { "book.pages", "book.author" })
+    Optional<Rating> queryById(@NotNull UUID id);
+
+    @EntityGraph(attributePaths = { "book.author", "book.pages", "author.books" })
+    Optional<Rating> getById(@NotNull UUID id);
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RatingRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RatingRepository.java
@@ -4,9 +4,9 @@ import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.hibernate.entities.Rating;
 import io.micronaut.data.jpa.annotation.EntityGraph;
 import io.micronaut.data.repository.CrudRepository;
-import org.jetbrains.annotations.NotNull;
 
 import javax.transaction.Transactional;
+import javax.validation.constraints.NotNull;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/Rating.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/Rating.java
@@ -1,0 +1,93 @@
+package io.micronaut.data.hibernate.entities;
+
+import io.micronaut.data.tck.entities.Author;
+import io.micronaut.data.tck.entities.Book;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@NamedEntityGraph(
+        name = "RatingEntityGraph",
+        attributeNodes = {
+                @NamedAttributeNode(value = "book", subgraph = "graph.RatingBookSubgraph"),
+                @NamedAttributeNode(value = "author")
+        },
+        subgraphs = {
+                @NamedSubgraph(
+                        name = "graph.RatingBookSubgraph",
+                        attributeNodes = {
+                                @NamedAttributeNode(value = "pages"),
+                                @NamedAttributeNode(value = "author")
+                        }
+                )
+        }
+)
+@Entity
+public class Rating {
+    @Id
+    @GeneratedValue
+    UUID id;
+
+    @Column(nullable = false)
+    Integer rating = 1;
+
+    @Column(nullable = true)
+    String comment;
+
+    @ManyToOne(optional = false)
+    Book book;
+
+    @ManyToOne(optional = false)
+    Author author;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Integer getRating() {
+        return rating;
+    }
+
+    public void setRating(Integer rating) {
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+
+    @Override
+    public String toString() {
+        return "Rating{" +
+                "id=" + id +
+                ", rating='" + rating + '\'' +
+                ", comment='" + comment + '\'' +
+                ", book=" + book +
+                ", author=" + author +
+                '}';
+    }
+}


### PR DESCRIPTION
This PR should address #1160, preventing subgraph on the same association to be overwritten when multiple nested properties are specified.
This is also fixing the issue described in #406, allowing an `@EntityGraph` with just a name to still generate a query hint even if we don't explicitly annotate the method with `@QueryHint` or by adding an empty `attributeNames`.