### PR TITLE
Issue with parameters for native query

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -261,19 +261,14 @@ public class HibernateJpaOperations implements JpaRepositoryOperations, AsyncCap
                 Class<?> argumentType = argument.getType();
                 if (Collection.class.isAssignableFrom(argumentType)) {
                     Type valueType = sessionFactory.getTypeHelper().heuristicType(argument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT).getType().getName());
-                    if (valueType != null) {
+                    if (valueType != null)
                         q.setParameterList(parameterName, value == null ? Collections.emptyList() : (Collection<?>) value, valueType);
-                        return;
-                    }
                 } else if (Object[].class.isAssignableFrom(argumentType)) {
                     q.setParameterList(parameterName, value == null ? ArrayUtils.EMPTY_OBJECT_ARRAY : (Object[]) value);
-                    return;
                 } else if (value == null) {
                     Type type = sessionFactory.getTypeHelper().heuristicType(argumentType.getName());
-                    if (type != null) {
+                    if (type != null)
                         q.setParameter(parameterName, null, type);
-                        return;
-                    }
                 }
             }
             q.setParameter(parameterName, value);


### PR DESCRIPTION
Hey guys, tinkering with micronaut data hibernate, I identified an issue about bind query parameters. This issue happens when I'm binding a Type List, Object[] or NULL parameter. Basically, the routine breaks the parameter assignment when it's assigned to one of the listed ones.

E.g: If i set four parameters (two Lists and two Strings), the code - depending on the order of the parameters - passes those two Strings and after the first List is made, an error will be returned, not passing the second List.

Is this a bug? I'm not sure this is the correct behaviour.