### PR TITLE
Pageable/start from 1

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
@@ -36,6 +36,7 @@ public class DataConfiguration implements DataSettings {
     public static class PageableConfiguration {
         public static final int    DEFAULT_MAX_PAGE_SIZE = 100;
         public static final boolean DEFAULT_SORT_IGNORE_CASE = false;
+        public static final boolean DEFAULT_START_FROM_PAGE_ONE = false;
         public static final String DEFAULT_SORT_PARAMETER = "sort";
         public static final String DEFAULT_SIZE_PARAMETER = "size";
         public static final String DEFAULT_PAGE_PARAMETER = "page";
@@ -43,6 +44,7 @@ public class DataConfiguration implements DataSettings {
         private int maxPageSize = DEFAULT_MAX_PAGE_SIZE;
         private Integer defaultPageSize = null; // When is not specified the maxPageSize should be used
         private boolean sortIgnoreCase = DEFAULT_SORT_IGNORE_CASE;
+        private boolean startFromPageOne = DEFAULT_START_FROM_PAGE_ONE;
         private String sortParameterName = DEFAULT_SORT_PARAMETER;
         private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
         private String pageParameterName = DEFAULT_PAGE_PARAMETER;
@@ -76,6 +78,21 @@ public class DataConfiguration implements DataSettings {
             if (StringUtils.isNotEmpty(sortDelimiter)) {
                 this.sortDelimiter = Pattern.compile(Pattern.quote(sortDelimiter));
             }
+        }
+
+        /**
+         * @return Whether the first page is 1
+         */
+        public boolean isStartFromPageOne() {
+            return startFromPageOne;
+        }
+
+        /**
+         * This parameter is used to shift the provided page number back one when this is true.
+         * @param startFromPageOne Whether the first page is 1
+         */
+        public void setStartFromPageOne(boolean startFromPageOne) {
+            this.startFromPageOne = startFromPageOne;
         }
 
         /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/config/DataConfiguration.java
@@ -81,7 +81,7 @@ public class DataConfiguration implements DataSettings {
         }
 
         /**
-         * @return Whether the first page is 1
+         * @return Whether the first page parameter starts at one
          */
         public boolean isStartFromPageOne() {
             return startFromPageOne;
@@ -89,6 +89,8 @@ public class DataConfiguration implements DataSettings {
 
         /**
          * This parameter is used to shift the provided page number back one when this is true.
+         * So when the page parameter is entered as one, the first page (0) is provided.
+         *
          * @param startFromPageOne Whether the first page is 1
          */
         public void setStartFromPageOne(boolean startFromPageOne) {
@@ -112,7 +114,7 @@ public class DataConfiguration implements DataSettings {
 
         /**
          * @return the page size to use when binding {@link io.micronaut.data.model.Pageable}
-         * objects and no size parameter is used. By default is set to the same vale as {@link #maxPageSize}
+         * objects and no size parameter is used. By default is set to the same value as {@link #maxPageSize}
          */
         public int getDefaultPageSize() {
             return defaultPageSize == null ? maxPageSize : defaultPageSize;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/http/PageableRequestArgumentBinder.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/http/PageableRequestArgumentBinder.java
@@ -96,6 +96,10 @@ public class PageableRequestArgumentBinder implements TypedRequestArgumentBinder
             sort = Sort.of(orders);
         }
 
+        if (configuration.isStartFromPageOne() && page > 0) {
+            page--;
+        }
+
         if (size < 1) {
             if (page == 0 && configuredMaxSize < 1 && sort == null) {
                 pageable = Pageable.UNPAGED;

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableConfigSpec.groovy
@@ -28,7 +28,8 @@ class PageableConfigSpec extends Specification {
                 'micronaut.data.pageable.default-page-size': 10,
                 'micronaut.data.pageable.sort-parameter-name': 's',
                 'micronaut.data.pageable.page-parameter-name': 'index',
-                'micronaut.data.pageable.size-parameter-name': 'max'
+                'micronaut.data.pageable.size-parameter-name': 'max',
+                'micronaut.data.pageable.start-from-page-one': true
         )
         DataConfiguration.PageableConfiguration configuration = context.getBean(DataConfiguration.PageableConfiguration)
 
@@ -38,6 +39,7 @@ class PageableConfigSpec extends Specification {
         configuration.sortParameterName == 's'
         configuration.pageParameterName == 'index'
         configuration.sizeParameterName == 'max'
+        configuration.startFromPageOne
 
         cleanup:
         context.close()

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
@@ -110,8 +110,8 @@ class PageableRequestArgumentBinderSpec extends Specification {
 
         where:
         page | pageNumber | startFromPageOne
-        "1"  | 0          | true // first page is shifted to 0
-        "5"  | 4          | true // fifth page is shifted to 4
-        "0"  | 0          | true // 0 page is still 0
+        "1"  | 0          | true  // first page is shifted to 0
+        "5"  | 4          | true  // fifth page is shifted to 4
+        "0"  | 0          | true  // 0 page is still 0
     }
 }

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
@@ -72,10 +72,10 @@ class PageableRequestArgumentBinderSpec extends Specification {
     void 'test bind size #size and page #page with custom configuration'() {
         given:
         def configuration = new DataConfiguration.PageableConfiguration()
-        configuration.defaultPageSize=40
-        configuration.maxPageSize=200
-        configuration.sizeParameterName="perPage"
-        configuration.pageParameterName="myPage"
+        configuration.defaultPageSize = 40
+        configuration.maxPageSize = 200
+        configuration.sizeParameterName = "perPage"
+        configuration.pageParameterName = "myPage"
         PageableRequestArgumentBinder binder = new PageableRequestArgumentBinder(configuration)
         def get = HttpRequest.GET('/')
         get.parameters.add("perPage", size)
@@ -93,5 +93,28 @@ class PageableRequestArgumentBinderSpec extends Specification {
         "-1"   | "10" | 40       | 10  // negative    => uses default != max
         "-1"   | "0"  | 40       | 0   // negative    => uses default != max
         "junk" | "0"  | 40       | 0   // can't be parsed
+    }
+
+    @Unroll
+    void 'test page #page is or is not shifted with custom configuration for startFromPageOne #startFromPageOne'() {
+        given:
+        def configuration = new DataConfiguration.PageableConfiguration()
+        configuration.startFromPageOne = startFromPageOne
+        PageableRequestArgumentBinder binder = new PageableRequestArgumentBinder(configuration)
+        def get = HttpRequest.GET('/')
+        get.parameters.add("page", page)
+        Pageable p = binder.bind(ConversionContext.of(Pageable), get).get()
+
+        expect:
+        p.number == pageNumber
+
+        where:
+        page | pageNumber | startFromPageOne
+        "1"  | 0          | true // first page is shifted to 0
+        "5"  | 4          | true // fifth page is shifted to 4
+        "0"  | 0          | true // 0 page is still 0
+        "1"  | 1          | false // 1 is 1
+        "5"  | 5          | false // 5 is 5
+        "0"  | 0          | false // 0 is 0
     }
 }

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/http/PageableRequestArgumentBinderSpec.groovy
@@ -113,8 +113,5 @@ class PageableRequestArgumentBinderSpec extends Specification {
         "1"  | 0          | true // first page is shifted to 0
         "5"  | 4          | true // fifth page is shifted to 4
         "0"  | 0          | true // 0 page is still 0
-        "1"  | 1          | false // 1 is 1
-        "5"  | 5          | false // 5 is 5
-        "0"  | 0          | false // 0 is 0
     }
 }

--- a/data-spring/src/main/java/io/micronaut/data/spring/runtime/http/SpringPageableRequestArgumentBinder.java
+++ b/data-spring/src/main/java/io/micronaut/data/spring/runtime/http/SpringPageableRequestArgumentBinder.java
@@ -100,6 +100,10 @@ public class SpringPageableRequestArgumentBinder implements TypedRequestArgument
             sort = Sort.unsorted();
         }
 
+        if (configuration.isStartFromPageOne() && page > 0) {
+            page--;
+        }
+
         if (size < 1) {
             if (page == 0 && configuredMaxSize < 1 && sort.isUnsorted()) {
                 pageable = Pageable.unpaged();


### PR DESCRIPTION
**What this does**
- Adds startFromPageOne config property that allows users to enter 1 for the page number and get the first page back
- This is done by shifting the page number in the PageableRequestArgumentBinder by one if that property is set to true

**Why is this needed**
- This functionality is currently in spring here: https://github.com/spring-projects/spring-data-commons/blob/0e5e869cbf987155590b7e04717f5e965d90d49b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java#L283 which does the same thing using the `oneIndexedParameters` property. 
- API standards for git, Target, and I am sure other corporations start from page one. Here is a snippet from gits page:
`This makes sense, since by default, all paginated queries start at page 1.` - https://docs.github.com/en/rest/guides/traversing-with-pagination

I am sure there are better ways to implement this, but this is similar to how spring has it implemented.


Also I noticed the docs for configuration properties are here: https://micronaut-projects.github.io/micronaut-data/latest/guide/configurationreference.html#io.micronaut.data.r2dbc.config.DataR2dbcConfiguration which doesn't seem to be linked to micronaut-data. Let me know if you would like me to update these docs if this does move forward.