### PR TITLE
Rework fix for issue #1948

### DIFF
--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataDecoderContext.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataDecoderContext.java
@@ -40,12 +40,12 @@ import org.bson.BsonDocument;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Codec;
 import org.bson.codecs.IterableCodec;
-import org.bson.codecs.MapCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.types.ObjectId;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * The Micronaut Data's Serde's {@link io.micronaut.serde.Deserializer.DecoderContext}.
@@ -188,7 +188,7 @@ final class DataDecoderContext implements Deserializer.DecoderContext {
         if (codec instanceof MappedCodec) {
             return ((MappedCodec<? extends T>) codec).deserializer;
         }
-        if (codec != null && !(codec instanceof IterableCodec) && !(codec instanceof MapCodec)) {
+        if (codec != null && !(codec instanceof IterableCodec) && !(Map.class.isAssignableFrom(codec.getEncoderClass()))) {
             return new CodecBsonDecoder<T>((Codec<T>) codec);
         }
         return parent.findDeserializer(type);

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataEncoderContext.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataEncoderContext.java
@@ -37,11 +37,11 @@ import io.micronaut.serde.reference.PropertyReference;
 import io.micronaut.serde.reference.SerializationReference;
 import org.bson.codecs.Codec;
 import org.bson.codecs.IterableCodec;
-import org.bson.codecs.MapCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.types.ObjectId;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Micronaut Data's Serde's {@link io.micronaut.serde.Serializer.EncoderContext}.
@@ -173,7 +173,7 @@ final class DataEncoderContext implements Serializer.EncoderContext {
         if (codec instanceof MappedCodec) {
             return ((MappedCodec<T>) codec).serializer;
         }
-        if (codec != null && !(codec instanceof IterableCodec) && !(codec instanceof MapCodec)) {
+        if (codec != null && !(codec instanceof IterableCodec) && !(Map.class.isAssignableFrom(codec.getEncoderClass()))) {
             return new CodecBsonDecoder<>((Codec<T>) codec);
         }
         return parent.findSerializer(type);

--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoDocumentRepositorySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoDocumentRepositorySpec.groovy
@@ -511,10 +511,14 @@ class MongoDocumentRepositorySpec extends AbstractDocumentRepositorySpec impleme
         optDoc.present
         def doc = optDoc.get()
         doc.owners.size() == 2
-        doc.owners["owner1"].name == "Owner1"
-        doc.owners["owner1"].age == 40
-        doc.owners["owner2"].name == "Owner2"
-        doc.owners["owner2"].age == 30
+        def docOwner1 = doc.owners["owner1"]
+        docOwner1.name == "Owner1"
+        docOwner1.age == 40
+        docOwner1.class == Owner
+        def docOwner2 = doc.owners["owner2"]
+        docOwner2.name == "Owner2"
+        docOwner2.age == 30
+        docOwner2.class == Owner
         cleanup:
         documentRepository.deleteAll()
     }


### PR DESCRIPTION
This is different workaround for issue when map of objects are returned as Bson which reappeared with new version of Bson serde libs. I think we want this fix, or else original issue should be reopened.