### PR TITLE
Properties annotated with JPA transient should not be excluded from introspections by default

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/mappers/MappedEntityMapper.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/mappers/MappedEntityMapper.java
@@ -50,8 +50,6 @@ public class MappedEntityMapper implements TypedAnnotationMapper<MappedEntity> {
      */
     public static AnnotationValue<Introspected> buildIntrospectionConfiguration() {
         final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class)
-                // don't bother with transients properties
-                .member("excludedAnnotations", Transient.class)
                 // following are indexed for fast lookups
                 .member("indexed",
                         AnnotationValue.builder(Introspected.IndexedAnnotation.class)

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/groovy/GroovyEntityAnnotationMapperSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/groovy/GroovyEntityAnnotationMapperSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.data.processor.groovy
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.MappedProperty
+import io.micronaut.data.processor.model.SourcePersistentEntity
 
 class GroovyEntityAnnotationMapperSpec extends AbstractBeanDefinitionSpec {
 
@@ -73,10 +74,167 @@ class Test {
         def indexes = introspection.getAnnotation("io.micronaut.data.annotation.Indexes")
         indexes
         indexes.getValues().isEmpty()
-        !introspection.getProperty("tmp").isPresent()
+        introspection.getProperty("tmp").isPresent()
         introspection.getIndexedProperty(io.micronaut.data.annotation.Id).isPresent()
         introspection.getIndexedProperty(io.micronaut.data.annotation.Id).get().name == 'id'
         introspection.getIndexedProperty(MappedProperty, "test_name").isPresent()
         introspection.getIndexedProperty(MappedProperty, "test_name").get().name == 'name'
+    }
+
+    void "test groovy mapping jakarta.persistent entity with empty indexes"() {
+        given:
+        def introspection = buildBeanIntrospection('test.Test', '''
+package test
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name="test_tb1", indexes = [])
+class Test {
+    private String name
+    @Id
+    private Long id
+    @Transient
+    private String tmp
+
+    @Column(name="test_name")
+    String getName() {
+        return name
+    }
+
+    void setName(String name) {
+        this.name = name
+    }
+
+
+    Long getId() {
+        return id
+    }
+
+    void setId(Long id) {
+        this.id = id
+    }
+
+    String getTmp() {
+        return tmp
+    }
+
+    void setTmp(String tmp) {
+        this.tmp = tmp
+    }
+}
+
+''')
+        expect:
+        introspection != null
+        introspection.hasStereotype(MappedEntity)
+        introspection.getPropertyNames()
+        introspection.getValue(MappedEntity, String).get() == 'test_tb1'
+        def indexes = introspection.getAnnotation("io.micronaut.data.annotation.Indexes")
+        indexes
+        indexes.getValues().isEmpty()
+        introspection.getProperty("tmp").isPresent()
+        introspection.getIndexedProperty(io.micronaut.data.annotation.Id).isPresent()
+        introspection.getIndexedProperty(io.micronaut.data.annotation.Id).get().name == 'id'
+        introspection.getIndexedProperty(MappedProperty, "test_name").isPresent()
+        introspection.getIndexedProperty(MappedProperty, "test_name").get().name == 'name'
+    }
+
+    void "test groovy mapping javax.persistent entity with empty indexes SourcePersistentEntity"() {
+        given:
+        def test = buildClassElement('test.Test', '''
+package test
+
+import javax.persistence.*
+
+@Entity
+@Table(name="test_tb1", indexes = [])
+class Test {
+    private String name
+    @Id
+    private Long id
+    @Transient
+    private String tmp
+
+    @Column(name="test_name")
+    String getName() {
+        return name
+    }
+
+    void setName(String name) {
+        this.name = name
+    }
+
+
+    Long getId() {
+        return id
+    }
+
+    void setId(Long id) {
+        this.id = id
+    }
+
+    String getTmp() {
+        return tmp
+    }
+
+    void setTmp(String tmp) {
+        this.tmp = tmp
+    }
+}
+
+''')
+        expect:
+        SourcePersistentEntity persistentEntity = new SourcePersistentEntity(test, (te) -> null)
+        persistentEntity.getPersistentPropertyNames() == ["name", "id"]
+    }
+
+    void "test groovy mapping jakarta.persistent entity with empty indexes SourcePersistentEntity"() {
+        given:
+        def test = buildClassElement('test.Test', '''
+package test
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name="test_tb1", indexes = [])
+class Test {
+    private String name
+    @Id
+    private Long id
+    @Transient
+    private String tmp
+
+    @Column(name="test_name")
+    String getName() {
+        return name
+    }
+
+    void setName(String name) {
+        this.name = name
+    }
+
+
+    Long getId() {
+        return id
+    }
+
+    void setId(Long id) {
+        this.id = id
+    }
+
+    String getTmp() {
+        return tmp
+    }
+
+    void setTmp(String tmp) {
+        this.tmp = tmp
+    }
+}
+
+''')
+        expect:
+        SourcePersistentEntity persistentEntity = new SourcePersistentEntity(test, (te) -> null)
+        persistentEntity.getPersistentPropertyNames() == ["name", "id"]
     }
 }


### PR DESCRIPTION
…ntrospections by default

This fixes the consequences from https://github.com/micronaut-projects/micronaut-core/pull/8072 and was done following https://github.com/micronaut-projects/micronaut-core/discussions/8052

Determining the persistent properties by filtering by the introspection properties that do not have the Transient annotation.