### PR TITLE
Improve API + cleanup code in style of Java 17

### DIFF
--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/AuditCompanyListener.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/AuditCompanyListener.java
@@ -30,8 +30,8 @@ public class AuditCompanyListener {
                 AuditCompany entity = context.getEntity();
                 prePersist(entity);
                 RuntimePersistentEntity<AuditCompany> persistentEntity = context.getPersistentEntity();
-                BeanProperty<AuditCompany, Object> prop1 = (BeanProperty<AuditCompany, Object>) persistentEntity.getPropertyByName("createUser").getProperty();
-                BeanProperty<AuditCompany, Object> prop2 = (BeanProperty<AuditCompany, Object>) persistentEntity.getPropertyByName("updateUser").getProperty();
+                BeanProperty<AuditCompany, Object> prop1 = persistentEntity.getPropertyByName("createUser").getProperty();
+                BeanProperty<AuditCompany, Object> prop2 = persistentEntity.getPropertyByName("updateUser").getProperty();
                 context.setProperty(prop1, prop1.get(entity));
                 context.setProperty(prop2, prop2.get(entity));
                 return true;

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -1089,7 +1089,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
                         if (generatedKeys.next()) {
                             RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
                             Object id = getGeneratedIdentity(generatedKeys, identity, storedQuery.getDialect());
-                            BeanProperty<T, Object> property = (BeanProperty<T, Object>) identity.getProperty();
+                            BeanProperty<T, Object> property = identity.getProperty();
                             entity = updateEntityId(property, entity, id);
                         } else {
                             throw new DataAccessException("Failed to generate ID for entity: " + entity);
@@ -1179,7 +1179,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
                             throw new DataAccessException("Failed to generate ID for entity: " + d.entity);
                         } else {
                             Object id = iterator.next();
-                            d.entity = updateEntityId((BeanProperty<T, Object>) identity.getProperty(), d.entity, id);
+                            d.entity = updateEntityId(identity.getProperty(), d.entity, id);
                         }
                     }
                 }

--- a/data-model/src/main/java/io/micronaut/data/model/AbstractPersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/AbstractPersistentEntity.java
@@ -71,8 +71,7 @@ public abstract class AbstractPersistentEntity implements PersistentEntity {
             return Optional.of(namingStrategy);
         } else {
             Object o = InstantiationUtils.tryInstantiate(className, classLoader).orElse(null);
-            if (o instanceof NamingStrategy) {
-                NamingStrategy ns = (NamingStrategy) o;
+            if (o instanceof NamingStrategy ns) {
                 NAMING_STRATEGIES.put(className, ns);
                 return Optional.of(ns);
             }

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
@@ -67,10 +67,9 @@ class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DefaultPage)) {
+        if (!(o instanceof DefaultPage<?> that)) {
             return false;
         }
-        DefaultPage<?> that = (DefaultPage<?>) o;
         return totalSize == that.totalSize && super.equals(o);
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
@@ -76,10 +76,9 @@ final class DefaultPageable implements Pageable {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DefaultPageable)) {
+        if (!(o instanceof DefaultPageable that)) {
             return false;
         }
-        DefaultPageable that = (DefaultPageable) o;
         return max == that.max &&
                 number == that.number &&
                 Objects.equals(sort, that.sort);

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultSlice.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultSlice.java
@@ -78,10 +78,9 @@ class DefaultSlice<T> implements Slice<T> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DefaultSlice)) {
+        if (!(o instanceof DefaultSlice<?> that)) {
             return false;
         }
-        DefaultSlice<?> that = (DefaultSlice<?>) o;
         return Objects.equals(content, that.content) &&
                 Objects.equals(pageable, that.pageable);
     }

--- a/data-model/src/main/java/io/micronaut/data/model/PersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/PersistentEntity.java
@@ -373,8 +373,7 @@ public interface PersistentEntity extends PersistentElement {
             for (int i = 0; i < propertyPath.length - 1; i++) {
                 String propertyName = propertyPath[i];
                 PersistentProperty prop = startingEntity.getPropertyByName(propertyName);
-                if (prop instanceof Association) {
-                    Association association = (Association) prop;
+                if (prop instanceof Association association) {
                     startingEntity = association.getAssociatedEntity();
                     associations.add(association);
                 } else {

--- a/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
@@ -86,8 +86,7 @@ public final class PersistentEntityUtils {
     public static void traversePersistentProperties(List<Association> associations,
                                                      PersistentProperty property,
                                                      BiConsumer<List<Association>, PersistentProperty> consumerProperty) {
-        if (property instanceof Embedded) {
-            Embedded embedded = (Embedded) property;
+        if (property instanceof Embedded embedded) {
             PersistentEntity embeddedEntity = embedded.getAssociatedEntity();
             Collection<? extends PersistentProperty> embeddedProperties = embeddedEntity.getPersistentProperties();
             List<Association> newAssociations = new ArrayList<>(associations);
@@ -95,8 +94,7 @@ public final class PersistentEntityUtils {
             for (PersistentProperty embeddedProperty : embeddedProperties) {
                 traversePersistentProperties(newAssociations, embeddedProperty, consumerProperty);
             }
-        } else if (property instanceof Association) {
-            Association association = (Association) property;
+        } else if (property instanceof Association association) {
             if (association.isForeignKey()) {
                 return;
             }

--- a/data-model/src/main/java/io/micronaut/data/model/PersistentPropertyPath.java
+++ b/data-model/src/main/java/io/micronaut/data/model/PersistentPropertyPath.java
@@ -139,16 +139,16 @@ public class PersistentPropertyPath {
         }
         Object value = bean;
         for (Association association : associations) {
-            RuntimePersistentProperty<?> property = (RuntimePersistentProperty) association;
-            BeanProperty beanProperty = property.getProperty();
+            RuntimePersistentProperty<Object> property = (RuntimePersistentProperty<Object>) association;
+            BeanProperty<Object, Object> beanProperty = property.getProperty();
             value = beanProperty.get(value);
             if (value == null) {
                 return null;
             }
         }
-        RuntimePersistentProperty<?> p = (RuntimePersistentProperty<?>) property;
+        RuntimePersistentProperty<Object> p = (RuntimePersistentProperty<Object>) property;
         if (value != null) {
-            BeanProperty beanProperty = p.getProperty();
+            BeanProperty<Object, Object> beanProperty = p.getProperty();
             value = beanProperty.get(value);
         }
         return value;

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaQuery.java
@@ -319,18 +319,15 @@ public abstract class AbstractPersistentEntityCriteriaQuery<T> implements Persis
     }
 
     private boolean isOnlyIdRestriction(Expression<?> predicate) {
-        if (predicate instanceof PersistentPropertyBinaryPredicate) {
-            PersistentPropertyBinaryPredicate<?> pp = (PersistentPropertyBinaryPredicate<?>) predicate;
+        if (predicate instanceof PersistentPropertyBinaryPredicate<?> pp) {
             return pp.getProperty() == pp.getProperty().getOwner().getIdentity();
         }
-        if (predicate instanceof ConjunctionPredicate) {
-            ConjunctionPredicate conjunctionPredicate = (ConjunctionPredicate) predicate;
+        if (predicate instanceof ConjunctionPredicate conjunctionPredicate) {
             if (conjunctionPredicate.getPredicates().size() == 1) {
                 return isOnlyIdRestriction(conjunctionPredicate.getPredicates().iterator().next());
             }
         }
-        if (predicate instanceof DisjunctionPredicate) {
-            DisjunctionPredicate disjunctionPredicate = (DisjunctionPredicate) predicate;
+        if (predicate instanceof DisjunctionPredicate disjunctionPredicate) {
             if (disjunctionPredicate.getPredicates().size() == 1) {
                 return isOnlyIdRestriction(disjunctionPredicate.getPredicates().iterator().next());
             }

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaUtils.java
@@ -89,8 +89,7 @@ public final class CriteriaUtils {
     }
 
     public static <T> PersistentPropertyPath<T> requireNumericProperty(Expression<T> exp) {
-        if (exp instanceof PersistentPropertyPath) {
-            PersistentPropertyPath<T> propertyPath = (PersistentPropertyPath<T>) exp;
+        if (exp instanceof PersistentPropertyPath<T> propertyPath) {
             if (!propertyPath.isNumeric()) {
                 throw new IllegalStateException("Expected a numeric expression property! Got: " + exp);
             }
@@ -100,8 +99,7 @@ public final class CriteriaUtils {
     }
 
     public static <T> PersistentPropertyPath<T> requireComparableProperty(Expression<T> exp) {
-        if (exp instanceof PersistentPropertyPath) {
-            PersistentPropertyPath<T> propertyPath = (PersistentPropertyPath<T>) exp;
+        if (exp instanceof PersistentPropertyPath<T> propertyPath) {
             if (!propertyPath.isComparable()) {
                 throw new IllegalStateException("Expected a comparable expression property! Got: " + exp);
             }
@@ -112,8 +110,7 @@ public final class CriteriaUtils {
 
     public static <T> Expression<T> requireComparablePropertyParameterOrLiteral(Expression<T> exp) {
         exp = requirePropertyParameterOrLiteral(exp);
-        if (exp instanceof PersistentPropertyPath) {
-            PersistentPropertyPath<?> propertyPath = (PersistentPropertyPath<?>) exp;
+        if (exp instanceof PersistentPropertyPath<?> propertyPath) {
             if (!propertyPath.isComparable()) {
                 throw new IllegalStateException("Expected a comparable expression property! Got: " + exp);
             }
@@ -134,8 +131,7 @@ public final class CriteriaUtils {
 
     public static <T> Expression<T> requireNumericPropertyParameterOrLiteral(Expression<T> exp) {
         exp = requirePropertyParameterOrLiteral(exp);
-        if (exp instanceof PersistentPropertyPath) {
-            PersistentPropertyPath<?> propertyPath = (PersistentPropertyPath<?>) exp;
+        if (exp instanceof PersistentPropertyPath<?> propertyPath) {
             if (!propertyPath.isNumeric()) {
                 throw new IllegalStateException("Expected a numeric expression property! Got: " + exp);
             }
@@ -185,20 +181,17 @@ public final class CriteriaUtils {
     }
 
     public static boolean hasVersionPredicate(Expression<?> predicate) {
-        if (predicate instanceof PersistentPropertyBinaryPredicate) {
-            PersistentPropertyBinaryPredicate<?> pp = (PersistentPropertyBinaryPredicate<?>) predicate;
+        if (predicate instanceof PersistentPropertyBinaryPredicate<?> pp) {
             return pp.getProperty() == pp.getProperty().getOwner().getVersion();
         }
-        if (predicate instanceof ConjunctionPredicate) {
-            ConjunctionPredicate conjunctionPredicate = (ConjunctionPredicate) predicate;
+        if (predicate instanceof ConjunctionPredicate conjunctionPredicate) {
             for (IExpression<Boolean> pred : conjunctionPredicate.getPredicates()) {
                 if (hasVersionPredicate(pred)) {
                     return true;
                 }
             }
         }
-        if (predicate instanceof DisjunctionPredicate) {
-            DisjunctionPredicate disjunctionPredicate = (DisjunctionPredicate) predicate;
+        if (predicate instanceof DisjunctionPredicate disjunctionPredicate) {
             for (IExpression<Boolean> pred : disjunctionPredicate.getPredicates()) {
                 if (hasVersionPredicate(pred)) {
                     return true;
@@ -218,25 +211,21 @@ public final class CriteriaUtils {
     }
 
     private static void extractPredicateParameters(Expression<?> predicate, Set<ParameterExpression<?>> parameters) {
-        if (predicate instanceof PersistentPropertyBinaryPredicate) {
-            PersistentPropertyBinaryPredicate<?> pp = (PersistentPropertyBinaryPredicate<?>) predicate;
+        if (predicate instanceof PersistentPropertyBinaryPredicate<?> pp) {
             if (pp.getExpression() instanceof ParameterExpression) {
                 parameters.add((ParameterExpression<?>) pp.getExpression());
             }
-        } else if (predicate instanceof PersistentPropertyInValuesPredicate) {
-            PersistentPropertyInValuesPredicate<?> pp = (PersistentPropertyInValuesPredicate<?>) predicate;
+        } else if (predicate instanceof PersistentPropertyInValuesPredicate<?> pp) {
             for (Expression<?> expression : pp.getValues()) {
                 if (expression instanceof ParameterExpression) {
                     parameters.add((ParameterExpression<?>) expression);
                 }
             }
-        } else if (predicate instanceof ConjunctionPredicate) {
-            ConjunctionPredicate conjunctionPredicate = (ConjunctionPredicate) predicate;
+        } else if (predicate instanceof ConjunctionPredicate conjunctionPredicate) {
             for (IExpression<Boolean> pred : conjunctionPredicate.getPredicates()) {
                 extractPredicateParameters(pred, parameters);
             }
-        } else if (predicate instanceof DisjunctionPredicate) {
-            DisjunctionPredicate disjunctionPredicate = (DisjunctionPredicate) predicate;
+        } else if (predicate instanceof DisjunctionPredicate disjunctionPredicate) {
             for (IExpression<Boolean> pred : disjunctionPredicate.getPredicates()) {
                 extractPredicateParameters(pred, parameters);
             }

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/query/QueryModelPredicateVisitor.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/query/QueryModelPredicateVisitor.java
@@ -66,8 +66,7 @@ public class QueryModelPredicateVisitor implements PredicateVisitor {
     private void visit(IExpression<Boolean> expression) {
         if (expression instanceof PredicateVisitable) {
             ((PredicateVisitable) expression).accept(this);
-        } else if (expression instanceof PersistentPropertyPath) {
-            PersistentPropertyPath<?> propertyPath = (PersistentPropertyPath<?>) expression;
+        } else if (expression instanceof PersistentPropertyPath<?> propertyPath) {
             // TODO
             add(Restrictions.isTrue(getPropertyPath(propertyPath)));
         } else {

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/util/Joiner.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/util/Joiner.java
@@ -103,11 +103,9 @@ public class Joiner implements SelectionVisitor, PredicateVisitor {
             } else {
                 join(associationPath);
             }
-        } else if (path instanceof PersistentPropertyPath) {
-            PersistentPropertyPath persistentPropertyPath = (PersistentPropertyPath) path;
+        } else if (path instanceof PersistentPropertyPath persistentPropertyPath) {
             Path parentPath = persistentPropertyPath.getParentPath();
-            if (parentPath instanceof PersistentAssociationPath) {
-                PersistentAssociationPath parent = (PersistentAssociationPath) parentPath;
+            if (parentPath instanceof PersistentAssociationPath parent) {
                 if (parent.getAssociation().getAssociatedEntity().getIdentity() == persistentPropertyPath.getProperty()) {
                     // We don't need a join to access the ID
                     return;
@@ -143,8 +141,7 @@ public class Joiner implements SelectionVisitor, PredicateVisitor {
 
     private void visitJoins(Set<? extends jakarta.persistence.criteria.Join<?, ?>> joins) {
         for (jakarta.persistence.criteria.Join<?, ?> join : joins) {
-            if (join instanceof PersistentAssociationPath) {
-                PersistentAssociationPath persistentAssociationPath = (PersistentAssociationPath) join;
+            if (join instanceof PersistentAssociationPath persistentAssociationPath) {
                 if (persistentAssociationPath.getAssociationJoinType() == null) {
                     continue;
                 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/DefaultProjectionList.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/DefaultProjectionList.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 class DefaultProjectionList implements ProjectionList {
 
-    private List<QueryModel.Projection> projections = new ArrayList(3);
+    private final List<QueryModel.Projection> projections = new ArrayList(3);
 
     /**
      * The backing list of projections.
@@ -52,9 +52,8 @@ class DefaultProjectionList implements ProjectionList {
                     QueryModel.Projection existing = projections.iterator().next();
                     if (existing instanceof QueryModel.CountProjection) {
                         return this;
-                    } else if (existing instanceof QueryModel.PropertyProjection) {
+                    } else if (existing instanceof QueryModel.PropertyProjection pp) {
                         projections.clear();
-                        QueryModel.PropertyProjection pp = (QueryModel.PropertyProjection) existing;
                         QueryModel.CountDistinctProjection newProjection = new QueryModel.CountDistinctProjection(pp.getPropertyName());
                         projections.add(newProjection);
                     } else if (existing instanceof QueryModel.IdProjection || existing instanceof QueryModel.DistinctProjection) {

--- a/data-model/src/main/java/io/micronaut/data/model/query/DefaultQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/DefaultQuery.java
@@ -67,13 +67,12 @@ public class DefaultQuery implements QueryModel {
      */
     public AssociationQuery createQuery(String associationName) {
         final PersistentProperty property = entity.getPropertyByPath(associationName).orElse(null);
-        if (!(property instanceof Association)) {
+        if (!(property instanceof Association association)) {
             throw new IllegalArgumentException("Cannot query association [" +
                     associationName + "] of class [" + entity +
                     "]. The specified property is not an association.");
         }
 
-        Association association = (Association) property;
         return new AssociationQuery(associationName, association);
     }
 
@@ -750,13 +749,11 @@ public class DefaultQuery implements QueryModel {
     }
 
     private void addToJunction(QueryModel.Junction currentJunction, QueryModel.Criterion criterion) {
-        if (criterion instanceof QueryModel.PropertyCriterion) {
-            final QueryModel.PropertyCriterion pc = (QueryModel.PropertyCriterion) criterion;
+        if (criterion instanceof final PropertyCriterion pc) {
             Object value = pc.getValue();
             pc.setValue(value);
         }
-        if (criterion instanceof QueryModel.Junction) {
-            QueryModel.Junction j = (QueryModel.Junction) criterion;
+        if (criterion instanceof Junction j) {
             QueryModel.Junction newj;
             if (j instanceof QueryModel.Disjunction) {
                 newj = disjunction(currentJunction);

--- a/data-model/src/main/java/io/micronaut/data/model/query/QueryModel.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/QueryModel.java
@@ -1048,7 +1048,7 @@ public interface QueryModel extends Criteria {
      * Used for exists subquery.
      */
     class Exists implements Criterion {
-        private QueryModel subquery;
+        private final QueryModel subquery;
 
         /**
          * Constructor for a subquery.
@@ -1070,7 +1070,7 @@ public interface QueryModel extends Criteria {
      * Used for exists subquery.
      */
     class NotExists implements Criterion {
-        private QueryModel subquery;
+        private final QueryModel subquery;
 
         /**
          * Constructor for a subquery.
@@ -1148,9 +1148,9 @@ public interface QueryModel extends Criteria {
      * Criterion used to restrict the result to be between values (range query).
      */
     class Between extends PropertyCriterion {
-        private String property;
-        private Object from;
-        private Object to;
+        private final String property;
+        private final Object from;
+        private final Object to;
 
         /**
          * Default constructor.
@@ -1409,7 +1409,7 @@ public interface QueryModel extends Criteria {
      * A projection that obtains the value of a property of an entity.
      */
     class PropertyProjection extends Projection {
-        private String propertyName;
+        private final String propertyName;
         private String alias;
 
         /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -301,8 +301,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
                     sb.append(",");
                 }
             }
-        } else if (value instanceof Object[]) {
-            Object[] objects = (Object[]) value;
+        } else if (value instanceof Object[] objects) {
             for (int i = 0; i < objects.length; i++) {
                 Object o = objects[i];
                 sb.append(asLiteral(o));
@@ -699,8 +698,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
                     } else {
                         throw new IllegalArgumentException("Cannot query on ID with entity that has no ID");
                     }
-                } else if (projection instanceof QueryModel.PropertyProjection) {
-                    QueryModel.PropertyProjection pp = (QueryModel.PropertyProjection) projection;
+                } else if (projection instanceof QueryModel.PropertyProjection pp) {
                     String alias = pp.getAlias().orElse(null);
                     if (projection instanceof QueryModel.AvgProjection) {
                         appendFunctionProjection(queryState.getEntity(), AVG, pp, tableAlias, queryString);
@@ -994,7 +992,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             if (additionalWhereBuff.length() > 0) {
                 queryClause.append(WHERE_CLAUSE)
                     .append(OPEN_BRACKET)
-                    .append(additionalWhereBuff.toString())
+                    .append(additionalWhereBuff)
                     .append(CLOSE_BRACKET);
             }
         }
@@ -1156,8 +1154,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
                                            Object value,
                                            String operator) {
 
-        if (value instanceof BindingParameter) {
-            BindingParameter bindingParameter = (BindingParameter) value;
+        if (value instanceof BindingParameter bindingParameter) {
             boolean computePropertyPaths = computePropertyPaths();
             if (!computePropertyPaths) {
                 appendPropertyRef(whereClause, propertyPath);

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -538,12 +538,10 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
 
     private String addIndex(PersistentEntity entity, IndexConfiguration config) {
         // Create index name without escaped table name and then escape if needed
-        StringBuilder sbIndexName = new StringBuilder();
-        sbIndexName.append(config.index.stringValue("name")
+        String indexName = config.index.stringValue("name")
             .orElse(String.format(
                 "idx_%s%s", prepareNames(config.unquotedTableName),
-                makeTransformedColumnList(provideColumnList(config)))));
-        String indexName = sbIndexName.toString();
+                makeTransformedColumnList(provideColumnList(config))));
         if (shouldEscape(entity)) {
             indexName = quote(indexName);
         }
@@ -745,8 +743,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
         return Stream.concat(Stream.of(persistentEntity.getIdentity()), persistentEntity.getPersistentProperties().stream())
                 .flatMap(this::flatMapEmbedded)
                 .filter(p -> {
-                    if (p instanceof Association) {
-                        Association a = (Association) p;
+                    if (p instanceof Association a) {
                         return isForeignKeyWithJoinTable(a);
                     }
                     return false;
@@ -792,12 +789,9 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
 
                     queryBuffer.append(COMMA);
 
-                    boolean includeIdentity = false;
-                    if (association.isForeignKey()) {
-                        // in the case of a foreign key association the ID is not in the table
-                        // so we need to retrieve it
-                        includeIdentity = true;
-                    }
+                    boolean includeIdentity = association.isForeignKey();
+                    // in the case of a foreign key association the ID is not in the table
+                    // so we need to retrieve it
                     traversePersistentProperties(associatedEntity, includeIdentity, true, (propertyAssociations, prop) -> {
                         String columnName;
                         if (computePropertyPaths()) {
@@ -895,8 +889,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
         return Stream.concat(Stream.of(entity.getIdentity()), entity.getPersistentProperties().stream())
                 .flatMap(this::flatMapEmbedded)
                 .noneMatch(pp -> {
-                    if (pp instanceof Association) {
-                        Association association = (Association) pp;
+                    if (pp instanceof Association association) {
                         return !association.isForeignKey();
                     }
                     return true;
@@ -904,8 +897,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
     }
 
     private Stream<? extends PersistentProperty> flatMapEmbedded(PersistentProperty pp) {
-        if (pp instanceof Embedded) {
-            Embedded embedded = (Embedded) pp;
+        if (pp instanceof Embedded embedded) {
             PersistentEntity embeddedEntity = embedded.getAssociatedEntity();
             return embeddedEntity.getPersistentProperties()
                     .stream()

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeAssociation.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeAssociation.java
@@ -43,7 +43,7 @@ public class RuntimeAssociation<T> extends RuntimePersistentProperty<T> implemen
      * @param property The property
      * @param constructorArg Whether it is a constructor arg
      */
-    RuntimeAssociation(RuntimePersistentEntity<T> owner, BeanProperty<T, ?> property, boolean constructorArg) {
+    RuntimeAssociation(RuntimePersistentEntity<T> owner, BeanProperty<T, Object> property, boolean constructorArg) {
         super(owner, property, constructorArg);
         this.kind = Association.super.getKind();
         this.aliasName = Association.super.getAliasName();

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeEmbedded.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimeEmbedded.java
@@ -33,7 +33,7 @@ class RuntimeEmbedded<T> extends RuntimeAssociation<T> implements Embedded {
      * @param property The bean property
      * @param constructorArg Whether it is a constructor arg
      */
-    RuntimeEmbedded(RuntimePersistentEntity owner, BeanProperty<T, ?> property, boolean constructorArg) {
+    RuntimeEmbedded(RuntimePersistentEntity<T> owner, BeanProperty<T, Object> property, boolean constructorArg) {
         super(owner, property, constructorArg);
     }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -329,12 +329,10 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
     @Override
     public List<String> getPersistentPropertyNames() {
         if (allPersistentPropertiesNames == null) {
-            allPersistentPropertiesNames = Collections.unmodifiableList(
-                    Arrays.stream(allPersistentProperties)
-                            .filter(Objects::nonNull)
-                            .map(RuntimePersistentProperty::getName)
-                            .collect(Collectors.toList())
-            );
+            allPersistentPropertiesNames = Arrays.stream(allPersistentProperties)
+                .filter(Objects::nonNull)
+                .map(RuntimePersistentProperty::getName)
+                .toList();
         }
         return allPersistentPropertiesNames;
     }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentProperty.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentProperty.java
@@ -38,11 +38,11 @@ import java.util.function.Supplier;
 public class RuntimePersistentProperty<T> implements PersistentProperty {
     public static final RuntimePersistentProperty<Object>[] EMPTY_PROPERTY_ARRAY = new RuntimePersistentProperty[0];
     private final RuntimePersistentEntity<T> owner;
-    private final BeanProperty<T, ?> property;
+    private final BeanProperty<T, Object> property;
     private final Class<?> type;
     private final DataType dataType;
     private final boolean constructorArg;
-    private final Argument<?> argument;
+    private final Argument<Object> argument;
     private final Supplier<AttributeConverter<Object, Object>> converter;
     private String persistedName;
 
@@ -52,7 +52,7 @@ public class RuntimePersistentProperty<T> implements PersistentProperty {
      * @param property The property
      * @param constructorArg whether it is a constructor arg
      */
-    RuntimePersistentProperty(RuntimePersistentEntity<T> owner, BeanProperty<T, ?> property, boolean constructorArg) {
+    RuntimePersistentProperty(RuntimePersistentEntity<T> owner, BeanProperty<T, Object> property, boolean constructorArg) {
         this.owner = owner;
         this.property = property;
         this.type = ReflectionUtils.getWrapperType(property.getType());
@@ -67,7 +67,7 @@ public class RuntimePersistentProperty<T> implements PersistentProperty {
     /**
      * @return The argument for this property.
      */
-    public Argument<?> getArgument() {
+    public Argument<Object> getArgument() {
         return argument;
     }
 
@@ -139,7 +139,7 @@ public class RuntimePersistentProperty<T> implements PersistentProperty {
     /**
      * @return The backing bean property
      */
-    public BeanProperty<T, ?> getProperty() {
+    public BeanProperty<T, Object> getProperty() {
         return property;
     }
 

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoRepositoryOperations.java
@@ -771,7 +771,7 @@ public final class DefaultMongoRepositoryOperations extends AbstractMongoReposit
                 }
                 InsertOneResult insertOneResult = collection.insertOne(ctx.clientSession, entity, getInsertOneOptions(ctx.annotationMetadata));
                 BsonValue insertedId = insertOneResult.getInsertedId();
-                BeanProperty<T, Object> property = (BeanProperty<T, Object>) persistentEntity.getIdentity().getProperty();
+                BeanProperty<T, Object> property = persistentEntity.getIdentity().getProperty();
                 if (property.get(entity) == null) {
                     entity = updateEntityId(property, entity, insertedId);
                 }
@@ -980,7 +980,7 @@ public final class DefaultMongoRepositoryOperations extends AbstractMongoReposit
                 if (hasGeneratedId) {
                     Map<Integer, BsonValue> insertedIds = insertManyResult.getInsertedIds();
                     RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
-                    BeanProperty<T, Object> idProperty = (BeanProperty<T, Object>) identity.getProperty();
+                    BeanProperty<T, Object> idProperty = identity.getProperty();
                     int index = 0;
                     for (Data d : entities) {
                         if (!d.vetoed) {

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultReactiveMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultReactiveMongoRepositoryOperations.java
@@ -771,7 +771,7 @@ public class DefaultReactiveMongoRepositoryOperations extends AbstractMongoRepos
                     }
                     return Mono.from(collection.insertOne(ctx.clientSession, d.entity, getInsertOneOptions(ctx.annotationMetadata))).map(insertOneResult -> {
                         BsonValue insertedId = insertOneResult.getInsertedId();
-                        BeanProperty<T, Object> property = (BeanProperty<T, Object>) persistentEntity.getIdentity().getProperty();
+                        BeanProperty<T, Object> property = persistentEntity.getIdentity().getProperty();
                         if (property.get(d.entity) == null) {
                             d.entity = updateEntityId(property, d.entity, insertedId);
                         }
@@ -1032,7 +1032,7 @@ public class DefaultReactiveMongoRepositoryOperations extends AbstractMongoRepos
                         if (hasGeneratedId) {
                             Map<Integer, BsonValue> insertedIds = insertManyResult.getInsertedIds();
                             RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
-                            BeanProperty<T, Object> idProperty = (BeanProperty<T, Object>) identity.getProperty();
+                            BeanProperty<T, Object> idProperty = identity.getProperty();
                             int index = 0;
                             for (Data d : list) {
                                 if (!d.vetoed) {

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/MongoUtils.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/MongoUtils.java
@@ -52,22 +52,22 @@ public final class MongoUtils {
     }
 
     public static BsonValue entityIdValue(ConversionService conversionService,
-                                          RuntimePersistentEntity<?> persistentEntity,
+                                          RuntimePersistentEntity<Object> persistentEntity,
                                           Object entity,
                                           CodecRegistry codecRegistry) {
-        RuntimePersistentProperty<?> identity = persistentEntity.getIdentity();
+        RuntimePersistentProperty<Object> identity = persistentEntity.getIdentity();
         if (identity != null) {
-            BeanProperty property = identity.getProperty();
+            BeanProperty<Object, Object> property = identity.getProperty();
             return idValue(conversionService, persistentEntity, property.get(entity), codecRegistry);
         }
         throw new IllegalStateException("Cannot determine id!");
     }
 
-    public static BsonValue idValue(ConversionService conversionService,
-                                    RuntimePersistentEntity<?> persistentEntity,
-                                    Object idValue,
-                                    CodecRegistry codecRegistry) {
-        RuntimePersistentProperty<?> identity = persistentEntity.getIdentity();
+    public static <T> BsonValue idValue(ConversionService conversionService,
+                                        RuntimePersistentEntity<T> persistentEntity,
+                                        Object idValue,
+                                        CodecRegistry codecRegistry) {
+        RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
         if (identity != null) {
             if (identity instanceof Association) {
                 return toBsonValue(conversionService, idValue, codecRegistry);
@@ -77,7 +77,7 @@ public final class MongoUtils {
                 BsonType bsonType = bsonRepresentation.getRequiredValue(BsonType.class);
                 return toBsonValue(conversionService, bsonType, idValue);
             } else {
-                BeanProperty property = identity.getProperty();
+                BeanProperty<T, Object> property = identity.getProperty();
                 Class<?> type = property.getType();
                 if (type == String.class && idValue != null) {
                     return new BsonObjectId(new ObjectId(idValue.toString()));

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataSerdeRegistry.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataSerdeRegistry.java
@@ -138,11 +138,11 @@ final class DataSerdeRegistry implements SerdeRegistry {
 
                 @Override
                 public Serializer<Object> createSpecific(EncoderContext encoderContext, Argument<?> type) throws SerdeException {
-                    RuntimePersistentEntity entity = runtimeEntityRegistry.getEntity(type.getType());
+                    RuntimePersistentEntity<Object> entity = runtimeEntityRegistry.getEntity((Class<Object>) type.getType());
                     if (entity.getIdentity() == null) {
                         throw new SerdeException("Cannot find ID of entity type: " + type);
                     }
-                    BeanProperty property = entity.getIdentity().getProperty();
+                    BeanProperty<Object, Object> property = entity.getIdentity().getProperty();
                     Argument<?> idType = entity.getIdentity().getArgument();
                     Serializer<Object> idSerializer = encoderContext.findCustomSerializer(IdSerializer.class).createSpecific(encoderContext, idType);
                     return new Serializer<Object>() {

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/MappedEntityCodec.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/MappedEntityCodec.java
@@ -37,7 +37,7 @@ class MappedEntityCodec<T> extends MappedCodec<T> implements CollectibleCodec<T>
     private final boolean isGeneratedId;
     private final boolean isGeneratedObjectIdAsString;
     private final boolean isGeneratedObjectId;
-    private final BeanProperty identityProperty;
+    private final BeanProperty<T, Object> identityProperty;
 
     /**
      * Default constructor.

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
@@ -1232,7 +1232,7 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
                     RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
                     return executeAndMapEachRowSingle(statement, row -> columnIndexResultSetReader.readDynamic(row, 0, identity.getDataType()))
                         .map(id -> {
-                            BeanProperty<T, Object> property = (BeanProperty<T, Object>) identity.getProperty();
+                            BeanProperty<T, Object> property = identity.getProperty();
                             d.entity = updateEntityId(property, d.entity, id);
                             return d;
                         });
@@ -1340,7 +1340,7 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
                                     throw new DataAccessException("Failed to generate ID for entity: " + d.entity);
                                 } else {
                                     Object id = iterator.next();
-                                    d.entity = updateEntityId((BeanProperty<T, Object>) identity.getProperty(), d.entity, id);
+                                    d.entity = updateEntityId(identity.getProperty(), d.entity, id);
                                 }
                             }
                             return Mono.just(list);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/convert/RuntimePersistentPropertyConversionContext.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/convert/RuntimePersistentPropertyConversionContext.java
@@ -36,6 +36,6 @@ public interface RuntimePersistentPropertyConversionContext extends ArgumentConv
 
     @Override
     default Argument<Object> getArgument() {
-        return (Argument<Object>) getRuntimePersistentProperty().getArgument();
+        return getRuntimePersistentProperty().getArgument();
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/metamodel/RuntimePersistentPropertyAttribute.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/metamodel/RuntimePersistentPropertyAttribute.java
@@ -39,22 +39,15 @@ abstract class RuntimePersistentPropertyAttribute<T, E> implements Attribute<T, 
 
     @Override
     public PersistentAttributeType getPersistentAttributeType() {
-        if (persistentProperty instanceof RuntimeAssociation) {
-            RuntimeAssociation<Object> runtimeAssociation = (RuntimeAssociation<Object>) persistentProperty;
-            switch (runtimeAssociation.getKind()) {
-                case EMBEDDED:
-                    return PersistentAttributeType.EMBEDDED;
-                case ONE_TO_ONE:
-                    return PersistentAttributeType.ONE_TO_ONE;
-                case MANY_TO_ONE:
-                    return PersistentAttributeType.MANY_TO_ONE;
-                case ONE_TO_MANY:
-                    return PersistentAttributeType.ONE_TO_MANY;
-                case MANY_TO_MANY:
-                    return PersistentAttributeType.MANY_TO_MANY;
-                default:
-                    return PersistentAttributeType.BASIC;
-            }
+        if (persistentProperty instanceof RuntimeAssociation runtimeAssociation) {
+            return switch (runtimeAssociation.getKind()) {
+                case EMBEDDED -> PersistentAttributeType.EMBEDDED;
+                case ONE_TO_ONE -> PersistentAttributeType.ONE_TO_ONE;
+                case MANY_TO_ONE -> PersistentAttributeType.MANY_TO_ONE;
+                case ONE_TO_MANY -> PersistentAttributeType.ONE_TO_MANY;
+                case MANY_TO_MANY -> PersistentAttributeType.MANY_TO_MANY;
+                default -> PersistentAttributeType.BASIC;
+            };
         }
         return PersistentAttributeType.BASIC;
     }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListener.java
@@ -26,7 +26,6 @@ import java.lang.annotation.Annotation;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Abstract implementation of a listener that handles {@link io.micronaut.data.annotation.AutoPopulated}.
@@ -59,7 +58,7 @@ public abstract class AutoPopulatedEntityEventListener implements EntityEventLis
                 }
                 propertyList.addAll(persistentProperties.stream()
                         .filter(PersistentProperty::isAutoPopulated)
-                        .collect(Collectors.toList()));
+                        .toList());
                 //noinspection unchecked
                 properties = propertyList.stream().filter(getPropertyPredicate()).toArray(RuntimePersistentProperty[]::new);
                 if (ArrayUtils.isEmpty(properties)) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoTimestampEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoTimestampEntityEventListener.java
@@ -117,7 +117,7 @@ public class AutoTimestampEntityEventListener extends AutoPopulatedEntityEventLi
                 }
             }
 
-            final BeanProperty<Object, Object> beanProperty = (BeanProperty<Object, Object>) property.getProperty();
+            final BeanProperty<Object, Object> beanProperty = property.getProperty();
             final Class<?> propertyType = property.getType();
             ChronoUnit truncateToValue;
             if (isUpdate) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/UUIDGeneratingEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/UUIDGeneratingEntityEventListener.java
@@ -54,7 +54,7 @@ public class UUIDGeneratingEntityEventListener extends AutoPopulatedEntityEventL
     public boolean prePersist(@NonNull EntityEventContext<Object> context) {
         final RuntimePersistentProperty<Object>[] persistentProperties = getApplicableProperties(context.getPersistentEntity());
         for (RuntimePersistentProperty<Object> persistentProperty : persistentProperties) {
-            final BeanProperty<Object, Object> property = (BeanProperty<Object, Object>) persistentProperty.getProperty();
+            final BeanProperty<Object, Object> property = persistentProperty.getProperty();
             context.setProperty(property, UUID.randomUUID());
         }
         return true;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListener.java
@@ -70,7 +70,7 @@ public class VersionGeneratingEntityEventListener implements EntityEventListener
         if (shouldSkip(context)) {
             return true;
         }
-        final BeanProperty<Object, Object> property = (BeanProperty<Object, Object>) context.getPersistentEntity().getVersion().getProperty();
+        final BeanProperty<Object, Object> property = context.getPersistentEntity().getVersion().getProperty();
         Object newVersion = init(property.getType());
         context.setProperty(property, newVersion);
         return true;
@@ -82,7 +82,7 @@ public class VersionGeneratingEntityEventListener implements EntityEventListener
             return true;
         }
         final Object entity = context.getEntity();
-        final BeanProperty<Object, Object> property = (BeanProperty<Object, Object>) context.getPersistentEntity().getVersion().getProperty();
+        final BeanProperty<Object, Object> property = context.getPersistentEntity().getVersion().getProperty();
         Object newVersion = increment(property.get(entity), property.getType());
         context.setProperty(property, newVersion);
         return true;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
@@ -23,7 +23,6 @@ import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.convert.ConversionService;
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.exceptions.EmptyResultException;
 import io.micronaut.data.intercept.DataInterceptor;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -353,8 +353,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         } else if (ctx.associations != null) {
             for (Map.Entry<Association, MappingContext> e : ctx.associations.entrySet()) {
                 MappingContext associationCtx = e.getValue();
-                RuntimeAssociation runtimeAssociation = (RuntimeAssociation) e.getKey();
-                BeanProperty beanProperty = runtimeAssociation.getProperty();
+                RuntimeAssociation<Object> runtimeAssociation = (RuntimeAssociation<Object>) e.getKey();
+                BeanProperty<Object, Object> beanProperty = runtimeAssociation.getProperty();
                 if (runtimeAssociation.getKind().isSingleEnded() && (associationCtx.manyAssociations == null || associationCtx.manyAssociations.isEmpty())) {
                     Object value = beanProperty.get(instance);
                     Object newValue = setChildrenAndTriggerPostLoad(value, associationCtx, instance);
@@ -491,7 +491,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
 
             if (id != null && identity != null) {
                 @SuppressWarnings("unchecked")
-                BeanProperty<K, Object> idProperty = (BeanProperty<K, Object>) identity.getProperty();
+                BeanProperty<K, Object> idProperty = identity.getProperty();
                 entity = (K) convertAndSetWithValue(entity, identity, idProperty, id);
             }
             RuntimePersistentProperty<K> version = persistentEntity.getVersion();
@@ -516,9 +516,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     }
                 }
                 @SuppressWarnings("unchecked")
-                BeanProperty<K, Object> property = (BeanProperty<K, Object>) rpp.getProperty();
-                if (rpp instanceof Association) {
-                    Association entityAssociation = (Association) rpp;
+                BeanProperty<K, Object> property = rpp.getProperty();
+                if (rpp instanceof Association entityAssociation) {
                     if (rpp instanceof Embedded) {
                         Object value = readEntity(rs, ctx.embedded((Embedded) rpp), parent == null ? entity : parent, null);
                         entity = setProperty(property, entity, value);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractCascadeOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractCascadeOperations.java
@@ -137,7 +137,7 @@ abstract class AbstractCascadeOperations {
      * @return The entity instance
      */
     protected <T> T afterCascadedOne(T entity, List<Association> associations, Object prevChild, Object newChild) {
-        RuntimeAssociation<Object> association = (RuntimeAssociation<Object>) associations.iterator().next();
+        RuntimeAssociation<T> association = (RuntimeAssociation<T>) associations.iterator().next();
         if (associations.size() == 1) {
             if (association.isForeignKey()) {
                 PersistentAssociationPath inverse = association.getInversePathSide().orElse(null);
@@ -147,11 +147,11 @@ abstract class AbstractCascadeOperations {
                 }
             }
             if (prevChild != newChild) {
-                entity = setProperty((BeanProperty<T, Object>) association.getProperty(), entity, newChild);
+                entity = setProperty(association.getProperty(), entity, newChild);
             }
             return entity;
         } else {
-            BeanProperty<T, Object> property = (BeanProperty<T, Object>) association.getProperty();
+            BeanProperty<T, Object> property = association.getProperty();
             Object innerEntity = property.get(entity);
             Object newInnerEntity = afterCascadedOne(innerEntity, associations.subList(1, associations.size()), prevChild, newChild);
             if (newInnerEntity != innerEntity) {
@@ -172,7 +172,7 @@ abstract class AbstractCascadeOperations {
      * @return The entity instance
      */
     protected <T> T afterCascadedMany(T entity, List<Association> associations, Iterable<Object> prevChildren, List<Object> newChildren) {
-        RuntimeAssociation<Object> association = (RuntimeAssociation<Object>) associations.iterator().next();
+        RuntimeAssociation<T> association = (RuntimeAssociation<T>) associations.iterator().next();
         if (associations.size() == 1) {
             for (ListIterator<Object> iterator = newChildren.listIterator(); iterator.hasNext(); ) {
                 Object c = iterator.next();
@@ -187,11 +187,11 @@ abstract class AbstractCascadeOperations {
                 }
             }
             if (prevChildren != newChildren) {
-                entity = convertAndSetWithValue((BeanProperty<T, Object>) association.getProperty(), entity, newChildren);
+                entity = convertAndSetWithValue(association.getProperty(), entity, newChildren);
             }
             return entity;
         } else {
-            BeanProperty<T, Object> property = (BeanProperty<T, Object>) association.getProperty();
+            BeanProperty<T, Object> property = association.getProperty();
             Object innerEntity = property.get(entity);
             Object newInnerEntity = afterCascadedMany(innerEntity, associations.subList(1, associations.size()), prevChildren, newChildren);
             if (newInnerEntity != innerEntity) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/query/DefaultBindableParametersStoredQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/query/DefaultBindableParametersStoredQuery.java
@@ -93,7 +93,7 @@ public class DefaultBindableParametersStoredQuery<E, R> implements BindableParam
         RuntimePersistentEntity<E> persistentEntity = getPersistentEntity();
         Class<?> parameterConverter = binding.getParameterConverterClass();
         Object value = binding.getValue();
-        RuntimePersistentProperty<?> persistentProperty = null;
+        RuntimePersistentProperty<Object> persistentProperty = null;
         Argument<?> argument = null;
         if (value == null) {
             if (binding.getParameterIndex() != -1) {
@@ -102,7 +102,7 @@ public class DefaultBindableParametersStoredQuery<E, R> implements BindableParam
                 argument = invocationContext.getArguments()[binding.getParameterIndex()];
             } else if (binding.isAutoPopulated()) {
                 PersistentPropertyPath pp = getRequiredPropertyPath(binding, persistentEntity);
-                persistentProperty = (RuntimePersistentProperty) pp.getProperty();
+                persistentProperty = (RuntimePersistentProperty<Object>) pp.getProperty();
                 if (binding.isRequiresPreviousPopulatedValue()) {
                     if (previousValues != null) {
                         value = previousValues.get(binding);
@@ -128,7 +128,7 @@ public class DefaultBindableParametersStoredQuery<E, R> implements BindableParam
             } else if (entity != null) {
                 PersistentPropertyPath pp = getRequiredPropertyPath(binding, persistentEntity);
                 value = pp.getPropertyValue(entity);
-                persistentProperty = (RuntimePersistentProperty<?>) pp.getProperty();
+                persistentProperty = (RuntimePersistentProperty<Object>) pp.getProperty();
             } else {
                 int currentIndex = binder.currentIndex();
                 if (currentIndex != -1) {


### PR DESCRIPTION
One of the points from https://github.com/micronaut-projects/micronaut-data/issues/1301:
`Replace BeanProperty<T, ?> with BeanProperty<T, Object> in API (RuntimePersistentProperty etc)`

I have applied `Cleanup` action in `data-model`.