### PR TITLE
Kotlin methods returning `Flow` shouldn't be suspended

### DIFF
--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
@@ -36,7 +36,7 @@ interface CoroutinePageableCrudRepository<E, ID> : CoroutineCrudRepository<E, ID
      * @param sort The sort
      * @return The results publisher
      */
-    suspend fun findAll(sort: Sort): Flow<E>
+    fun findAll(sort: Sort): Flow<E>
 
     /**
      * Finds all records for the given pageable.


### PR DESCRIPTION
Fixes #1836