### PR TITLE
Fixes #1178

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2JoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2JoinFetchSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.data.jdbc.h2
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class H2JoinFetchSpec extends AbstractJoinFetchSpec implements H2TestPropertyProvider {
+
+    boolean outerJoinSupported = false
+
+    boolean outerFetchJoinSupported = false
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(H2BookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(H2AuthorRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(H2AuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(H2AuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(H2AuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(H2AuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by H2.")
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by H2.")
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.createBean(H2AuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(H2AuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinInnerRepository extends AuthorJoinTypeRepositories.AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinLeftFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinLeftRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinRightFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2AuthorJoinRightRepository extends AuthorJoinTypeRepositories.AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mariadb/MariaJoinFetchSpec.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.data.jdbc.mariadb
+
+
+import io.micronaut.data.jdbc.mysql.MySqlDialectJoinFetchSpec
+
+class MariaJoinFetchSpec extends MySqlDialectJoinFetchSpec implements MariaTestPropertyProvider {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlDialectJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MySqlDialectJoinFetchSpec.groovy
@@ -1,0 +1,90 @@
+package io.micronaut.data.jdbc.mysql
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+/**
+ * Abstract Spec class used for DBs using mysql dialect (MySql, MariaDB)
+ */
+abstract class MySqlDialectJoinFetchSpec extends AbstractJoinFetchSpec {
+
+    boolean outerJoinSupported = false
+
+    boolean outerFetchJoinSupported = false
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MySqlBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MySqlAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(MySqlAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(MySqlAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(MySqlAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(MySqlAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by MySql.")
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        throw new UnsupportedOperationException("Full Outer Join is not supported by MySql.")
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(MySqlAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(MySqlAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinInnerRepository extends AuthorJoinTypeRepositories.AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinLeftFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinLeftRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinRightFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.MYSQL)
+interface MySqlAuthorJoinRightRepository extends AuthorJoinTypeRepositories.AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlJoinFetchSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.data.jdbc.mysql
+
+class MysqlJoinFetchSpec extends MySqlDialectJoinFetchSpec implements MySQLTestPropertyProvider {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEJoinFetchSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.data.jdbc.oraclexe
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class OracleXEJoinFetchSpec extends AbstractJoinFetchSpec implements OracleTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(OracleXEBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(OracleXEAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(OracleXEAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(OracleXEAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(OracleXEAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(OracleXEAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(OracleXEAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinInnerRepository extends AuthorJoinTypeRepositories.AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinLeftFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinLeftRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinOuterFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinOuterRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinRightFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleXEAuthorJoinRightRepository extends AuthorJoinTypeRepositories.AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresJoinFetchSpec.groovy
@@ -1,0 +1,94 @@
+package io.micronaut.data.jdbc.postgres
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+
+import io.micronaut.data.tck.repositories.AuthorJoinTypeRepositories
+import io.micronaut.data.tck.repositories.AuthorRepository
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class PostgresJoinFetchSpec extends AbstractJoinFetchSpec implements PostgresTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(PostgresBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(PostgresAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(PostgresAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(PostgresAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(PostgresAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(PostgresAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(PostgresAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(PostgresAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(PostgresAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(PostgresAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinInnerRepository extends AuthorJoinTypeRepositories.AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinLeftFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinLeftRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinOuterFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinOuterRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinRightFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresAuthorJoinRightRepository extends AuthorJoinTypeRepositories.AuthorJoinRightRepository {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerJoinFetchSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerJoinFetchSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.data.jdbc.sqlserver
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractJoinFetchSpec
+
+class SqlServerJoinFetchSpec extends AbstractJoinFetchSpec implements MSSQLTestPropertyProvider {
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MSBookRepository)
+    }
+
+    @Override
+    AuthorRepository getAuthorRepository() {
+        return context.getBean(MSAuthorRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository() {
+        return context.getBean(MSAuthorJoinLeftFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository() {
+        return context.getBean(MSAuthorJoinLeftRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository() {
+        return context.getBean(MSAuthorJoinRightFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository() {
+        return context.getBean(MSAuthorJoinRightRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository() {
+        return context.getBean(MSAuthorJoinOuterRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository() {
+        return context.getBean(MSAuthorJoinOuterFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository() {
+        return context.getBean(MSAuthorJoinFetchRepository)
+    }
+
+    @Override
+    AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository() {
+        return context.getBean(MSAuthorJoinInnerRepository)
+    }
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinInnerRepository extends AuthorJoinTypeRepositories.AuthorJoinInnerRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinLeftFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinLeftRepository extends AuthorJoinTypeRepositories.AuthorJoinLeftRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinOuterFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinOuterRepository extends AuthorJoinTypeRepositories.AuthorJoinOuterRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinRightFetchRepository extends AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository {
+}
+
+@JdbcRepository(dialect = Dialect.SQL_SERVER)
+interface MSAuthorJoinRightRepository extends AuthorJoinTypeRepositories.AuthorJoinRightRepository {
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/Join.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/Join.java
@@ -18,6 +18,7 @@ package io.micronaut.data.annotation;
 import io.micronaut.data.annotation.repeatable.JoinSpecifications;
 
 import java.lang.annotation.*;
+import java.util.EnumSet;
 
 /**
  * A @Join defines how a join for a particular association path should be generated.
@@ -56,7 +57,13 @@ public @interface Join {
         RIGHT_FETCH,
         FETCH,
         INNER,
-        OUTER;
+        OUTER,
+        OUTER_FETCH;
+
+        /**
+         * An enumset of all enum values.
+         */
+        public static final EnumSet<Type> ALL_TYPES = EnumSet.allOf(Type.class);
 
         /**
          * @return an indicator telling whether join type is fetching

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/Dialect.java
@@ -16,7 +16,12 @@
 package io.micronaut.data.model.query.builder.sql;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.annotation.Join;
 import io.micronaut.data.model.DataType;
+
+import java.util.EnumSet;
+
+import static io.micronaut.data.annotation.Join.Type.*;
 
 /**
  * The SQL dialect to use.
@@ -28,42 +33,63 @@ public enum Dialect {
     /**
      * H2 database.
      */
-    H2(true, false, true),
+    H2(true, false, true,
+        EnumSet.of(
+            DEFAULT,
+            LEFT,
+            LEFT_FETCH,
+            RIGHT,
+            RIGHT_FETCH,
+            FETCH,
+            INNER
+        )),
     /**
      * MySQL 5.5 or above.
      */
-    MYSQL(true, true, false),
+    MYSQL(true, true, false, EnumSet.of(
+        DEFAULT,
+        LEFT,
+        LEFT_FETCH,
+        RIGHT,
+        RIGHT_FETCH,
+        FETCH,
+        INNER
+    )),
     /**
      * Postgres 9.5 or later.
      */
-    POSTGRES(true, false, true),
+    POSTGRES(true, false, true, ALL_TYPES),
     /**
      * SQL server 2012 or above.
      */
-    SQL_SERVER(false, false, false),
+    SQL_SERVER(false, false, false, ALL_TYPES),
     /**
      * Oracle 12c or above.
      */
-    ORACLE(true, true, false),
+    ORACLE(true, true, false, ALL_TYPES),
     /**
      * Ansi compliant SQL.
      */
-    ANSI(true, false, true);
+    ANSI(true, false, true, ALL_TYPES);
 
     private final boolean supportsBatch;
     private final boolean stringUUID;
     private final boolean supportsArrays;
+
+    private final EnumSet<Join.Type> joinTypesSupported;
 
     /**
      * Allows customization of batch support.
      * @param supportsBatch If batch is supported
      * @param stringUUID Does the dialect require a string UUID
      * @param supportsArrays Does the dialect supports arrays
+     * @param joinTypesSupported EnumSet of supported join types.
      */
-    Dialect(boolean supportsBatch, boolean stringUUID, boolean supportsArrays) {
+    Dialect(boolean supportsBatch, boolean stringUUID, boolean supportsArrays, EnumSet<Join.Type> joinTypesSupported) {
         this.supportsBatch = supportsBatch;
         this.stringUUID = stringUUID;
         this.supportsArrays = supportsArrays;
+        this.joinTypesSupported = joinTypesSupported;
     }
 
     /**
@@ -106,4 +132,15 @@ public enum Dialect {
     public final boolean requiresStringUUID(@NonNull DataType type) {
         return type == DataType.UUID && this.stringUUID;
     }
+
+    /**
+     * Determines whether the join type is supported this dialect.
+     *
+     * @param joinType the join type
+     * @return True if the type is supported by this dialect.
+     */
+    public final boolean supportsJoinType(@NonNull Join.Type joinType) {
+        return this.joinTypesSupported.contains(joinType);
+    }
+
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -908,6 +908,10 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
 
     @Override
     public String resolveJoinType(Join.Type jt) {
+        if (!this.dialect.supportsJoinType(jt)) {
+            throw new IllegalArgumentException("Unsupported join type [" + jt + "] by dialect [" + this.dialect + "]");
+        }
+
         String joinType;
         switch (jt) {
             case LEFT:
@@ -919,6 +923,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
                 joinType = " RIGHT JOIN ";
                 break;
             case OUTER:
+            case OUTER_FETCH:
                 joinType = " FULL OUTER JOIN ";
                 break;
             default:

--- a/data-model/src/test/groovy/io/micronaut/data/model/annotation/JoinTypeSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/annotation/JoinTypeSpec.groovy
@@ -25,6 +25,7 @@ class JoinTypeSpec extends Specification {
         Join.Type.FETCH.isFetch()
         Join.Type.LEFT_FETCH.isFetch()
         Join.Type.RIGHT_FETCH.isFetch()
+        Join.Type.OUTER_FETCH.isFetch()
         !Join.Type.LEFT.isFetch()
         !Join.Type.RIGHT.isFetch()
         !Join.Type.DEFAULT.isFetch()

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJoinFetchSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJoinFetchSpec.groovy
@@ -1,0 +1,159 @@
+package io.micronaut.data.tck.tests
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.entities.AuthorBooksDto
+import io.micronaut.data.tck.repositories.*
+import spock.lang.AutoCleanup
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class AbstractJoinFetchSpec extends Specification {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
+    @Shared
+    boolean leftJoinSupported = true
+
+    @Shared
+    boolean leftFetchJoinSupported = true
+
+    @Shared
+    boolean rightJoinSupported = true
+
+    @Shared
+    boolean rightFetchJoinSupported = true
+
+    @Shared
+    boolean outerJoinSupported = true
+
+    @Shared
+    boolean outerFetchJoinSupported = true
+
+    @Shared
+    boolean fetchJoinSupported = true
+
+    @Shared
+    boolean innerJoinSupported = true
+
+    abstract BookRepository getBookRepository()
+    abstract AuthorRepository getAuthorRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinLeftFetchRepository getAuthorJoinLeftFetchRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinLeftRepository getAuthorJoinLeftRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinRightFetchRepository getAuthorJoinRightFetchRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinRightRepository getAuthorJoinRightRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinOuterRepository getAuthorJoinOuterRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinOuterFetchRepository getAuthorJoinOuterFetchRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinFetchRepository getAuthorJoinFetchRepository()
+
+    abstract AuthorJoinTypeRepositories.AuthorJoinInnerRepository getAuthorJoinInnerRepository()
+
+    void setup() {
+        saveSampleBooks()
+    }
+
+    void cleanup() {
+        bookRepository?.deleteAll()
+        authorRepository?.deleteAll()
+    }
+
+    void saveSampleBooks() {
+        bookRepository.saveAuthorBooks([
+                new AuthorBooksDto("Stephen King", Arrays.asList(
+                        new io.micronaut.data.tck.entities.BookDto("The Stand", 1000),
+                        new io.micronaut.data.tck.entities.BookDto("Pet Sematary", 400)
+                ))
+        ])
+    }
+
+    @Requires({shared.leftJoinSupported})
+    void "left join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinLeftRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.leftFetchJoinSupported})
+    void "left fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinLeftFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.rightJoinSupported})
+    void "right join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinRightRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.rightFetchJoinSupported})
+    void "right fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinRightFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.outerJoinSupported})
+    void "outer join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinOuterRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+    @Requires({shared.outerFetchJoinSupported})
+    void "outer fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinOuterFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.fetchJoinSupported})
+    void "fetch join fetches projected entities"() {
+        given:
+        def authors = getAuthorJoinFetchRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.title.containsAll(["The Stand", "Pet Sematary"])
+    }
+
+    @Requires({shared.innerJoinSupported})
+    void "inner join does not fetch projected entities"() {
+        given:
+        def authors = getAuthorJoinInnerRepository().findAll()
+
+        expect:
+        !authors.isEmpty()
+        authors.get(0).books.isEmpty()
+    }
+
+
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinTypeRepositories.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorJoinTypeRepositories.java
@@ -1,0 +1,52 @@
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.tck.entities.Author;
+
+import java.util.List;
+
+/**
+ * Interface holding a set of repository interfaces with findAll query and different join types.
+ */
+public interface AuthorJoinTypeRepositories {
+    interface AuthorJoinFetchRepository {
+        @Join(value = "books", type = Join.Type.FETCH)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinInnerRepository {
+        @Join(value = "books", type = Join.Type.INNER)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinLeftFetchRepository {
+        @Join(value = "books", type = Join.Type.LEFT_FETCH)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinLeftRepository {
+        @Join(value = "books", type = Join.Type.LEFT)
+        List<Author> findAll();
+
+    }
+
+    interface AuthorJoinOuterFetchRepository {
+        @Join(value = "books", type = Join.Type.OUTER_FETCH)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinOuterRepository {
+        @Join(value = "books", type = Join.Type.OUTER)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinRightFetchRepository {
+        @Join(value = "books", type = Join.Type.RIGHT_FETCH)
+        List<Author> findAll();
+    }
+
+    interface AuthorJoinRightRepository {
+        @Join(value = "books", type = Join.Type.RIGHT)
+        List<Author> findAll();
+    }
+}

--- a/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
+++ b/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
@@ -19,7 +19,7 @@ snippet::example.ProductRepository[project-base="doc-examples/hibernate-example"
 
 <1> The ann:data.annotation.Join[] is used to indicate a `JOIN FETCH` clause should be included.
 
-Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER` or `RIGHT`.
+Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER`, `RIGHT` or `OUTER`.
 
 === JPA 2.1 Entity Graphs
 

--- a/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
+++ b/src/main/docs/guide/hibernate/hibernateJoinQueries.adoc
@@ -19,7 +19,7 @@ snippet::example.ProductRepository[project-base="doc-examples/hibernate-example"
 
 <1> The ann:data.annotation.Join[] is used to indicate a `JOIN FETCH` clause should be included.
 
-Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER`, `RIGHT` or `OUTER`.
+Note that the ann:data.annotation.Join[] annotation is repeatable and hence can be specified multiple times for different associations. In addition, the `type` member of the annotation can be used to specify the join type, for example `LEFT`, `INNER` or `RIGHT`.
 
 === JPA 2.1 Entity Graphs
 


### PR DESCRIPTION
This change adds OUTER_FETCH join type and makes SQLBuilder throw an exception when creating a repository bean for with a join type unsupported by a dialect (i.e. H2 or MySql and OUTER join)

Addded OUTER_FETCH join type
Dialect enum - joinTypesSupported field
SqlQueryBuilder - throws exception when initializing a repository with an unsupported join type (i.e. H2 and MySql with OUTER and OUTER_FETCH) Repository tests in data-jdbc, unit tests in data-model

Note:
This change does not implement OUTER or OUTER_FETCH to be working H2, that should be implemented in H2 itself.