### PR TITLE
fix(locking): make sure optimistic locking works with updateAll

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -1083,7 +1083,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
                 if (d.vetoed) {
                     continue;
                 }
-                sqlOperation.collectAutoPopulatedPreviousValues(persistentEntity, d.entity);
+                d.previousValues = sqlOperation.collectAutoPopulatedPreviousValues(persistentEntity, d.entity);
             }
         }
 


### PR DESCRIPTION
It looks like there was a missed call to set the previous values on an entity when updating an entity with optimistic locking in a batched update.