### PR TITLE
Enable failing hibernate-reactive tests with PendingFeature annotation

### DIFF
--- a/data-hibernate-reactive/build.gradle
+++ b/data-hibernate-reactive/build.gradle
@@ -24,6 +24,11 @@ dependencies {
     testImplementation libs.groovy.sql
     testImplementation platform(libs.testcontainers.bom)
     testImplementation libs.testcontainers.postgresql
+    testImplementation libs.testcontainers.mysql
 
     testRuntimeOnly libs.drivers.vertx.pg
+    testRuntimeOnly libs.drivers.vertx.mysql
+
+    // Testcontainers wait function needs the driver
+    testImplementation libs.drivers.jdbc.mysql
 }

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
@@ -20,12 +20,10 @@ import io.micronaut.data.tck.entities.Face
 import io.micronaut.data.tck.entities.Product
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
-@IgnoreIf({ jvm.isJava15Compatible() })
 class AutoTimestampSpec extends Specification implements PostgresHibernateReactiveProperties {
 
     @Shared

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
@@ -95,7 +95,7 @@ class AutoTimestampSpec extends Specification implements PostgresHibernateReacti
         face.id != null
         dateCreated != null
         face.dateCreated == face.lastUpdated
-        taskRepo.findById(face.id).block().dateCreated == face.dateCreated
+        taskRepo.findById(face.id).block().dateCreated.toEpochMilli() == face.dateCreated.toEpochMilli()
 
         when:
         face.setName("Bar")
@@ -103,8 +103,8 @@ class AutoTimestampSpec extends Specification implements PostgresHibernateReacti
         def task2 = taskRepo.findById(face.id).block()
 
         then:
-        face.dateCreated == dateCreated
-        face.dateCreated == task2.dateCreated
+        face.dateCreated.toEpochMilli() == dateCreated.toEpochMilli()
+        face.dateCreated.toEpochMilli() == task2.dateCreated.toEpochMilli()
         task2.name == "Bar"
         task2.lastUpdated > task2.dateCreated
     }

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/AutoTimestampSpec.groovy
@@ -20,10 +20,12 @@ import io.micronaut.data.tck.entities.Face
 import io.micronaut.data.tck.entities.Product
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest(transactional = false, packages = "io.micronaut.data.tck.entities")
+@IgnoreIf({ jvm.isJava15Compatible() })
 class AutoTimestampSpec extends Specification implements PostgresHibernateReactiveProperties {
 
     @Shared
@@ -95,7 +97,7 @@ class AutoTimestampSpec extends Specification implements PostgresHibernateReacti
         face.id != null
         dateCreated != null
         face.dateCreated == face.lastUpdated
-        taskRepo.findById(face.id).block().dateCreated.toEpochMilli() == face.dateCreated.toEpochMilli()
+        taskRepo.findById(face.id).block().dateCreated == face.dateCreated
 
         when:
         face.setName("Bar")
@@ -103,8 +105,8 @@ class AutoTimestampSpec extends Specification implements PostgresHibernateReacti
         def task2 = taskRepo.findById(face.id).block()
 
         then:
-        face.dateCreated.toEpochMilli() == dateCreated.toEpochMilli()
-        face.dateCreated.toEpochMilli() == task2.dateCreated.toEpochMilli()
+        face.dateCreated == dateCreated
+        face.dateCreated == task2.dateCreated
         task2.name == "Bar"
         task2.lastUpdated > task2.dateCreated
     }

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
@@ -29,7 +29,6 @@ import io.micronaut.data.tck.entities.Student
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.hibernate.LazyInitializationException
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.PendingFeature
 import spock.lang.Shared
@@ -38,8 +37,6 @@ import spock.lang.Specification
 import jakarta.persistence.OptimisticLockException
 
 @MicronautTest(packages = "io.micronaut.data.tck.entities", transactional = false)
-// TODO: Re-enable when possible
-@Ignore("Temp disabled failing test")
 class HibernateQuerySpec extends Specification implements PostgresHibernateReactiveProperties {
 
     @Shared
@@ -146,6 +143,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             books3[0].title == "The Border"
     }
 
+    @PendingFeature
     void "author find by id with joins"() {
         when:
         def author = authorRepository.searchByName("Stephen King").block()
@@ -165,6 +163,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         author == null
     }
 
+    @PendingFeature
     void "author find by id with EntityGraph"() {
         when:
         def author = authorRepository.searchByName("Stephen King").block()
@@ -176,6 +175,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         author.books[1].pages.size() == 0
     }
 
+    @PendingFeature
     void "Rating find by id with named EntityGraph"() {
         setup:
         Book book = bookRepository.findByTitle("The Power of the Dog").block()
@@ -323,6 +323,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         !result.isPresent()
     }
 
+    @PendingFeature
     void "test @Where annotation placeholder"() {
         given:
         def size = bookRepository.countNativeByTitleWithPagesGreaterThan("The%", 300).block()
@@ -389,6 +390,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             books12.size() == 1
     }
 
+    @PendingFeature
     void "test IN queries"() {
         when:
             def books1 = bookRepository.listNativeBooksWithTitleInCollection(null).collectList().block()
@@ -435,6 +437,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             books1.size() == 1
     }
 
+    @PendingFeature
     void "test join on many ended association"() {
         when:
         def author = authorRepository.searchByName("Stephen King").block()
@@ -444,6 +447,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         author.books.size() == 2
     }
 
+    @PendingFeature
     void "test update many"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -454,6 +458,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             author.getBooks().every {it.title.endsWith(" updated")}
     }
 
+    @PendingFeature
     void "test update custom only titles"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -471,6 +476,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             author.getBooks().every {it.totalPages > 0}
     }
 
+    @PendingFeature
     void "test custom insert"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -485,6 +491,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             authorAfter.books.find { it.title == "Xyz" }
     }
 
+    @PendingFeature
     void "test custom single insert"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -518,6 +525,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             firstBook != null
     }
 
+    @PendingFeature
     void "test custom delete"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -532,6 +540,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             author.books.size() == 1
     }
 
+    @PendingFeature
     void "test custom delete single"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -554,6 +563,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             author.books.size() == 1
     }
 
+    @PendingFeature
     void "test custom delete by title"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()
@@ -566,6 +576,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             author.books.size() == 1
     }
 
+    @PendingFeature
     void "test update relation custom query"() {
         when:
             def book = bookRepository.findAllByTitleStartsWith("Along Came a Spider").collectList().block().first()
@@ -576,6 +587,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             book.author.id == book.author.id
     }
 
+    @PendingFeature
     void "test update relation"() {
         when:
             def book = bookRepository.findAllByTitleStartsWith("Along Came a Spider").collectList().block().first()
@@ -586,6 +598,7 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
             book.author.id == book.author.id
     }
 
+    @PendingFeature
     void "test query by relation"() {
         when:
             def author = authorRepository.searchByName("Stephen King").block()

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/MySqlCrudRepositorySpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/MySqlCrudRepositorySpec.groovy
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.hibernate.reactive
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.tck.entities.Person
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.PendingFeature
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+/**
+ * All tests in data-hibernate-reactive use Postgres but we need at least one for MySql.
+ */
+@MicronautTest(transactional = true, packages = "io.micronaut.data.tck.entities")
+@Stepwise
+class MySqlCrudRepositorySpec extends Specification implements MySqlHibernateReactiveProperties {
+
+    private static final Duration TEST_TIMEOUT = Duration.of(3, ChronoUnit.SECONDS)
+
+    @Inject
+    @Shared
+    PersonCrudRepository crudRepository
+
+    @Inject
+    @Shared
+    ApplicationContext context
+
+    /**
+     * This will be called from each method, to avoid test failure on setup.
+     * Currently MySql is not supported and will throw IllegalException because of timeout on block(timeout)
+     */
+    void setupData() {
+        if (crudRepository.count().block(TEST_TIMEOUT) == 0) {
+            crudRepository.saveAll([
+                    new Person(name: "Jeff"),
+                    new Person(name: "James")
+            ]).collectList().block(TEST_TIMEOUT)
+        }
+    }
+
+    @PendingFeature
+    void "test save one"() {
+        given:
+        setupData()
+
+        when:"one is saved"
+        def person = new Person(name: "Fred")
+        crudRepository.save(person).block()
+
+        then:"the instance is persisted"
+        person.id != null
+        crudRepository.findById(person.id).blockOptional().isPresent()
+        !crudRepository.findById(1000L).blockOptional().isPresent()
+        crudRepository.getById(person.id).block().name == 'Fred'
+        crudRepository.existsById(person.id).block()
+        crudRepository.count().block() == 3
+        crudRepository.count("Fred").block() == 1
+        crudRepository.findAll().collectList().block().size() == 3
+        crudRepository.listPeople("Fred").collectList().block().size() == 1
+    }
+
+    @PendingFeature
+    void "test save many"() {
+        given:
+        setupData()
+
+        when:"many are saved"
+        def p1 = crudRepository.save("Frank", 0).block()
+        def p2 = crudRepository.save("Bob", 0).block()
+        def people = [p1,p2]
+
+        then:"all are saved"
+        people.every { it.id != null }
+        people.every { crudRepository.findById(it.id).blockOptional().isPresent() }
+        crudRepository.findAll().collectList().block().size() == 5
+        crudRepository.count().block() == 5
+        crudRepository.count("Fred").block() == 1
+        crudRepository.list(Pageable.from(1)).collectList().block().isEmpty()
+        crudRepository.list(Pageable.from(0, 1)).collectList().block().size() == 1
+
+        when:"The person is updated with reactor"
+        long result = crudRepository.updatePersonRx(crudRepository.findByName("Jeff").block().id).block()
+
+        then:
+        result == 1
+
+    }
+
+    @PendingFeature
+    void "test delete by id"() {
+        given:
+        setupData()
+
+        when:"an entity is retrieved"
+        def person = crudRepository.findByName("Frank").block()
+
+        then:"the person is not null"
+        person != null
+        person.name == 'Frank'
+        crudRepository.findByName("Frank").block().name == person.name
+        crudRepository.findById(person.id).blockOptional().isPresent()
+
+        when:"the person is deleted"
+        crudRepository.deleteById(person.id).block()
+
+        then:"They are really deleted"
+        !crudRepository.findById(person.id).blockOptional().isPresent()
+        crudRepository.count().block() == 4
+    }
+
+    @PendingFeature
+    void "test delete by multiple ids"() {
+        given:
+        setupData()
+
+        when:"A search for some people"
+        def people = crudRepository.findAllAndDelete("J%").block()
+
+        then:
+        people.size() == 2
+
+        and:"Only the correct people are deleted"
+        people.every { !crudRepository.findById(it.id).blockOptional().isPresent() }
+        crudRepository.count().block() == 2
+    }
+
+    @PendingFeature
+    void "test delete one"() {
+        given:
+        setupData()
+
+        when:"A specific person is found and deleted"
+        def bob = crudRepository.findOneAndDelete("Bob").block()
+
+        then:"The person is present"
+        bob != null
+
+        and:"They are deleted"
+        !crudRepository.findById(bob.id).blockOptional().isPresent()
+        crudRepository.count().block() == 1
+    }
+
+    @PendingFeature
+    void "test update one"() {
+        given:
+        setupData()
+
+        when:"A person is retrieved"
+        def fred = crudRepository.findByName("Fred").block()
+        def id = fred.id
+        def jack = crudRepository.findByName("Jack").block()
+
+        then:"The person is present"
+        fred != null
+        jack == null
+
+        when:"The person name is updated"
+        crudRepository.updatePerson(id, "Jack").block()
+        fred = crudRepository.findByName("Fred").block()
+        jack = crudRepository.findByName("Jack").block()
+
+        then:"the person name is updated"
+        fred == null
+        jack != null
+        jack.name == "Jack"
+    }
+
+    @PendingFeature
+    void "test delete all"() {
+        given:
+        setupData()
+
+        when:"everything is deleted"
+        crudRepository.deleteAll().block()
+
+        then:"data is gone"
+        crudRepository.count().block() == 0
+    }
+
+}

--- a/data-hibernate-reactive/src/test/java/io/micronaut/data/hibernate/reactive/MySqlHibernateReactiveProperties.java
+++ b/data-hibernate-reactive/src/test/java/io/micronaut/data/hibernate/reactive/MySqlHibernateReactiveProperties.java
@@ -1,0 +1,24 @@
+package io.micronaut.data.hibernate.reactive;
+
+import io.micronaut.test.support.TestPropertyProvider;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+public interface MySqlHibernateReactiveProperties extends TestPropertyProvider {
+
+    MySQLContainer<?> CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql"));
+
+    @Override
+    default Map<String, String> getProperties() {
+        CONTAINER.start();
+        return Map.of(
+                "jpa.default.properties.hibernate.hbm2ddl.auto", "create-drop",
+                "jpa.default.reactive", "true",
+                "jpa.default.properties.hibernate.connection.url", CONTAINER.getJdbcUrl(),
+                "jpa.default.properties.hibernate.connection.username", CONTAINER.getUsername(),
+                "jpa.default.properties.hibernate.connection.password", CONTAINER.getPassword()
+        );
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ spring-data-commons = { module = "org.springframework.data:spring-data-commons",
 
 vertx-core = { module = "io.vertx:vertx-core", version.ref = "vertx" }
 drivers-vertx-pg = { module = "io.vertx:vertx-pg-client", version.ref = "vertx" }
+drivers-vertx-mysql = { module = "io.vertx:vertx-mysql-client", version.ref = "vertx" }
 
 # JDBC
 


### PR DESCRIPTION
Un-ignored failing tests for hibernate-reactive and marked with `@PendingFeature`
Also added on test for mysql because we had only postgres and missed that there are failures with mysql that [Cedric discovered in test-resources.](https://ge.micronaut.io/s/gbhoa7kzyoj3m/tests/overview?outcome=failed) Looking at [this](https://tinyurl.com/yuzks9cd), seems like mysql is not yet supported but should be soon.