### PR TITLE
micronaut-data-jpa-hibernate - Use hasPostRemoveEventListeners for POST_DELETE case

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/event/EventIntegrator.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/event/EventIntegrator.java
@@ -129,7 +129,7 @@ public class EventIntegrator implements Integrator {
                             return;
                         }
                         final RuntimePersistentEntity<Object> entity = entityRegistry.getEntity(mappedClass);
-                        if (entity.hasPostPersistEventListeners()) {
+                        if (entity.hasPostRemoveEventListeners()) {
                             final DefaultEntityEventContext<Object> context = new SimpleHibernateEventContext<>(entity, event.getEntity());
                             entityEventListener.postRemove(context);
                         }

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/event/EventIntegrator.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/event/EventIntegrator.java
@@ -165,7 +165,7 @@ public class EventIntegrator implements Integrator {
                             return;
                         }
                         final RuntimePersistentEntity<Object> entity = entityRegistry.getEntity(mappedClass);
-                        if (entity.hasPostPersistEventListeners()) {
+                        if (entity.hasPostUpdateEventListeners()) {
                             final DefaultEntityEventContext<Object> context = new SimpleHibernateEventContext<>(entity, event.getEntity());
                             entityEventListener.postUpdate(context);
                         }
@@ -179,7 +179,7 @@ public class EventIntegrator implements Integrator {
                         return;
                     }
                     final RuntimePersistentEntity<Object> entity = entityRegistry.getEntity(mappedClass);
-                    if (entity.hasPreUpdateEventListeners()) {
+                    if (entity.hasPostLoadEventListeners()) {
                         final DefaultEntityEventContext<Object> context = new SimpleHibernateEventContext<>(entity, event.getEntity());
                         entityEventListener.postLoad(context);
                     }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostPersistSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostPersistSpec.groovy
@@ -56,9 +56,11 @@ class EventsPostPersistTestListener {
 
     @Singleton
     PostPersistEventListener<EventIndividualTest> postPersistListener() {
-        return {
-            postPersist++
-            true
+        return new PostPersistEventListener<EventIndividualTest>() {
+            @Override
+            void postPersist(EventIndividualTest entity) {
+                postPersist++
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostPersistSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostPersistSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostPersistEventListener
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPostPersistSpec")
+@Stepwise
+class EventsPostPersistSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPostPersistTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.postPersist == 1
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPostPersistSpec")
+class EventsPostPersistTestListener {
+    private int postPersist = 0
+
+    int getPostPersist() {
+        return postPersist
+    }
+
+    void reset() {
+        postPersist = 0
+    }
+
+    @Singleton
+    PostPersistEventListener<EventIndividualTest> postPersistListener() {
+        return {
+            postPersist++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostRemoveSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostRemoveSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostRemoveEventListener
+import io.micronaut.data.event.listeners.PreRemoveEventListener
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPostRemoveSpec")
+@Stepwise
+class EventsPostRemoveSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPostRemoveTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.postRemove == 0
+    }
+
+    void "test update event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        eventTest.value = 2
+        repo.update(eventTest)
+
+        then:
+        eventTestListener.postRemove == 0
+    }
+
+    void "test remove event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        repo.delete(eventTest)
+
+        then:
+        eventTestListener.postRemove == 1
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPostRemoveSpec")
+class EventsPostRemoveTestListener {
+    private int postRemove = 0
+
+    int getPostRemove() {
+        return postRemove
+    }
+
+
+    void reset() {
+        postRemove = 0
+    }
+
+    @Singleton
+    PostRemoveEventListener<EventIndividualTest> postRemoveEventListener() {
+        return {
+            postRemove++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostRemoveSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostRemoveSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.data.hibernate
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostPersistEventListener
 import io.micronaut.data.event.listeners.PostRemoveEventListener
 import io.micronaut.data.event.listeners.PreRemoveEventListener
 import io.micronaut.data.hibernate.entities.EventIndividualTest
@@ -81,9 +82,11 @@ class EventsPostRemoveTestListener {
 
     @Singleton
     PostRemoveEventListener<EventIndividualTest> postRemoveEventListener() {
-        return {
-            postRemove++
-            true
+        return new PostRemoveEventListener<EventIndividualTest>() {
+            @Override
+            void postRemove(EventIndividualTest entity) {
+                postRemove++
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostUpdateSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostUpdateSpec.groovy
@@ -1,0 +1,88 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostUpdateEventListener
+import io.micronaut.data.event.listeners.PreUpdateEventListener
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPostUpdateSpec")
+@Stepwise
+class EventsPostUpdateSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPostUpdateTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.postUpdate == 0
+    }
+
+    void "test update event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        eventTest.value = 2
+        repo.update(eventTest)
+
+        then:
+        eventTestListener.postUpdate == 1
+    }
+
+    void "test remove event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        repo.delete(eventTest)
+
+        then:
+        eventTestListener.postUpdate == 0
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPostUpdateSpec")
+class EventsPostUpdateTestListener {
+    private int postUpdate = 0
+
+    int getPostUpdate() {
+        return postUpdate
+    }
+
+    void reset() {
+        postUpdate = 0
+    }
+
+    @Singleton
+    PostUpdateEventListener<EventIndividualTest> postUpdateEventListener() {
+        return {
+            postUpdate++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostUpdateSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPostUpdateSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.data.hibernate
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostRemoveEventListener
 import io.micronaut.data.event.listeners.PostUpdateEventListener
 import io.micronaut.data.event.listeners.PreUpdateEventListener
 import io.micronaut.data.hibernate.entities.EventIndividualTest
@@ -80,9 +81,11 @@ class EventsPostUpdateTestListener {
 
     @Singleton
     PostUpdateEventListener<EventIndividualTest> postUpdateEventListener() {
-        return {
-            postUpdate++
-            true
+        return new PostUpdateEventListener<EventIndividualTest>() {
+            @Override
+            void postUpdate(EventIndividualTest entity) {
+                postUpdate++
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPrePersistSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPrePersistSpec.groovy
@@ -56,9 +56,12 @@ class EventsPrePersistTestListener {
 
     @Singleton
     PrePersistEventListener<EventIndividualTest> prePersistListener() {
-        return {
-            prePersist++
-            true
+        return new PrePersistEventListener<EventIndividualTest>() {
+            @Override
+            boolean prePersist(EventIndividualTest entity) {
+                prePersist++
+                true
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPrePersistSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPrePersistSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.*
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPrePersistSpec")
+@Stepwise
+class EventsPrePersistSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPrePersistTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.prePersist == 1
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPrePersistSpec")
+class EventsPrePersistTestListener {
+    private int prePersist = 0
+
+    int getPrePersist() {
+        return prePersist
+    }
+
+    void reset() {
+        prePersist = 0
+    }
+
+    @Singleton
+    PrePersistEventListener<EventIndividualTest> prePersistListener() {
+        return {
+            prePersist++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreRemoveSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreRemoveSpec.groovy
@@ -80,9 +80,12 @@ class EventsPreRemoveTestListener {
 
     @Singleton
     PreRemoveEventListener<EventIndividualTest> preRemoveEventListener() {
-        return {
-            preRemove++
-            true
+        return new PreRemoveEventListener<EventIndividualTest>() {
+            @Override
+            boolean preRemove(EventIndividualTest entity) {
+                preRemove++
+                true
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreRemoveSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreRemoveSpec.groovy
@@ -1,0 +1,88 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.*
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPreRemoveSpec")
+@Stepwise
+class EventsPreRemoveSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPreRemoveTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.preRemove == 0
+    }
+
+    void "test update event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        eventTest.value = 2
+        repo.update(eventTest)
+
+        then:
+        eventTestListener.preRemove == 0
+    }
+
+    void "test remove event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        repo.delete(eventTest)
+
+        then:
+        eventTestListener.preRemove == 1
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPreRemoveSpec")
+class EventsPreRemoveTestListener {
+    private int preRemove = 0
+
+    int getPreRemove() {
+        return preRemove
+    }
+
+
+    void reset() {
+        preRemove = 0
+    }
+
+    @Singleton
+    PreRemoveEventListener<EventIndividualTest> preRemoveEventListener() {
+        return {
+            preRemove++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreUpdateSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreUpdateSpec.groovy
@@ -79,9 +79,12 @@ class EventsPreUpdateTestListener {
 
     @Singleton
     PreUpdateEventListener<EventIndividualTest> preUpdateEventListener() {
-        return {
-            preUpdate++
-            true
+        return new PreUpdateEventListener<EventIndividualTest>() {
+            @Override
+            boolean preUpdate(EventIndividualTest entity) {
+                preUpdate++
+                true
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreUpdateSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsPreUpdateSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.data.hibernate
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.*
+import io.micronaut.data.hibernate.entities.EventIndividualTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@Property(name = "datasources.default.name", value = "mydb")
+@Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsPreUpdateSpec")
+@Stepwise
+class EventsPreUpdateSpec extends Specification {
+
+    @Inject EventIndividualTestRepo repo
+
+    @Inject EventsPreUpdateTestListener eventTestListener
+
+    void setup() {
+        eventTestListener.reset()
+    }
+
+    void "test persist event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+
+        then:
+        eventTest.uuid != null
+        eventTest.dateCreated != null
+        eventTest.dateUpdated == eventTest.dateCreated
+
+        eventTestListener.preUpdate == 0
+    }
+
+    void "test update event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        eventTest.value = 2
+        repo.update(eventTest)
+
+        then:
+        eventTestListener.preUpdate == 1
+    }
+
+    void "test remove event"() {
+        given:
+        def eventTest = new EventIndividualTest(1)
+        when:
+        repo.save(eventTest)
+        repo.delete(eventTest)
+
+        then:
+        eventTestListener.preUpdate == 0
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsPreUpdateSpec")
+class EventsPreUpdateTestListener {
+    private int preUpdate = 0
+
+    int getPreUpdate() {
+        return preUpdate
+    }
+
+    void reset() {
+        preUpdate = 0
+    }
+
+    @Singleton
+    PreUpdateEventListener<EventIndividualTest> preUpdateEventListener() {
+        return {
+            preUpdate++
+            true
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
@@ -9,7 +9,6 @@ import io.micronaut.data.event.listeners.PostUpdateEventListener
 import io.micronaut.data.event.listeners.PrePersistEventListener
 import io.micronaut.data.event.listeners.PreRemoveEventListener
 import io.micronaut.data.event.listeners.PreUpdateEventListener
-import io.micronaut.data.hibernate.entities.EventIndividualTest
 import io.micronaut.data.hibernate.entities.EventTest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Singleton
@@ -164,10 +163,10 @@ class EventTestListeners {
     }
 
     @Singleton
-    PrePersistEventListener<EventIndividualTest> prePersistListener() {
-        return new PrePersistEventListener<EventIndividualTest>() {
+    PrePersistEventListener<EventTest> prePersistListener() {
+        return new PrePersistEventListener<EventTest>() {
             @Override
-            boolean prePersist(EventIndividualTest entity) {
+            boolean prePersist(EventTest entity) {
                 prePersist++
                 true
             }
@@ -175,20 +174,20 @@ class EventTestListeners {
     }
 
     @Singleton
-    PostPersistEventListener<EventIndividualTest> postPersistListener() {
-        return new PostPersistEventListener<EventIndividualTest>() {
+    PostPersistEventListener<EventTest> postPersistListener() {
+        return new PostPersistEventListener<EventTest>() {
             @Override
-            void postPersist(EventIndividualTest entity) {
+            void postPersist(EventTest entity) {
                 postPersist++
             }
         }
     }
 
     @Singleton
-    PreUpdateEventListener<EventIndividualTest> preUpdateEventListener() {
-        return new PreUpdateEventListener<EventIndividualTest>() {
+    PreUpdateEventListener<EventTest> preUpdateEventListener() {
+        return new PreUpdateEventListener<EventTest>() {
             @Override
-            boolean preUpdate(EventIndividualTest entity) {
+            boolean preUpdate(EventTest entity) {
                 preUpdate++
                 true
             }
@@ -196,20 +195,20 @@ class EventTestListeners {
     }
 
     @Singleton
-    PostUpdateEventListener<EventIndividualTest> postUpdateEventListener() {
-        return new PostUpdateEventListener<EventIndividualTest>() {
+    PostUpdateEventListener<EventTest> postUpdateEventListener() {
+        return new PostUpdateEventListener<EventTest>() {
             @Override
-            void postUpdate(EventIndividualTest entity) {
+            void postUpdate(EventTest entity) {
                 postUpdate++
             }
         }
     }
 
     @Singleton
-    PreRemoveEventListener<EventIndividualTest> preRemoveEventListener() {
-        return new PreRemoveEventListener<EventIndividualTest>() {
+    PreRemoveEventListener<EventTest> preRemoveEventListener() {
+        return new PreRemoveEventListener<EventTest>() {
             @Override
-            boolean preRemove(EventIndividualTest entity) {
+            boolean preRemove(EventTest entity) {
                 preRemove++
                 true
             }
@@ -217,10 +216,10 @@ class EventTestListeners {
     }
 
     @Singleton
-    PostRemoveEventListener<EventIndividualTest> postRemoveEventListener() {
-        return new PostRemoveEventListener<EventIndividualTest>() {
+    PostRemoveEventListener<EventTest> postRemoveEventListener() {
+        return new PostRemoveEventListener<EventTest>() {
             @Override
-            void postRemove(EventIndividualTest entity) {
+            void postRemove(EventTest entity) {
                 postRemove++
             }
         }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
@@ -1,8 +1,17 @@
 package io.micronaut.data.hibernate
 
+import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.event.listeners.PostPersistEventListener
+import io.micronaut.data.event.listeners.PostRemoveEventListener
+import io.micronaut.data.event.listeners.PostUpdateEventListener
+import io.micronaut.data.event.listeners.PrePersistEventListener
+import io.micronaut.data.event.listeners.PreRemoveEventListener
+import io.micronaut.data.event.listeners.PreUpdateEventListener
 import io.micronaut.data.hibernate.entities.EventTest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Singleton
 import spock.lang.Specification
 import spock.lang.Stepwise
 
@@ -11,14 +20,21 @@ import jakarta.inject.Inject
 @MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
 @Property(name = "datasources.default.name", value = "mydb")
 @Property(name = 'jpa.default.properties.hibernate.hbm2ddl.auto', value = 'create-drop')
+@Property(name = "spec.name", value = "EventsSpec")
 @Stepwise
 class EventsSpec extends Specification {
 
     @Inject EventTestRepo repo
 
-    void "test pre-persist event"() {
+    @Inject EventTestListeners eventTestListeners
+
+    void setup() {
+        eventTestListeners.reset()
+    }
+
+    void "test persist event"() {
         given:
-        def eventTest = new EventTest()
+        def eventTest = new EventTest(1)
         when:
         repo.save(eventTest)
 
@@ -26,10 +42,171 @@ class EventsSpec extends Specification {
         eventTest.uuid != null
         eventTest.dateCreated != null
         eventTest.dateUpdated == eventTest.dateCreated
+
         eventTest.prePersist == 1
         eventTest.postPersist == 1
         eventTest.preRemove == 0
+        eventTest.postRemove == 0
         eventTest.preUpdate == 0
         eventTest.preUpdate == 0
+        eventTest.postLoad == 0
+
+        eventTestListeners.prePersist == 1
+        eventTestListeners.postPersist == 1
+        eventTestListeners.preUpdate == 0
+        eventTestListeners.postUpdate == 0
+        eventTestListeners.preRemove == 0
+        eventTestListeners.postRemove == 0
+    }
+
+    void "test update event"() {
+        given:
+        def eventTest = new EventTest(1)
+        when:
+        repo.save(eventTest)
+        eventTest.value = 2
+        def eventTestDetachedUpdate =repo.update(eventTest)
+
+        then:
+        eventTest.prePersist == 1
+        eventTest.postPersist == 1
+        eventTest.preRemove == 0
+        eventTest.postRemove == 0
+        eventTest.preUpdate == 0
+        eventTest.preUpdate == 0
+        eventTest.postLoad == 0
+
+        // Update listeners are run on the new entity post-update. Essentially, Hibernate detaches the original
+        // persisted entity, and then the update re-loads a whole new entity before performing the update operation.
+        eventTestDetachedUpdate.prePersist == 0
+        eventTestDetachedUpdate.postPersist == 0
+        eventTestDetachedUpdate.preRemove == 0
+        eventTestDetachedUpdate.preUpdate == 1
+        eventTestDetachedUpdate.postUpdate == 1
+        eventTestDetachedUpdate.postLoad == 1
+
+        eventTestListeners.prePersist == 1
+        eventTestListeners.postPersist == 1
+        eventTestListeners.preUpdate == 1
+        eventTestListeners.postUpdate == 1
+        eventTestListeners.preRemove == 0
+        eventTestListeners.postRemove == 0
+    }
+
+    void "test remove event"() {
+        given:
+        def eventTest = new EventTest(1)
+        when:
+        repo.save(eventTest)
+        repo.delete(eventTest)
+
+        then:
+        // Remove listeners are run on the original detached event.
+        eventTest.prePersist == 1
+        eventTest.postPersist == 1
+        eventTest.preRemove == 1
+        eventTest.postRemove == 1
+        eventTest.preUpdate == 0
+        eventTest.preUpdate == 0
+        eventTest.postLoad == 0
+
+        eventTestListeners.prePersist == 1
+        eventTestListeners.postPersist == 1
+        eventTestListeners.preUpdate == 0
+        eventTestListeners.postUpdate == 0
+        eventTestListeners.preRemove == 1
+        eventTestListeners.postRemove == 1
+    }
+}
+
+@Factory
+@Requires(property = "spec.name", value = "EventsSpec")
+class EventTestListeners {
+    private int prePersist = 0
+    private int postPersist = 0
+    private int preUpdate = 0
+    private int postUpdate = 0
+    private int preRemove = 0
+    private int postRemove = 0
+
+    int getPrePersist() {
+        return prePersist
+    }
+
+    int getPostPersist() {
+        return postPersist
+    }
+
+    int getPreUpdate() {
+        return preUpdate
+    }
+
+    int getPostUpdate() {
+        return postUpdate
+    }
+
+    int getPreRemove() {
+        return preRemove
+    }
+
+    int getPostRemove() {
+        return postRemove
+    }
+
+    void reset() {
+        prePersist = 0
+        postPersist = 0
+        preUpdate = 0
+        postUpdate = 0
+        preRemove = 0
+        postRemove = 0
+    }
+
+    @Singleton
+    PrePersistEventListener<EventTest> prePersistListener() {
+        return {
+            prePersist++
+            true
+        }
+    }
+
+    @Singleton
+    PostPersistEventListener<EventTest> postPersistListener() {
+        return {
+            postPersist++
+            true
+        }
+    }
+
+    @Singleton
+    PreUpdateEventListener<EventTest> preUpdateEventListener() {
+        return {
+            preUpdate++
+            true
+        }
+    }
+
+    @Singleton
+    PostUpdateEventListener<EventTest> postUpdateEventListener() {
+        return {
+            postUpdate++
+            true
+        }
+    }
+
+    @Singleton
+    PreRemoveEventListener<EventTest> preRemoveEventListener() {
+        return {
+            preRemove++
+            true
+        }
+    }
+
+    @Singleton
+    PostRemoveEventListener<EventTest> postRemoveEventListener() {
+        return {
+            postRemove++
+            true
+        }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
@@ -65,7 +65,7 @@ class EventsSpec extends Specification {
         when:
         repo.save(eventTest)
         eventTest.value = 2
-        def eventTestDetachedUpdate =repo.update(eventTest)
+        def eventTestDetachedUpdate = repo.update(eventTest)
 
         then:
         eventTest.prePersist == 1

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/EventsSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.data.event.listeners.PostUpdateEventListener
 import io.micronaut.data.event.listeners.PrePersistEventListener
 import io.micronaut.data.event.listeners.PreRemoveEventListener
 import io.micronaut.data.event.listeners.PreUpdateEventListener
+import io.micronaut.data.hibernate.entities.EventIndividualTest
 import io.micronaut.data.hibernate.entities.EventTest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Singleton
@@ -163,50 +164,65 @@ class EventTestListeners {
     }
 
     @Singleton
-    PrePersistEventListener<EventTest> prePersistListener() {
-        return {
-            prePersist++
-            true
+    PrePersistEventListener<EventIndividualTest> prePersistListener() {
+        return new PrePersistEventListener<EventIndividualTest>() {
+            @Override
+            boolean prePersist(EventIndividualTest entity) {
+                prePersist++
+                true
+            }
         }
     }
 
     @Singleton
-    PostPersistEventListener<EventTest> postPersistListener() {
-        return {
-            postPersist++
-            true
+    PostPersistEventListener<EventIndividualTest> postPersistListener() {
+        return new PostPersistEventListener<EventIndividualTest>() {
+            @Override
+            void postPersist(EventIndividualTest entity) {
+                postPersist++
+            }
         }
     }
 
     @Singleton
-    PreUpdateEventListener<EventTest> preUpdateEventListener() {
-        return {
-            preUpdate++
-            true
+    PreUpdateEventListener<EventIndividualTest> preUpdateEventListener() {
+        return new PreUpdateEventListener<EventIndividualTest>() {
+            @Override
+            boolean preUpdate(EventIndividualTest entity) {
+                preUpdate++
+                true
+            }
         }
     }
 
     @Singleton
-    PostUpdateEventListener<EventTest> postUpdateEventListener() {
-        return {
-            postUpdate++
-            true
+    PostUpdateEventListener<EventIndividualTest> postUpdateEventListener() {
+        return new PostUpdateEventListener<EventIndividualTest>() {
+            @Override
+            void postUpdate(EventIndividualTest entity) {
+                postUpdate++
+            }
         }
     }
 
     @Singleton
-    PreRemoveEventListener<EventTest> preRemoveEventListener() {
-        return {
-            preRemove++
-            true
+    PreRemoveEventListener<EventIndividualTest> preRemoveEventListener() {
+        return new PreRemoveEventListener<EventIndividualTest>() {
+            @Override
+            boolean preRemove(EventIndividualTest entity) {
+                preRemove++
+                true
+            }
         }
     }
 
     @Singleton
-    PostRemoveEventListener<EventTest> postRemoveEventListener() {
-        return {
-            postRemove++
-            true
+    PostRemoveEventListener<EventIndividualTest> postRemoveEventListener() {
+        return new PostRemoveEventListener<EventIndividualTest>() {
+            @Override
+            void postRemove(EventIndividualTest entity) {
+                postRemove++
+            }
         }
     }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/event/EventIntegratorSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/event/EventIntegratorSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.data.hibernate.event
+
+class EventIntegratorSpec {
+}

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/event/EventIntegratorSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/event/EventIntegratorSpec.groovy
@@ -1,4 +1,0 @@
-package io.micronaut.data.hibernate.event
-
-class EventIntegratorSpec {
-}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/EventIndividualTestRepo.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/EventIndividualTestRepo.java
@@ -1,0 +1,10 @@
+package io.micronaut.data.hibernate;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.hibernate.entities.EventIndividualTest;
+import io.micronaut.data.hibernate.entities.EventTest;
+import io.micronaut.data.repository.CrudRepository;
+
+@Repository
+public interface EventIndividualTestRepo extends CrudRepository<EventIndividualTest, Long> {
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/EventIndividualTest.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/EventIndividualTest.java
@@ -1,0 +1,72 @@
+package io.micronaut.data.hibernate.entities;
+
+import io.micronaut.data.annotation.AutoPopulated;
+import io.micronaut.data.annotation.DateCreated;
+import io.micronaut.data.annotation.DateUpdated;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// This Entity comes with no listeners to test the behavior of individual EntityEventListener
+// interface implementations
+@Entity
+public class EventIndividualTest {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    @AutoPopulated
+    private UUID uuid;
+
+    @DateCreated
+    private LocalDateTime dateCreated;
+
+    @DateUpdated
+    private LocalDateTime dateUpdated;
+
+    private int value;
+
+    public EventIndividualTest(int value) {
+        this.value = value;
+    }
+
+    public EventIndividualTest() {
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getDateCreated() {
+        return dateCreated;
+    }
+
+    public void setDateCreated(LocalDateTime dateCreated) {
+        this.dateCreated = dateCreated;
+    }
+
+    public LocalDateTime getDateUpdated() {
+        return dateUpdated;
+    }
+
+    public void setDateUpdated(LocalDateTime dateUpdated) {
+        this.dateUpdated = dateUpdated;
+    }
+
+    public void setValue(int value) { this.value = value; }
+
+    public int getValue() { return value; }
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/EventTest.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/EventTest.java
@@ -23,6 +23,15 @@ public class EventTest {
     @DateUpdated
     private LocalDateTime dateUpdated;
 
+    private int value;
+
+    public EventTest(int value) {
+        this.value = value;
+    }
+
+    public EventTest() {
+    }
+
     public UUID getUuid() {
         return uuid;
     }
@@ -55,6 +64,11 @@ public class EventTest {
         this.dateUpdated = dateUpdated;
     }
 
+    public void setValue(int value) { this.value = value; }
+
+    public int getValue() { return value; }
+
+    @Transient
     private int prePersist;
     @PrePersist
     public void prePersist() {


### PR DESCRIPTION
Pretty straightforward, the `EventType.POST_DELETE` listener group should check for `hasPostRemoveEventListeners` instead of `hasPostPersistEventListeners`. Currently the only workaround to this bug is to implement a no-op post persist listener.

I also found similar issues with `EventType.POST_UPDATE` and `EventType.POST_LOAD`. 

~That said, does this need any tests to go along with it?~