### PR TITLE
Update jdbcQuickStart.adoc to bump Jakarta versión to v3.0.0

### DIFF
--- a/doc-examples/jdbc-example-groovy/build.gradle
+++ b/doc-examples/jdbc-example-groovy/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-validation"
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
-    implementation libs.javax.persistence.api
     implementation libs.jakarta.persistence.api
     implementation libs.jakarta.transaction.api
     runtimeOnly "ch.qos.logback:logback-classic"

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/Book.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/Book.groovy
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 class Book {

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/Manufacturer.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/Manufacturer.groovy
@@ -3,7 +3,7 @@ package example
 
 import io.micronaut.core.annotation.Creator
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 class Manufacturer {

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/Product.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/Product.groovy
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 class Product {

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/Project.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/Project.groovy
@@ -1,8 +1,8 @@
 
 package example
 
-import javax.persistence.EmbeddedId
-import javax.persistence.Entity
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
 
 @Entity
 class Project {

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/ProjectId.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/ProjectId.groovy
@@ -2,7 +2,7 @@
 package example
 
 import groovy.transform.EqualsAndHashCode
-import javax.persistence.Embeddable
+import jakarta.persistence.Embeddable
 
 @EqualsAndHashCode
 @Embeddable

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/Sale.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/Sale.groovy
@@ -1,10 +1,10 @@
 
 package example
 
-import javax.persistence.Id
-import javax.persistence.Entity
-import javax.persistence.ManyToOne
-import javax.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Entity
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.GeneratedValue
 
 @Entity
 class Sale {

--- a/doc-examples/jdbc-example-java/build.gradle
+++ b/doc-examples/jdbc-example-java/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-validation"
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
-    compileOnly libs.javax.persistence.api
     implementation libs.jakarta.persistence.api
     implementation libs.jakarta.transaction.api
     runtimeOnly "ch.qos.logback:logback-classic"

--- a/doc-examples/jdbc-example-java/src/main/java/example/Book.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/Book.java
@@ -1,7 +1,7 @@
 
 package example;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class Book {

--- a/doc-examples/jdbc-example-java/src/main/java/example/Manufacturer.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/Manufacturer.java
@@ -3,7 +3,7 @@ package example;
 
 import io.micronaut.core.annotation.Creator;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class Manufacturer {

--- a/doc-examples/jdbc-example-java/src/main/java/example/Product.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/Product.java
@@ -1,7 +1,7 @@
 
 package example;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class Product {

--- a/doc-examples/jdbc-example-java/src/main/java/example/Project.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/Project.java
@@ -1,8 +1,8 @@
 
 package example;
 
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
 
 @Entity
 public class Project {

--- a/doc-examples/jdbc-example-java/src/main/java/example/ProjectId.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/ProjectId.java
@@ -1,7 +1,7 @@
 
 package example;
 
-import javax.persistence.Embeddable;
+import jakarta.persistence.Embeddable;
 import java.util.Objects;
 
 @Embeddable

--- a/doc-examples/jdbc-example-java/src/main/java/example/Sale.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/Sale.java
@@ -1,7 +1,7 @@
 
 package example;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 public class Sale {

--- a/doc-examples/jdbc-example-kotlin/build.gradle
+++ b/doc-examples/jdbc-example-kotlin/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "io.micronaut:micronaut-http-client"
     implementation project(":data-jdbc")
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
-    compileOnly libs.javax.persistence.api
     implementation libs.jakarta.persistence.api
     implementation libs.jakarta.transaction.api
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Book.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Book.kt
@@ -1,9 +1,9 @@
 
 package example
 
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
 
 @Entity
 data class Book(@Id

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Manufacturer.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Manufacturer.kt
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 data class Manufacturer(

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Product.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Product.kt
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 data class Product(

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Project.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Project.kt
@@ -1,8 +1,8 @@
 
 package example
 
-import javax.persistence.EmbeddedId
-import javax.persistence.Entity
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
 
 @Entity
 class Project(

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProjectId.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProjectId.kt
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.Embeddable
+import jakarta.persistence.Embeddable
 
 @Embeddable
 data class ProjectId(val departmentId: Int, val projectId: Int)

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Sale.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Sale.kt
@@ -1,7 +1,7 @@
 
 package example
 
-import javax.persistence.*
+import jakarta.persistence.*
 
 @Entity
 data class Sale(

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/User.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/User.kt
@@ -2,9 +2,9 @@
 package example
 
 import io.micronaut.data.annotation.Where
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
 
 
 @Entity

--- a/doc-examples/mongo-example-kotlin/src/main/kotlin/example/Student.kt
+++ b/doc-examples/mongo-example-kotlin/src/main/kotlin/example/Student.kt
@@ -3,12 +3,15 @@ package example
 import io.micronaut.data.annotation.*
 import org.bson.types.ObjectId
 
+// tag::student[]
 @MappedEntity
 data class Student(
         @field:Id @GeneratedValue
         val id: ObjectId?,
         @field:Version
         val version: Long?,
+// end::student[]
+
         val name: String,
         @Relation(value = Relation.Kind.MANY_TO_MANY, cascade = [Relation.Cascade.PERSIST])
         val courses: List<Course>,

--- a/src/main/docs/guide/sql/dbc/dbcQuickStart/jdbcQuickStart.adoc
+++ b/src/main/docs/guide/sql/dbc/dbcQuickStart/jdbcQuickStart.adoc
@@ -28,7 +28,7 @@ NOTE: The `schema-generate` setting is only useful for demos and testing trivial
 
 To retrieve objects from the database you need to define a class annotated with ann:data.annotation.MappedEntity[]. Note that this is a meta annotation and in fact if you prefer you can use JPA annotations (only a subset are supported, more on that later). If you wish to use JPA annotations include the following `compileOnly` scoped dependency:
 
-dependency:jakarta.persistence:jakarta.persistence-api[version="2.2.2", scope="compileOnly"]
+dependency:jakarta.persistence:jakarta.persistence-api[version="3.0.0", scope="compileOnly"]
 
 As above since only the annotations are used the dependency can be included only for compilation and not at runtime so you don't drag along the rest of the API, reducing your JAR file size.
 

--- a/src/main/docs/guide/sql/dbc/dbcQuickStart/r2dbcQuickStart.adoc
+++ b/src/main/docs/guide/sql/dbc/dbcQuickStart/r2dbcQuickStart.adoc
@@ -55,7 +55,7 @@ snippet::example.AuthorRepository[project-base="doc-examples/r2dbc-example", sou
 
 You can now inject this interface into controllers and use it to perform R2DBC queries:
 
-snippet::example.AuthorController[project-base="doc-examples/example", source="main", indent="0"]
+snippet::example.AuthorController[project-base="doc-examples/r2dbc-example", source="main", indent="0"]
 
 <1> By returning a reactive type that emits many items you can stream data (either rx:Flowable[] or `Flux`)
 <1> By returning a reactive type that emits a single item you return the entire response (either rx:Single[] or `Mono`)


### PR DESCRIPTION
I propose to update the Jakarta version to the `3.0.0` because this version contains the new packages `jakarta.persistence.criteria`.

What do you think? Is correct?