### PR TITLE
Fix for ignoring field in json serialization

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/DefaultSort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultSort.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.util.ArgumentUtils;
 
@@ -77,6 +78,7 @@ final class DefaultSort implements Sort {
     }
 
     @Override
+    @JsonIgnore
     public boolean isSorted() {
         return CollectionUtils.isNotEmpty(orderBy);
     }

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -137,6 +137,7 @@ public interface Pageable extends Sort {
     }
 
     @Override
+    @JsonIgnore
     default boolean isSorted() {
         return getSort().isSorted();
     }

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -91,7 +91,6 @@ class PageSpec extends Specification {
         deserializedPage == page
     }
 
-    //@PendingFeature(reason = "Need to prioritize introspections over iterables")
     void "test serialization and deserialization of a page - serde"() {
         def page = Page.of([new Dummy(
                 propertyOne: "value one",
@@ -116,8 +115,6 @@ class PageSpec extends Specification {
         deserializedPage == page
     }
 
-    // TODO: Temp disabling until fix in core is available
-    @PendingFeature
     void "test serialization and deserialization of a pageable - serde"() {
         def pageable = Pageable.from(0, 3)
 


### PR DESCRIPTION
@dstepanov Looks like this is the fix for json serialization issue. Had to add `@JsonIgnore` to default method in `Pageable` and another in `DefaultSort` for existing method `isSortable()`. Before it worked on interface method declarations, now it seems it needs to be either on default method implementation in interface or implementing class.