### PR TITLE
Fix GraalVM warning

### DIFF
--- a/data-runtime/src/main/resources/META-INF/native-image/io.micronaut.data/micronaut-data-runtime/native-image.properties
+++ b/data-runtime/src/main/resources/META-INF/native-image/io.micronaut.data/micronaut-data-runtime/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.data.runtime.intercept.criteria.AbstractSpecificationInterceptor


### PR DESCRIPTION
Fixes the following GraalVM warning:

```
Warning: class initialization of class io.micronaut.data.runtime.intercept.criteria.AbstractSpecificationInterceptor failed with exception java.lang.NoClassDefFoundError: jakarta/persistence/criteria/Expression. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.data.runtime.intercept.criteria.AbstractSpecificationInterceptor to explicitly request delayed initialization of this class.
```