### PR TITLE
Fix "Cannot decode value of type java.lang.String with OID 2950"

### DIFF
--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnIndexR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnIndexR2dbcResultReader.java
@@ -65,9 +65,9 @@ public class ColumnIndexR2dbcResultReader implements ResultReader<Row, Integer> 
     @Override
     public Object readDynamic(@NonNull Row resultSet, @NonNull Integer index, @NonNull DataType dataType) {
         switch (dataType) {
-            case STRING:
             case UUID:
                 return readUUID(resultSet, index);
+            case STRING:
             case JSON:
                 return readString(resultSet, index);
             case LONG:

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnIndexR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnIndexR2dbcResultReader.java
@@ -67,6 +67,7 @@ public class ColumnIndexR2dbcResultReader implements ResultReader<Row, Integer> 
         switch (dataType) {
             case STRING:
             case UUID:
+                return readUUID(resultSet, index);
             case JSON:
                 return readString(resultSet, index);
             case LONG:

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractUUIDSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractUUIDSpec.groovy
@@ -60,4 +60,23 @@ abstract class AbstractUUIDSpec extends Specification {
             uuidRepository.deleteAll()
     }
 
+
+    void 'test insert and return uuid'() {
+        when:
+           def test = uuidRepository.save(new UuidEntity("Fred"))
+
+            def uuid = test.uuid
+        then:
+            uuid != null
+
+        when:
+            test = uuidRepository.findUuidByName("Fred")
+
+        then:
+            test != null
+            test == uuid
+
+        cleanup:
+            uuidRepository.deleteAll()
+    }
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/UuidRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/UuidRepository.java
@@ -22,4 +22,6 @@ import java.util.UUID;
 
 public interface UuidRepository extends CrudRepository<UuidEntity, UUID> {
 
+    UUID findUuidByName(String name);
+
 }


### PR DESCRIPTION
When an object is saved and the returning ID is a `UUID` the `ColumnIndexR2dbcResultReader` was falling through the switch statement and trying to handle the data type as a `String` despite Postgres returning it as `UUID` datatype `2950`.

I do have two concerns/questions I need some help with.

1) I am not quite sure where is a good place to add a test for this.
2) I am not sure if this interferes with the ability to define a `String` type in code that is backed by a `UUID` type in Postgres. I am honestly not sure if that's a supported scenario here. I was not able to get it to work either way before this fix.

Happy to handle these two items above this is just my first time here so I am still getting my bearings. Any nudges in the right direction would be helpful.

I was running into this playing with adding r2dbc to an existing project. With this fix in place I was able to pass my sample test with a local snapshot including this change.

Abbreviated stack trace and screenshot of what caught my eye while debugging.

```
23:58:11.782 [reactor-tcp-nio-1] WARN  i.m.d.r.o.DefaultR2dbcRepositoryOperations - Rolling back transaction on error: Cannot decode value of type java.lang.String with OID 2950
java.lang.IllegalArgumentException: Cannot decode value of type java.lang.String with OID 2950
	at io.r2dbc.postgresql.codec.DefaultCodecs.decode(DefaultCodecs.java:180)
	at io.r2dbc.postgresql.PostgresqlRow.decode(PostgresqlRow.java:90)
	at io.r2dbc.postgresql.PostgresqlRow.get(PostgresqlRow.java:67)
	at io.micronaut.data.r2dbc.mapper.ColumnIndexR2dbcResultReader.readString(ColumnIndexR2dbcResultReader.java:147)
	at io.micronaut.data.r2dbc.mapper.ColumnIndexR2dbcResultReader.readDynamic(ColumnIndexR2dbcResultReader.java:71)
	at io.micronaut.data.r2dbc.mapper.ColumnIndexR2dbcResultReader.readDynamic(ColumnIndexR2dbcResultReader.java:41)
	at io.micronaut.data.r2dbc.operations.DefaultR2dbcRepositoryOperations$R2dbcEntityOperations.lambda$null$12(DefaultR2dbcRepositoryOperations.java:1178)
	at io.r2dbc.postgresql.PostgresqlResult.lambda$map$2(PostgresqlResult.java:124)
	at reactor.core.publisher.FluxHandle$HandleSubscriber.onNext(FluxHandle.java:103)
	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onNext(MonoFlatMapMany.java:250)
```

<img width="1403" alt="CleanShot 2021-11-13 at 23 41 22@2x" src="https://user-images.githubusercontent.com/304495/141669355-06f884a0-0e50-491a-9cae-fd42e013d558.png">

Sample code from my demo project to trigger this.

```kotlin
@MappedEntity("apns")
data class Apns(
    @field:Id
    @field:GeneratedValue
    var id: UUID? = null,
    @MappedProperty("userid")
    val userId: UUID,
    @MappedProperty("apnstoken")
    val token: String,
    @MappedProperty("updatedat")
    @field:GeneratedValue
    var updatedAt: Timestamp? = null
)

@R2dbcRepository(dialect = Dialect.POSTGRES)
interface ApnsRepo : CoroutineCrudRepository<Apns, UUID> {
    suspend fun save(apns: Apns): Apns
}
```

```kotlin
@MicronautTest
class ApnsRepoTests {

    @Inject
    lateinit var apnsRepo: ApnsRepo

    @Test
    fun count() = runBlocking {
        val apnsToken = "EA" + System.currentTimeMillis()
        val saved = apnsRepo.save(
            Apns(
                userId = UUID.fromString("38c69f49-4125-4a28-b199-dd57c58540e6"),
                token = apnsToken
            )
        )
        assertEquals(apnsToken, saved.token)
    }
}
```
