### PR TITLE
Make DataInterceptorResolver#resolve safe for concurrent usage.

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/intercept/DataInterceptorResolver.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/DataInterceptorResolver.java
@@ -59,11 +59,7 @@ final class DataInterceptorResolver {
     DataInterceptor<Object, Object> resolve(@NonNull RepositoryMethodKey key,
                                             @NonNull MethodInvocationContext<Object, Object> context,
                                             @Nullable InjectionPoint<?> injectionPoint) {
-        return interceptors.compute(key, (k, interceptor) -> {
-            if (interceptor != null) {
-                return interceptor;
-            }
-
+        return interceptors.computeIfAbsent(key, (k) -> {
             final String dataSourceName = context.stringValue(Repository.class)
                 .orElseGet(() -> injectionPoint == null ? null : injectionPoint.getAnnotationMetadata().stringValue(Repository.class).orElse(null));
             final Class<?> operationsType = context.classValue(RepositoryConfiguration.class, "operations")


### PR DESCRIPTION
- DataInterceptorResolver: utilise Map#compute in DataInterceptorResolver#resolve to ensure that resolution of DataInterceptors is safe for concurrent use.

- DataInterceptorResolver: misc. polishing/refactoring.