### PR TITLE
Fix for TransactionEventListener AFTER_COMPLETION never fires

### DIFF
--- a/data-tx/src/main/java/io/micronaut/transaction/interceptor/TransactionalEventInterceptor.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/interceptor/TransactionalEventInterceptor.java
@@ -103,12 +103,12 @@ public class TransactionalEventInterceptor implements MethodInterceptor<Object, 
                     public void afterCompletion(@NonNull Status status) {
                         switch (status) {
                             case ROLLED_BACK:
-                                if (phase == TransactionalEventListener.TransactionPhase.AFTER_ROLLBACK) {
+                                if (phase == TransactionalEventListener.TransactionPhase.AFTER_ROLLBACK || phase == TransactionalEventListener.TransactionPhase.AFTER_COMPLETION) {
                                     context.proceed();
                                 }
                                 break;
                             case COMMITTED:
-                                if (phase == TransactionalEventListener.TransactionPhase.AFTER_COMMIT) {
+                                if (phase == TransactionalEventListener.TransactionPhase.AFTER_COMMIT || phase == TransactionalEventListener.TransactionPhase.AFTER_COMPLETION) {
                                     context.proceed();
                                 }
                                 break;


### PR DESCRIPTION
Potential fix for #1819 
I am not quite sure this is proper way to fix this, but it looks like it is according to the test I created. It checks whether each rollback/commit matches number of completion calls.