### PR TITLE
Performance improvements

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -127,7 +127,6 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
             this.constructorArguments[i] = prop;
         }
         this.aliasName = super.getAliasName();
-        this.cascadedTypes = cascades(this);
     }
 
     private static EnumSet<Relation.Cascade> cascades(RuntimePersistentEntity<?> persistentEntity) {
@@ -168,7 +167,7 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
      * @return True if it does
      */
     public boolean cascadesPersist() {
-        return cascadedTypes.contains(Relation.Cascade.PERSIST);
+        return getCascadedTypes().contains(Relation.Cascade.PERSIST);
     }
 
     /**
@@ -177,7 +176,14 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
      * @return True if it does
      */
     public boolean cascadesUpdate() {
-        return cascadedTypes.contains(Relation.Cascade.UPDATE);
+        return getCascadedTypes().contains(Relation.Cascade.UPDATE);
+    }
+
+    private EnumSet<Relation.Cascade> getCascadedTypes() {
+        if (cascadedTypes == null) {
+            cascadedTypes = cascades(this);
+        }
+        return cascadedTypes;
     }
 
     /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/BaseOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/BaseOperations.java
@@ -77,10 +77,15 @@ abstract class BaseOperations<T, Exc extends Exception> {
             if (vetoed) {
                 return;
             }
-            cascadePre(Relation.Cascade.PERSIST);
+            boolean cascades = persistentEntity.cascadesPersist();
+            if (cascades) {
+                cascadePre(Relation.Cascade.PERSIST);
+            }
             execute();
             triggerPostPersist();
-            cascadePost(Relation.Cascade.PERSIST);
+            if (cascades) {
+                cascadePost(Relation.Cascade.PERSIST);
+            }
         } catch (Exception e) {
             failed(e, "PERSIST");
         }
@@ -116,10 +121,15 @@ abstract class BaseOperations<T, Exc extends Exception> {
             return;
         }
         try {
-            cascadePre(Relation.Cascade.UPDATE);
+            boolean cascades = persistentEntity.cascadesUpdate();
+            if (cascades) {
+                cascadePre(Relation.Cascade.UPDATE);
+            }
             execute();
             triggerPostUpdate();
-            cascadePost(Relation.Cascade.UPDATE);
+            if (cascades) {
+                cascadePost(Relation.Cascade.UPDATE);
+            }
         } catch (OptimisticLockException ex) {
             throw ex;
         } catch (Exception e) {


### PR DESCRIPTION
This PR adds a check for the cascading and a way to avoid triggering it, and for the reactive code, batch operations are processed as `Mono<List>` instead of `Flux`. There were already processed as lists but operations like cascade and pre/post were using `map` operator per item.