### PR TITLE
Disable cosmos initializing if there are no required configs

### DIFF
--- a/data-azure-cosmos/src/main/java/io/micronaut/data/cosmos/common/CosmosDatabaseInitializer.java
+++ b/data-azure-cosmos/src/main/java/io/micronaut/data/cosmos/common/CosmosDatabaseInitializer.java
@@ -60,6 +60,8 @@ import java.util.stream.Collectors;
 @Context
 @Internal
 @Requires(classes = CosmosClient.class)
+@Requires(property = "azure.cosmos.endpoint")
+@Requires(property = "azure.cosmos.key")
 final class CosmosDatabaseInitializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(CosmosDatabaseInitializer.class);

--- a/data-azure-cosmos/src/test/groovy/io/micronaut/data/cosmos/common/ExistingCosmosDbSpec.groovy
+++ b/data-azure-cosmos/src/test/groovy/io/micronaut/data/cosmos/common/ExistingCosmosDbSpec.groovy
@@ -1,6 +1,6 @@
-package io.micronaut.data.azure
+package io.micronaut.data.cosmos.common
 
-
+import com.azure.cosmos.CosmosAsyncClient
 import com.azure.cosmos.CosmosClient
 import com.azure.cosmos.models.CosmosContainerProperties
 import com.azure.cosmos.models.ExcludedPath
@@ -12,6 +12,7 @@ import com.azure.cosmos.models.ThroughputProperties
 import com.azure.cosmos.models.UniqueKey
 import com.azure.cosmos.models.UniqueKeyPolicy
 import io.micronaut.context.ApplicationContext
+import io.micronaut.data.azure.AzureCosmosTestProperties
 import io.micronaut.data.azure.entities.CosmosBook
 import io.micronaut.data.azure.repositories.CosmosBookRepository
 import io.micronaut.data.cosmos.config.CosmosDatabaseConfiguration
@@ -133,14 +134,18 @@ class ExistingCosmosDbSpec extends Specification implements AzureCosmosTestPrope
     def "test configuration"() {
         given:
             def config = context.getBean(CosmosDatabaseConfiguration)
+            def client = context.getBean(CosmosClient)
+            def cosmosDatabaseInitializer = context.getBean(CosmosDatabaseInitializer)
 
         expect:
             config.databaseName == 'mydb'
             config.throughput.autoScale
             config.throughput.requestUnits == 1000
             config.updatePolicy == StorageUpdatePolicy.NONE
-
             !config.containers || config.containers.size() == 0
+
+            client
+            cosmosDatabaseInitializer
     }
 
 

--- a/data-azure-cosmos/src/test/groovy/io/micronaut/data/cosmos/common/MissingEndpointConfigSpec.groovy
+++ b/data-azure-cosmos/src/test/groovy/io/micronaut/data/cosmos/common/MissingEndpointConfigSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.data.cosmos.common
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.data.cosmos.config.CosmosDatabaseConfiguration
+import io.micronaut.data.cosmos.config.StorageUpdatePolicy
+import io.micronaut.test.support.TestPropertyProvider
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MissingEndpointConfigSpec extends Specification implements TestPropertyProvider {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
+    @Override
+    Map<String, String> getProperties() {
+        return [
+                'azure.cosmos.default-gateway-mode'                        : 'true',
+                'azure.cosmos.endpoint-discovery-enabled'                  : 'false',
+                'azure.cosmos.database.throughput-settings.request-units'  : '1200',
+                'azure.cosmos.database.throughput-settings.auto-scale'     : 'false',
+                'azure.cosmos.database.database-name'                      : 'customdb',
+                'azure.cosmos.database.packages'                           : 'io.micronaut.data.azure.entities',
+                'spec.name'                                                : getClass().getSimpleName()
+        ]
+    }
+
+    def "test configuration"() {
+        given:
+            def config = context.getBean(CosmosDatabaseConfiguration)
+
+        expect:
+            config.databaseName == 'customdb'
+            !config.throughput.autoScale
+            config.throughput.requestUnits == 1200
+            config.updatePolicy == StorageUpdatePolicy.NONE
+            !config.containers || config.containers.size() == 0
+
+        when:
+            context.getBean(CosmosDatabaseInitializer)
+        then:
+            thrown(NoSuchBeanException)
+    }
+
+
+}


### PR DESCRIPTION
This is needed before adding feature to micronaut-starter, since we can't have default values and any other will trigger initializer (PostConstruct) which will fail since there is no valid endpoint and key.