### PR TITLE
Update documentation with @TransactionalAdvice

### DIFF
--- a/src/main/docs/guide/sql/dbc/dbcRepositories.adoc
+++ b/src/main/docs/guide/sql/dbc/dbcRepositories.adoc
@@ -1,19 +1,21 @@
 As seen in the <<jdbcQuickStart, Quick Start>> JDBC / R2DBC repositories in Micronaut Data are defined as interfaces that are annotated with the ann:data.jdbc.annotation.JdbcRepository[] annotation, ann:data.r2dbc.annotation.R2dbcRepository[] accordingly.
 
 
-In multiple datasource scenario, the @io.micronaut.data.annotation.Repository annotation can be used to specify the datasource configuration to use. By default Micronaut Data will look for the default datasource.
+In a multiple datasource scenario, the ann:io.micronaut.data.annotation.Repository[] and ann:io.micronaut.transaction.annotation.TransactionalAdvice[] annotations can be used to specify the datasource configuration to use. By default Micronaut Data will look for the default datasource.
 
 For example: 
 [source,java]
 ----
-@Repository(value = "inventoryDataSource") // <1>
+@Repository("inventoryDataSource") // <1>
 @JdbcRepository(dialect = Dialect.ORACLE) // <2>
+@TransactionalAdvice("inventoryDataSource") // <3>
 public interface PhoneRepository extends CrudRepository<Phone, Integer> {
     Optional<Phone> findByAssetId(@NotNull Integer assetId);
 }
 ----
-<1> @Repository annotaiton, pointing to data source configuration 'inventoryDataSource'
-<2> @JdbcRepository with a specific dialect. 
+<1> @Repository annotation, pointing to data source configuration 'inventoryDataSource'
+<2> @JdbcRepository with a specific dialect.
+<3> @TransactionalAdvice annotation, pointing to the data source configuration 'inventoryDataSource'
 
 
 The entity to treat as the root entity for the purposes of querying is established either from the method signature or from the generic type parameter specified to the api:data.repository.GenericRepository[] interface.


### PR DESCRIPTION
Updating documentation to clarify an issue I ran into here #1285 

This adds the `@TransactionalAdvice` annotation example to the section pertaining to usage of multiple datasources with repositories.

I also updated some links to the code annotations where they were not present.