### PR TITLE
Product.kt example — remove nullable type on association property

### DIFF
--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Product.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Product.kt
@@ -10,5 +10,5 @@ data class Product(
     var id: Long?,
     var name: String,
     @ManyToOne
-    var manufacturer: Manufacturer?
+    var manufacturer: Manufacturer
 )


### PR DESCRIPTION
`Manufacturer?` -> `Manufacturer`

If you look at the docs in https://github.com/micronaut-projects/micronaut-data/blob/master/src/main/docs/guide/sql/dbc/sqlMapping/sqlAssociationFetching.adoc, they state:
> an exception will occur since the manufacturer association is not Nullable.

Then state to solve this by:
> in Kotlin add ? to the end of the constructor argument name

However the example already is nullable and has a `?` at the end of the property type. This seems to be a mistake.