### PR TITLE
Fix compilation flakiness

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -58,5 +58,25 @@
         "type": "io.micronaut.transaction.jdbc.DataSourceTransactionManager",
         "member": "Class io.micronaut.transaction.jdbc.DataSourceTransactionManager",
         "reason": "Internal method"
+    },
+    {
+    "type": "io.micronaut.data.processor.visitors.finders.AbstractPrefixPatternMethodMatcher",
+    "member": "Class io.micronaut.data.processor.visitors.finders.AbstractPrefixPatternMethodMatcher",
+    "reason": "Class is considered internal API"
+},
+    {
+        "type": "io.micronaut.data.processor.visitors.finders.AbstractPrefixPatternMethodMatcher",
+        "member": "Constructor io.micronaut.data.processor.visitors.finders.AbstractPrefixPatternMethodMatcher(java.lang.String[])",
+        "reason": "Class is considered internal API"
+    },
+    {
+        "type": "io.micronaut.data.processor.visitors.finders.SaveEntityMethodMatcher",
+        "member": "Class io.micronaut.data.processor.visitors.finders.SaveEntityMethodMatcher",
+        "reason": "Class is considered internal API"
+    },
+    {
+        "type": "io.micronaut.data.processor.visitors.finders.SaveEntityMethodMatcher",
+        "member": "Field PREFIXES",
+        "reason": "Class is considered internal API"
     }
 ]

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractSpecificationMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractSpecificationMethodMatcher.java
@@ -24,6 +24,8 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.VisitorContext;
 
+import java.util.Arrays;
+
 /**
  * Abstract superclass for specification methods.
  *
@@ -39,7 +41,7 @@ public abstract class AbstractSpecificationMethodMatcher extends AbstractPrefixP
      * @param prefixes The method prefixes to match
      */
     protected AbstractSpecificationMethodMatcher(String... prefixes) {
-        super(prefixes);
+        super(Arrays.asList(prefixes));
     }
 
     @Override

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/SaveEntityMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/SaveEntityMethodMatcher.java
@@ -27,6 +27,8 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ParameterElement;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static io.micronaut.data.processor.visitors.finders.FindersUtils.getInterceptorElement;
@@ -39,7 +41,9 @@ import static io.micronaut.data.processor.visitors.finders.FindersUtils.getInter
  */
 public class SaveEntityMethodMatcher extends AbstractPrefixPatternMethodMatcher {
 
-    public static final String[] PREFIXES = {"save", "persist", "store", "insert"};
+    public static final List<String> PREFIXES = Collections.unmodifiableList(
+            Arrays.asList("save", "persist", "store", "insert")
+    );
 
     /**
      * The default constructor.


### PR DESCRIPTION
This commit fixes an accidental mutation of the static `PREFIXES` field which
was happening when sorting the list of prefixes in `AbstractPrefixPatternMethodMatcher`.

The consequence was the creation, sometimes, of incorrect patterns. For example,
the generated pattern could be `^((persist|insert|insert|store)(\S*?))$`
instead of `^((persist|insert|save|store)(\S*?))$` (notice the duplicate entry).

It also replaces the static array type with an unmodifiable list, as it's in
general not a good idea to have mutable datastructures as static fields.

Fixes #1400