### PR TITLE
Fix for hibernate-reactive and EntityGraph join collection issue

### DIFF
--- a/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactiveRepositoryOperations.java
+++ b/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactiveRepositoryOperations.java
@@ -224,7 +224,10 @@ final class DefaultHibernateReactiveRepositoryOperations extends AbstractHiberna
     @Override
     public <T, R> Mono<R> findOne(PreparedQuery<T, R> preparedQuery) {
         return operation(session -> {
-            FirstResultCollector<R> collector = new FirstResultCollector<>(!preparedQuery.isNative());
+            // TODO: Until this issue https://github.com/hibernate/hibernate-reactive/issues/1551 is fixed
+            // we should not limit maxResults or else we could start having bugs
+            // FirstResultCollector<R> collector = new FirstResultCollector<>(!preparedQuery.isNative());
+            FirstResultCollector<R> collector = new FirstResultCollector<>(false);
             collectFindOne(session, preparedQuery, collector);
             return collector.result;
         });

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/HibernateQuerySpec.groovy
@@ -162,7 +162,6 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         author == null
     }
 
-    @PendingFeature(reason = "join books collection not returning all items with EntityGraph")
     void "author find by id with EntityGraph"() {
         when:
         def author = authorRepository.searchByName("Stephen King").block()
@@ -174,7 +173,6 @@ class HibernateQuerySpec extends Specification implements PostgresHibernateReact
         author.books[1].pages.size() == 0
     }
 
-    @PendingFeature(reason = "join books collection not returning all items with EntityGraph")
     void "Rating find by id with named EntityGraph"() {
         setup:
         Book book = bookRepository.findByTitle("The Power of the Dog").block()


### PR DESCRIPTION
I reported this [issue](https://github.com/hibernate/hibernate-reactive/issues/1551) in hibernate-reactive, but I think it would be ok to have this fix/workaround until they fix it.