### PR TITLE
Multitenancy docs

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
@@ -52,6 +52,8 @@ import io.micronaut.data.runtime.convert.DataConversionService;
 import io.micronaut.data.runtime.date.DateTimeProvider;
 import io.micronaut.data.runtime.mapper.QueryStatement;
 import io.micronaut.data.runtime.mapper.ResultReader;
+import io.micronaut.data.runtime.multitenancy.MultiTenancyMode;
+import io.micronaut.data.runtime.multitenancy.conf.MultiTenancyConfiguration;
 import io.micronaut.data.runtime.operations.internal.AbstractRepositoryOperations;
 import io.micronaut.data.runtime.query.MethodContextAwareStoredQueryDecorator;
 import io.micronaut.data.runtime.query.PreparedQueryDecorator;
@@ -134,9 +136,11 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
         this.preparedStatementWriter = preparedStatementWriter;
         Collection<BeanDefinition<GenericRepository>> beanDefinitions = beanContext
                 .getBeanDefinitions(GenericRepository.class, Qualifiers.byStereotype(Repository.class));
+        MultiTenancyConfiguration multiTenancyConfiguration = beanContext
+            .getBean(MultiTenancyConfiguration.class);
         for (BeanDefinition<GenericRepository> beanDefinition : beanDefinitions) {
             String targetDs = beanDefinition.stringValue(Repository.class).orElse("default");
-            if (targetDs.equalsIgnoreCase(dataSourceName)) {
+            if (targetDs.equalsIgnoreCase(dataSourceName) || MultiTenancyMode.DATASOURCE.equals(multiTenancyConfiguration.getMode())) {
                 Class<GenericRepository> beanType = beanDefinition.getBeanType();
                 SqlQueryBuilder queryBuilder = new SqlQueryBuilder(beanDefinition.getAnnotationMetadata());
                 queryBuilders.put(beanType, queryBuilder);

--- a/src/main/docs/guide/multitenancy.adoc
+++ b/src/main/docs/guide/multitenancy.adoc
@@ -1,0 +1,70 @@
+Micronaut Data supports multi-tenancy to allow the use of multiple databases or schemas by a single micronaut application.
+
+.Supported Multitenancy Modes
+[cols=2*]
+|===
+|*Mode*
+|*Description*
+
+|DATASOURCE
+|Use different repositories and datasources. Transaction Manager is used based on the tenant defined.
+
+|SCHEMA
+|Only supported by JDBC/R2DBC/MongoDB (collections)
+
+|===
+
+=== Datasource Mode
+The DATASOURCE mode is used in combination with the micronaut-multitenancy library in order to resolve the tenant name.
+In the below example, the tenant resolver is set to use an http header. See https://micronaut-projects.github.io/micronaut-multitenancy/latest/guide/[Micronaut Multitenancy] for more information.
+
+[source,yaml]
+----
+micronaut:
+  data:
+    multi-tenancy:
+      mode: DATASOURCE
+  multitenancy:
+    tenantresolver:
+      httpheader:
+        enabled: true
+
+datasources:
+  tenantA:
+    url: jdbc:h2:mem:dbTenantA
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+    schema-generate: CREATE_DROP
+    dialect: H2
+  tenantB:
+    url: jdbc:h2:mem:dbTenantB
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+    schema-generate: CREATE_DROP
+    dialect: H2
+----
+
+=== Schema Mode
+The SCHEMA mode uses a single datasource and set the active schema based on the tenant resolved.
+
+[source,yaml]
+----
+micronaut:
+  data:
+    multi-tenancy:
+      mode: SCHEMA
+  multitenancy:
+    tenantresolver:
+      httpheader:
+        enabled: true
+
+datasources:
+  default:
+    url: jdbc:h2:mem:db
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+    dialect: H2
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -37,7 +37,7 @@ hibernate:
   hibernateJpaAnnotations: JPA Annotations
   hibernateQuickStart:
     title: Quick Start
-  hibernateLogging: Logging SQL with Micronaut Data JPA Hibernate    
+  hibernateLogging: Logging SQL with Micronaut Data JPA Hibernate
   hibernateJoinQueries: Join queries
   hibernateExplicitQueries: Explicit queries
   hibernateNativeQueries: Native queries
@@ -132,5 +132,7 @@ graal:
   title: Going Native with GraalVM
 spring:
   title: Spring Data Support
+multitenancy:
+  title: Multitenancy
 
 


### PR DESCRIPTION
- Initial attempt to include documentation for the multitenancy feature, please provide feedback.
- if the datasource is not named “default” then the dialect is not taken from the configuration and defaulted to “ANSI” when DATASOURCE mode is used.