### PR TITLE
Enable AutoTimestampSpec hibernate reactive test and update comments for temp disabled tests

### DIFF
--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
@@ -36,6 +36,10 @@ import spock.lang.Specification
 
 import jakarta.persistence.OptimisticLockException
 
+/**
+ * Bunch of @PendingFeature tests here are because it seems hibernate reactive 2 Alpha using hibernate 6 CR is not handling
+ * joins well as previous version (hibernate reactive 1.1.x and hibernate 5.x).
+ */
 @MicronautTest(packages = "io.micronaut.data.tck.entities", transactional = false)
 class HibernateQuerySpec extends Specification implements PostgresHibernateReactiveProperties {
 

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/MySqlCrudRepositorySpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/MySqlCrudRepositorySpec.groovy
@@ -30,6 +30,8 @@ import java.time.temporal.ChronoUnit
 
 /**
  * All tests in data-hibernate-reactive use Postgres but we need at least one for MySql.
+ * MySql is currently failing with timeout when getting results so all tests are marked
+ * @PendingFeature until root cause found and fixed.
  */
 @MicronautTest(transactional = true, packages = "io.micronaut.data.tck.entities")
 @Stepwise
@@ -47,7 +49,7 @@ class MySqlCrudRepositorySpec extends Specification implements MySqlHibernateRea
 
     /**
      * This will be called from each method, to avoid test failure on setup.
-     * Currently MySql is not supported and will throw IllegalException because of timeout on block(timeout)
+     * Currently MySql will throw IllegalException because of timeout on block(timeout)
      */
     void setupData() {
         if (crudRepository.count().block(TEST_TIMEOUT) == 0) {


### PR DESCRIPTION
Enabling one hibernate reactive test that was disabled. Also updating comments about why some tests are marked `PendingFeature` as well as about MySql tests. For some reason .block() waits indefinitely with MySql in hibernate-reactive2 and when used timeout 2 secs it throws timeout error. Happens only for MySql for some reason. In hibernate reactive 1.1.x and hibernate 5.x works ok as can be seen [here](https://github.com/micronaut-projects/micronaut-data/compare/3.9.x...hibreactive-mysql-3.9.x) 
So currently we have two issues with hibernate-reactive in micronaut-data 4.0.0

1. Repository methods that return results with `Join` annotation are failing
2. MySql repository methods with .block(timeout) are failing. Didn't happen in prev version.

Will be trying to figure that out these days, but not in this PR. This is just to enable one test and update comments for a bit clarity about tests.