### PR TITLE
#1772 accept empty list in CrudRepository.saveAll

### DIFF
--- a/data-document-tck/src/main/groovy/io/micronaut/data/document/tck/AbstractDocumentRepositorySpec.groovy
+++ b/data-document-tck/src/main/groovy/io/micronaut/data/document/tck/AbstractDocumentRepositorySpec.groovy
@@ -807,6 +807,17 @@ abstract class AbstractDocumentRepositorySpec extends Specification {
             studentRepository.deleteAll()
     }
 
+    def "test save all with empty collection"() {
+        given:
+        personRepository.deleteAll()
+
+        when:
+        personRepository.saveAll([])
+
+        then:
+        personRepository.count() == 0
+    }
+
     def "test batch optimistic locking"() {
         given:
             def student1 = new Student("Denis")

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2EmbeddedSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2EmbeddedSpec.groovy
@@ -15,7 +15,6 @@
  */
 package io.micronaut.data.jdbc.h2
 
-
 import io.micronaut.data.tck.entities.Address
 import io.micronaut.data.tck.entities.Restaurant
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -32,7 +31,7 @@ class H2EmbeddedSpec extends Specification {
     @Shared
     H2RestaurantRepository restaurantRepository
 
-    void "test save and retreive entity with embedded"() {
+    void "test save and retrieve entity with embedded"() {
         when:"An entity is saved"
         restaurantRepository.save(new Restaurant("Fred's Cafe", new Address("High St.", "7896")))
         def restaurant = restaurantRepository.save(new Restaurant("Joe's Cafe", new Address("Smith St.", "1234")))

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultReactiveMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultReactiveMongoRepositoryOperations.java
@@ -1009,6 +1009,9 @@ public class DefaultReactiveMongoRepositoryOperations extends AbstractMongoRepos
             protected void execute() throws RuntimeException {
                 entities = entities.collectList().flatMapMany(data -> {
                     List<T> toInsert = data.stream().filter(d -> !d.vetoed).map(d -> d.entity).collect(Collectors.toList());
+                    if (toInsert.isEmpty()) {
+                        return Flux.fromIterable(data);
+                    }
 
                     MongoCollection<T> collection = getCollection(persistentEntity, ctx.repositoryType);
                     if (QUERY_LOG.isDebugEnabled()) {

--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoEmbeddedSpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoEmbeddedSpec.groovy
@@ -35,7 +35,7 @@ class MongoEmbeddedSpec extends Specification implements MongoTestPropertyProvid
         restaurantRepository.deleteAll()
     }
 
-    void "test save and retreive entity with embedded"() {
+    void "test save and retrieve entity with embedded"() {
         when:"An entity is saved"
         restaurantRepository.save(new Restaurant("Fred's Cafe", new Address("High St.", "7896")))
         def restaurant = restaurantRepository.save(new Restaurant("Joe's Cafe", new Address("Smith St.", "1234")))

--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoEmbeddedSpec2.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoEmbeddedSpec2.groovy
@@ -45,7 +45,7 @@ class MongoEmbeddedSpec2 extends Specification implements MongoTestPropertyProvi
         restaurantRepository.deleteAll()
     }
 
-    void "test save and retreive entity with embedded"() {
+    void "test save and retrieve entity with embedded"() {
         when:"An entity is saved"
         restaurantRepository.saveAll([new Restaurant2("Fred's Cafe", new Address2("High St.", "7896"))])
         def restaurant = restaurantRepository.save(new Restaurant2("Joe's Cafe", new Address2("Smith St.", "1234")))

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractReactiveEntitiesOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractReactiveEntitiesOperations.java
@@ -75,9 +75,6 @@ public abstract class AbstractReactiveEntitiesOperations<Ctx extends OperationCo
         this.insert = insert;
         this.hasGeneratedId = insert && persistentEntity.getIdentity() != null && persistentEntity.getIdentity().isGenerated();
         Objects.requireNonNull(entities, "Entities cannot be null");
-        if (!entities.iterator().hasNext()) {
-            throw new IllegalStateException("Entities cannot be empty");
-        }
         this.entities = Flux.fromIterable(entities).map(entity -> {
             Data data = new Data();
             data.entity = entity;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
@@ -79,9 +79,6 @@ public abstract class AbstractSyncEntitiesOperations<Ctx extends OperationContex
         this.insert = insert;
         this.hasGeneratedId = insert && persistentEntity.getIdentity() != null && persistentEntity.getIdentity().isGenerated();
         Objects.requireNonNull(entities, "Entities cannot be null");
-        if (!entities.iterator().hasNext()) {
-            throw new IllegalStateException("Entities cannot be empty");
-        }
         Stream<T> stream;
         if (entities instanceof Collection) {
             stream = ((Collection) entities).stream();

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractAsyncRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractAsyncRepositorySpec.groovy
@@ -99,7 +99,7 @@ abstract class AbstractAsyncRepositorySpec extends Specification {
         def p2 = personRepository.save("Bob", 0).get()
         def people = [p1,p2]
 
-        then:"all are saved"
+        then: "all are saved"
         people.every { it.id != null }
         people.every { personRepository.findById(it.id).get() != null }
         personRepository.findAll().get().size() == 4
@@ -107,6 +107,17 @@ abstract class AbstractAsyncRepositorySpec extends Specification {
         personRepository.count("Jeff").get() == 1
         personRepository.list(Pageable.from(1)).get().isEmpty()
         personRepository.list(Pageable.from(0, 1)).get().size() == 1
+    }
+
+    def "test save all with empty collection"() {
+        given:
+        personRepository.deleteAll().get()
+
+        when:
+        personRepository.saveAll([]).get()
+
+        then:
+        personRepository.count().get() == 0
     }
 
     void "test update many"() {

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractReactiveRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractReactiveRepositorySpec.groovy
@@ -402,14 +402,25 @@ abstract class AbstractReactiveRepositorySpec extends Specification {
             def e = thrown(Exception)
             e.message.contains "Execute update returned unexpected row count. Expected: 2 got: 1"
         when:
-            student1 = studentRepository.findById(student1.getId()).blockingGet()
-            student2 = studentRepository.findById(student2.getId()).blockingGet()
-            student1.setVersion(5)
-            e = studentRepository.deleteAll([student1, student2]).blockingGet()
+        student1 = studentRepository.findById(student1.getId()).blockingGet()
+        student2 = studentRepository.findById(student2.getId()).blockingGet()
+        student1.setVersion(5)
+        e = studentRepository.deleteAll([student1, student2]).blockingGet()
         then:
-            e.message.contains "Execute update returned unexpected row count. Expected: 2 got: 1"
+        e.message.contains "Execute update returned unexpected row count. Expected: 2 got: 1"
         cleanup:
-            studentRepository.deleteAll().blockingGet()
+        studentRepository.deleteAll().blockingGet()
+    }
+
+    def "test save all with empty collection"() {
+        given:
+        personRepository.deleteAll().block()
+
+        when:
+        personRepository.saveAll([]).collectList().block()
+
+        then:
+        personRepository.count().block() == 0
     }
 
     void "test custom delete"() {
@@ -419,7 +430,7 @@ abstract class AbstractReactiveRepositorySpec extends Specification {
 
         when:
         def people = personRepository.findAll().collectList().block()
-        people.findAll {it.name == "Dennis"}.forEach{ it.name = "DoNotDelete"}
+        people.findAll { it.name == "Dennis" }.forEach { it.name = "DoNotDelete" }
         def deleted = personRepository.deleteCustom(people).block()
         people = personRepository.findAll().collectList().block()
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -563,6 +563,17 @@ abstract class AbstractRepositorySpec extends Specification {
         personRepository.list(Pageable.from(0, 1)).size() == 1
     }
 
+    void "test save all with empty collection"() {
+        given:
+        personRepository.deleteAll()
+
+        when:
+        personRepository.saveAll([])
+
+        then:
+        personRepository.count() == 0
+    }
+
     void "save entity using repository method with different mapped entity argument"() {
         given:
             Author author = authorRepository.save(new Author().with(true, {it.name = "Kartarka Jolanda"}))


### PR DESCRIPTION
This PR removes the "list not empty" assertion in the base classes AbstractSyncEntitiesOperations and AbstractReactiveEntitiesOperations.
Some implementations of that base classes already had a short circuit to exit early if no work needs to be done because the list is empty.

With this PR the following implementations now accept empty lists:

- MongoReactiveEntitiesOperation (short circuit added in "save all")
- JdbcEntitiesOperations (no short circuit in "save all")
- MongoEntitiesOperation (short circuit existed in "save all")
- R2dbcEntitiesOperations (short circuit existed in "save all")

Related issue #1772