### PR TITLE
Race-condition causes failing property mapping during startup

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
@@ -109,12 +109,8 @@ final class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, Appli
     @Override
     public <T> RuntimePersistentEntity<T> getEntity(@NonNull Class<T> type) {
         ArgumentUtils.requireNonNull("type", type);
-        RuntimePersistentEntity<T> entity = entities.get(type);
-        if (entity == null) {
-            entity = newEntity(type);
-            entities.put(type, entity);
-        }
-        return entity;
+        // we need atomicity here, since entites are compared by identity (==)
+        return entities.computeIfAbsent(type, this::newEntity);
     }
 
     @NonNull


### PR DESCRIPTION
Hi,
during startup of my application this exception often occurred:

```
io.micronaut.data.exceptions.DataAccessException: Error reading object for name [custom_asset_id_asset_id] from result set: The column name custom_asset_id_asset_id was not found in this ResultSet.
	at io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader.exceptionForColumn(ColumnNameResultSetReader.java:248)
	at io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader.readInt(ColumnNameResultSetReader.java:154)
	at io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader.readInt(ColumnNameResultSetReader.java:41)
	at io.micronaut.data.runtime.mapper.ResultReader.readDynamic(ResultReader.java:111)
	at io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader.readDynamic(ColumnNameResultSetReader.java:67)
	at io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader.readDynamic(ColumnNameResultSetReader.java:41)
	at io.micronaut.data.runtime.mapper.sql.SqlResultEntityTypeMapper.readProperty(SqlResultEntityTypeMapper.java:575)
	at io.micronaut.data.runtime.mapper.sql.SqlResultEntityTypeMapper.readEntityId(SqlResultEntityTypeMapper.java:602)
	at io.micronaut.data.runtime.mapper.sql.SqlResultEntityTypeMapper.readEntity(SqlResultEntityTypeMapper.java:531)
```
The mapping of column names was seemingly not taken into account, even though they were mapped properly.
The issue resolved itself after a few exceptions and then the app ran fine.

Digging into the code, the problem was triggered by ```NamingStrategy``` comparing ```RuntimePersistentEntity```s by identity:
```
  if (foreignAssociation.getAssociatedEntity() == property.getOwner()
          && foreignAssociation.getAssociatedEntity().getIdentity() == property) {
      ...
  }
```

But the generation of ```RuntimePersistentEntity```s was not atomic in ```DefaultRuntimeEntityRegistry```, so shortly there were multiple entities available for the exact same type, and the comparison failed wrongly.

This PR fixes the issue.
