### PR TITLE
Remove default Jakarta validation from repositories

### DIFF
--- a/data-document-model/build.gradle
+++ b/data-document-model/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     annotationProcessor mn.micronaut.inject.java
     annotationProcessor mn.micronaut.graal
     api mn.micronaut.inject
-    api mnValidation.micronaut.validation
     api mn.micronaut.aop
     api projects.dataModel
     api mnSerde.micronaut.serde.api

--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder.java
@@ -43,7 +43,6 @@ import io.micronaut.data.model.query.builder.QueryParameterBinding;
 import io.micronaut.data.model.query.builder.QueryResult;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 
-import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1165,7 +1164,7 @@ public final class MongoQueryBuilder implements QueryBuilder {
 
         PersistentPropertyPath getRequiredProperty(String name, Class<?> criterionClazz);
 
-        default int pushParameter(@NotNull BindingParameter bindingParameter, @NotNull BindingParameter.BindingContext bindingContext) {
+        default int pushParameter(@NonNull BindingParameter bindingParameter, @NonNull BindingParameter.BindingContext bindingContext) {
             return getQueryState().pushParameter(bindingParameter, bindingContext);
         }
 
@@ -1244,7 +1243,7 @@ public final class MongoQueryBuilder implements QueryBuilder {
          *
          * @return The parameters
          */
-        public @NotNull Map<String, String> getAdditionalRequiredParameters() {
+        public @NonNull Map<String, String> getAdditionalRequiredParameters() {
             return this.additionalRequiredParameters;
         }
 
@@ -1258,7 +1257,7 @@ public final class MongoQueryBuilder implements QueryBuilder {
         }
 
         @Override
-        public int pushParameter(@NotNull BindingParameter bindingParameter, @NotNull BindingParameter.BindingContext bindingContext) {
+        public int pushParameter(@NonNull BindingParameter bindingParameter, @NonNull BindingParameter.BindingContext bindingContext) {
             int index = position.getAndIncrement();
             bindingContext = bindingContext.index(index);
             parameterBindings.add(
@@ -1270,8 +1269,8 @@ public final class MongoQueryBuilder implements QueryBuilder {
 
     private interface PropertyParameterCreator {
 
-        int pushParameter(@NotNull BindingParameter bindingParameter,
-                          @NotNull BindingParameter.BindingContext bindingContext);
+        int pushParameter(@NonNull BindingParameter bindingParameter,
+                          @NonNull BindingParameter.BindingContext bindingContext);
 
     }
 

--- a/data-document-tck/build.gradle
+++ b/data-document-tck/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     annotationProcessor mnValidation.micronaut.validation.processor
 
     implementation projects.dataModel
+    implementation mnValidation.micronaut.validation
     implementation mnTest.micronaut.test.spock
     implementation mnTest.micronaut.test.core
     implementation libs.jakarta.persistence.api

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -217,7 +217,7 @@ public class HibernateJpaOperations extends AbstractHibernateOperations<Session,
     @NonNull
     @Override
     public <T> T load(@NonNull Class<T> type, @NonNull Serializable id) {
-        return transactionOperations.executeRead(status -> sessionFactory.getCurrentSession().load(type, id));
+        return transactionOperations.executeRead(status -> sessionFactory.getCurrentSession().getReference(type, id));
     }
 
     @Nullable

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/jpa/repository/JpaRepository.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/jpa/repository/JpaRepository.java
@@ -24,8 +24,6 @@ import io.micronaut.data.model.Sort;
 import io.micronaut.data.repository.CrudRepository;
 import io.micronaut.data.repository.PageableRepository;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.List;
 
@@ -40,7 +38,7 @@ import java.util.List;
 public interface JpaRepository<E, ID> extends CrudRepository<E, ID>, PageableRepository<E, ID> {
     @NonNull
     @Override
-    <S extends E> List<S> saveAll(@NonNull @Valid @NotNull Iterable<S> entities);
+    <S extends E> List<S> saveAll(@NonNull Iterable<S> entities);
 
     @NonNull
     @Override
@@ -57,7 +55,7 @@ public interface JpaRepository<E, ID> extends CrudRepository<E, ID>, PageableRep
      * @return The entity, possibly mutated
      */
     @QueryHint(name = "jakarta.persistence.FlushModeType", value = "AUTO")
-    <S extends E> S saveAndFlush(@NonNull @Valid @NotNull S entity);
+    <S extends E> S saveAndFlush(@NonNull S entity);
 
     /**
      * Adds a flush method.
@@ -72,5 +70,5 @@ public interface JpaRepository<E, ID> extends CrudRepository<E, ID>, PageableRep
      * @return An uninitialized proxy
      */
     @DataMethod(interceptor = LoadInterceptor.class)
-    <S extends E> S load(@NonNull @NotNull Serializable id);
+    <S extends E> S load(@NonNull Serializable id);
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/LoadSpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/LoadSpec.groovy
@@ -66,4 +66,12 @@ class LoadSpec extends Specification {
         thrown(ConstraintViolationException)
     }
 
+    def "retrieving an entity with null id throws an exception"() {
+        when:
+        childrenRepository.findById(null)
+
+        then:
+        thrown(ConstraintViolationException)
+    }
+
 }

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/ChildrenRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/ChildrenRepository.java
@@ -4,13 +4,21 @@ import io.micronaut.data.annotation.Query;
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.hibernate.entities.Children;
 import io.micronaut.data.hibernate.entities.ChildrenId;
+import io.micronaut.data.intercept.annotation.DataMethod;
 import io.micronaut.data.jpa.repository.JpaRepository;
+import io.micronaut.data.jpa.repository.intercept.LoadInterceptor;
+import jakarta.validation.constraints.NotNull;
+
+import java.io.Serializable;
 
 @Repository
-public interface ChildrenRepository extends JpaRepository<Children, ChildrenId> {
-
+public interface ChildrenRepository extends JpaRepository<Children, @NotNull ChildrenId> {
     //int findMaxIdNumberByIdParentId(int parentId);
 
     @Query(nativeQuery = true, value = "SELECT max(c.number) FROM children c WHERE c.parent_id = :parentId")
     Integer getMaxNumber(int parentId);
+
+    @DataMethod(interceptor = LoadInterceptor.class)
+    @Override
+    <S extends Children> S load(@NotNull Serializable id);
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2MealRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2MealRepository.java
@@ -17,9 +17,12 @@ package io.micronaut.data.jdbc.h2;
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.Meal;
 import io.micronaut.data.tck.repositories.MealRepository;
 import io.micronaut.validation.Validated;
+import jakarta.validation.Valid;
 
 @JdbcRepository(dialect = Dialect.H2)
-public interface H2MealRepository extends MealRepository {
+public interface H2MealRepository extends MealRepository, CrudRepository<@Valid Meal, Long> {
 }

--- a/data-model/build.gradle
+++ b/data-model/build.gradle
@@ -10,8 +10,8 @@ dependencies {
 
     api projects.dataTx
     api mn.micronaut.inject
-    api mnValidation.micronaut.validation
     api mn.micronaut.aop
+    api mn.micronaut.core.reactive
 
     implementation libs.reactor
 

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -51,7 +51,6 @@ import io.micronaut.data.model.query.QueryModel;
 import io.micronaut.data.model.query.QueryParameter;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 
-import jakarta.validation.constraints.NotNull;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2065,7 +2064,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
 
         QueryPropertyPath getRequiredProperty(String name, Class<?> criterionClazz);
 
-        default void pushParameter(@NotNull BindingParameter bindingParameter, @NotNull BindingParameter.BindingContext bindingContext) {
+        default void pushParameter(@NonNull BindingParameter bindingParameter, @NonNull BindingParameter.BindingContext bindingContext) {
             getQueryState().pushParameter(bindingParameter, bindingContext);
         }
 
@@ -2271,7 +2270,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
          *
          * @return The parameters
          */
-        public @NotNull Map<String, String> getAdditionalRequiredParameters() {
+        public @NonNull Map<String, String> getAdditionalRequiredParameters() {
             return this.additionalRequiredParameters;
         }
 
@@ -2285,7 +2284,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
         }
 
         @Override
-        public void pushParameter(@NotNull BindingParameter bindingParameter, @NotNull BindingParameter.BindingContext bindingContext) {
+        public void pushParameter(@NonNull BindingParameter bindingParameter, @NonNull BindingParameter.BindingContext bindingContext) {
             Placeholder placeholder = newParameter();
             bindingContext = bindingContext
                 .index(position.get() + 1)
@@ -2302,7 +2301,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
          *
          * @param parameterBinding the query parameter binding
          */
-        public void pushParameter(@NotNull QueryParameterBinding parameterBinding) {
+        public void pushParameter(@NonNull QueryParameterBinding parameterBinding) {
             parameterBindings.add(parameterBinding);
             queryParts.add(query.toString());
             query.setLength(0);
@@ -2319,8 +2318,8 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
 
     private interface PropertyParameterCreator {
 
-        void pushParameter(@NotNull BindingParameter bindingParameter,
-                           @NotNull BindingParameter.BindingContext bindingContext);
+        void pushParameter(@NonNull BindingParameter bindingParameter,
+                           @NonNull BindingParameter.BindingContext bindingContext);
 
     }
 
@@ -2377,7 +2376,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
          * @param propertyPath The propertyPath
          * @param tableAlias   The tableAlias
          */
-        public QueryPropertyPath(@NotNull PersistentPropertyPath propertyPath, @Nullable String tableAlias) {
+        public QueryPropertyPath(@NonNull PersistentPropertyPath propertyPath, @Nullable String tableAlias) {
             this.propertyPath = propertyPath;
             this.tableAlias = tableAlias;
         }

--- a/data-model/src/main/java/io/micronaut/data/repository/CrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/CrudRepository.java
@@ -17,10 +17,7 @@ package io.micronaut.data.repository;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Blocking;
-import io.micronaut.validation.Validated;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,40 +31,37 @@ import java.util.Optional;
  * @param <ID> The ID type
  */
 @Blocking
-@Validated
 public interface CrudRepository<E, ID> extends GenericRepository<E, ID> {
+
     /**
      * Saves the given valid entity, returning a possibly new entity representing the saved state. Note that certain implementations may not be able to detect whether a save or update should be performed and may always perform an insert. The {@link #update(Object)} method can be used in this case to explicitly request an update.
       *
      * @param entity The entity to save. Must not be {@literal null}.
      * @return The saved entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> S save(@Valid @NotNull @NonNull S entity);
+    <S extends E> S save(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entity. The method differs from {@link #save(Object)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entity The entity to save. Must not be {@literal null}.
      * @return The updated entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> S update(@Valid @NotNull @NonNull S entity);
+    <S extends E> S update(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entities. The method differs from {@link #saveAll(Iterable)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entities The entities to update. Must not be {@literal null}.
      * @return The updated entities will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if entities is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> List<S> updateAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> List<S> updateAll(@NonNull Iterable<S> entities);
 
     /**
      * Saves all given entities, possibly returning new instances representing the saved state.
@@ -75,29 +69,26 @@ public interface CrudRepository<E, ID> extends GenericRepository<E, ID> {
      * @param entities The entities to saved. Must not be {@literal null}.
      * @param <S> The generic type
      * @return The saved entities objects. will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entities are {@literal null}.
      */
     @NonNull
-    <S extends E> List<S> saveAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> List<S> saveAll(@NonNull Iterable<S> entities);
 
     /**
      * Retrieves an entity by its id.
      *
      * @param id The ID of the entity to retrieve. Must not be {@literal null}.
      * @return the entity with the given id or {@literal Optional#empty()} if none found
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
     @NonNull
-    Optional<E> findById(@NotNull @NonNull ID id);
+    Optional<E> findById(@NonNull ID id);
 
     /**
      * Returns whether an entity with the given id exists.
      *
      * @param id must not be {@literal null}.
      * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
-    boolean existsById(@NotNull @NonNull ID id);
+    boolean existsById(@NonNull ID id);
 
     /**
      * Returns all instances of the type.
@@ -117,25 +108,22 @@ public interface CrudRepository<E, ID> extends GenericRepository<E, ID> {
      * Deletes the entity with the given id.
      *
      * @param id must not be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    void deleteById(@NonNull @NotNull ID id);
+    void deleteById(@NonNull ID id);
 
     /**
      * Deletes a given entity.
      *
      * @param entity The entity to delete
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    void delete(@NonNull @NotNull E entity);
+    void delete(@NonNull E entity);
 
     /**
      * Deletes the given entities.
      *
      * @param entities The entities to delete
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    void deleteAll(@NonNull @NotNull Iterable<? extends E> entities);
+    void deleteAll(@NonNull Iterable<? extends E> entities);
 
     /**
      * Deletes all entities managed by the repository.

--- a/data-model/src/main/java/io/micronaut/data/repository/async/AsyncCrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/async/AsyncCrudRepository.java
@@ -19,8 +19,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.NonBlocking;
 import io.micronaut.data.repository.GenericRepository;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -38,33 +36,30 @@ public interface AsyncCrudRepository<E, ID> extends GenericRepository<E, ID> {
      *
      * @param entity The entity to save. Must not be {@literal null}.
      * @return The saved entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> CompletableFuture<S> save(@Valid @NotNull @NonNull S entity);
+    <S extends E> CompletableFuture<S> save(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entity. The method differs from {@link #save(Object)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entity The entity to updated. Must not be {@literal null}.
      * @return The updated entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> CompletableFuture<S> update(@Valid @NotNull @NonNull S entity);
+    <S extends E> CompletableFuture<S> update(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entities. The method differs from {@link #saveAll(Iterable)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entities The entities to update. Must not be {@literal null}.
      * @return The updating entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> CompletableFuture<? extends Iterable<S>> updateAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> CompletableFuture<? extends Iterable<S>> updateAll(@NonNull Iterable<S> entities);
 
     /**
      * Saves all given entities, possibly returning new instances representing the saved state.
@@ -72,30 +67,27 @@ public interface AsyncCrudRepository<E, ID> extends GenericRepository<E, ID> {
      * @param entities The entities to saved. Must not be {@literal null}.
      * @param <S> The generic type
      * @return The saved entities objects. will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entities are {@literal null}.
      */
     @NonNull
-    <S extends E> CompletableFuture<? extends Iterable<S>> saveAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> CompletableFuture<? extends Iterable<S>> saveAll(@NonNull Iterable<S> entities);
 
     /**
      * Retrieves an entity by its id.
      *
      * @param id The ID of the entity to retrieve. Must not be {@literal null}.
      * @return the entity with the given id or emits an {@link io.micronaut.data.exceptions.EmptyResultException} if it the entity is not found
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      * @throws io.micronaut.data.exceptions.EmptyResultException if no entity exists for the ID
      */
     @NonNull
-    CompletableFuture<E> findById(@NotNull @NonNull ID id);
+    CompletableFuture<E> findById(@NonNull ID id);
 
     /**
      * Returns whether an entity with the given id exists.
      *
      * @param id must not be {@literal null}.
      * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
-    @NonNull CompletableFuture<Boolean> existsById(@NotNull @NonNull ID id);
+    @NonNull CompletableFuture<Boolean> existsById(@NonNull ID id);
 
     /**
      * Returns all instances of the type.
@@ -116,27 +108,24 @@ public interface AsyncCrudRepository<E, ID> extends GenericRepository<E, ID> {
      *
      * @param id must not be {@literal null}.
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    @NonNull CompletableFuture<Void> deleteById(@NonNull @NotNull ID id);
+    @NonNull CompletableFuture<Void> deleteById(@NonNull ID id);
 
     /**
      * Deletes a given entity.
      *
      * @param entity The entity to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    @NonNull CompletableFuture<Void> delete(@NonNull @NotNull E entity);
+    @NonNull CompletableFuture<Void> delete(@NonNull E entity);
 
     /**
      * Deletes the given entities.
      *
      * @param entities The entities to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    @NonNull CompletableFuture<Void> deleteAll(@NonNull @NotNull Iterable<? extends E> entities);
+    @NonNull CompletableFuture<Void> deleteAll(@NonNull Iterable<? extends E> entities);
 
     /**
      * Deletes all entities managed by the repository.

--- a/data-model/src/main/java/io/micronaut/data/repository/reactive/ReactiveStreamsCrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/reactive/ReactiveStreamsCrudRepository.java
@@ -20,9 +20,6 @@ import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.data.repository.GenericRepository;
 import org.reactivestreams.Publisher;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
 /**
  * Interface for CRUD using Reactive Streams.
  *
@@ -38,12 +35,11 @@ public interface ReactiveStreamsCrudRepository<E, ID> extends GenericRepository<
      *
      * @param entity The entity to save. Must not be {@literal null}.
      * @return The saved entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
     @SingleResult
-    <S extends E> Publisher<S> save(@Valid @NotNull @NonNull S entity);
+    <S extends E> Publisher<S> save(@NonNull S entity);
 
     /**
      * Saves all given entities, possibly returning new instances representing the saved state.
@@ -51,53 +47,48 @@ public interface ReactiveStreamsCrudRepository<E, ID> extends GenericRepository<
      * @param entities The entities to saved. Must not be {@literal null}.
      * @param <S> The generic type
      * @return The saved entities objects. will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entities are {@literal null}.
      */
     @NonNull
-    <S extends E> Publisher<S> saveAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> Publisher<S> saveAll(@NonNull Iterable<S> entities);
 
     /**
      * This method issues an explicit update for the given entity. The method differs from {@link #save(Object)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entity The entity to update. Must not be {@literal null}.
      * @return The updated entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> Publisher<S> update(@Valid @NotNull @NonNull S entity);
+    <S extends E> Publisher<S> update(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entities. The method differs from {@link #saveAll(Iterable)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entities The entities to update. Must not be {@literal null}.
      * @return The updated entities will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if entities is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> Publisher<S> updateAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> Publisher<S> updateAll(@NonNull Iterable<S> entities);
 
     /**
      * Retrieves an entity by its id.
      *
      * @param id The ID of the entity to retrieve. Must not be {@literal null}.
      * @return the entity with the given id or {@literal Optional#empty()} if none found
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
     @NonNull
     @SingleResult
-    Publisher<E> findById(@NotNull @NonNull ID id);
+    Publisher<E> findById(@NonNull ID id);
 
     /**
      * Returns whether an entity with the given id exists.
      *
      * @param id must not be {@literal null}.
      * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
     @SingleResult
-    @NonNull Publisher<Boolean> existsById(@NotNull @NonNull ID id);
+    @NonNull Publisher<Boolean> existsById(@NonNull ID id);
 
     /**
      * Returns all instances of the type.
@@ -119,31 +110,28 @@ public interface ReactiveStreamsCrudRepository<E, ID> extends GenericRepository<
      *
      * @param id must not be {@literal null}.
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
     @NonNull
     @SingleResult
-    Publisher<Long> deleteById(@NonNull @NotNull ID id);
+    Publisher<Long> deleteById(@NonNull ID id);
 
     /**
      * Deletes a given entity.
      *
      * @param entity The entity to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
     @SingleResult
-    @NonNull Publisher<Long> delete(@NonNull @NotNull E entity);
+    @NonNull Publisher<Long> delete(@NonNull E entity);
 
     /**
      * Deletes the given entities.
      *
      * @param entities The entities to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
     @SingleResult
-    @NonNull Publisher<Long> deleteAll(@NonNull @NotNull Iterable<? extends E> entities);
+    @NonNull Publisher<Long> deleteAll(@NonNull Iterable<? extends E> entities);
 
     /**
      * Deletes all entities managed by the repository.

--- a/data-model/src/main/java/io/micronaut/data/repository/reactive/ReactorCrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/reactive/ReactorCrudRepository.java
@@ -19,9 +19,6 @@ import io.micronaut.core.annotation.NonNull;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
 /**
  * CRUD repository for Project Reactor.
  * @param <E> The entity type
@@ -35,27 +32,27 @@ import jakarta.validation.constraints.NotNull;
 public interface ReactorCrudRepository<E, ID> extends ReactiveStreamsCrudRepository<E, ID> {
     @NonNull
     @Override
-    <S extends E> Mono<S> save(@NonNull @Valid @NotNull S entity);
+    <S extends E> Mono<S> save(@NonNull S entity);
 
     @NonNull
     @Override
-    <S extends E> Flux<S> saveAll(@NonNull @Valid @NotNull Iterable<S> entities);
+    <S extends E> Flux<S> saveAll(@NonNull Iterable<S> entities);
 
     @NonNull
     @Override
-    <S extends E> Mono<S> update(@NonNull @Valid @NotNull S entity);
+    <S extends E> Mono<S> update(@NonNull S entity);
 
     @NonNull
     @Override
-    <S extends E> Flux<S> updateAll(@NonNull @Valid @NotNull Iterable<S> entities);
+    <S extends E> Flux<S> updateAll(@NonNull Iterable<S> entities);
 
     @NonNull
     @Override
-    Mono<E> findById(@NonNull @NotNull ID id);
+    Mono<E> findById(@NonNull ID id);
 
     @NonNull
     @Override
-    Mono<Boolean> existsById(@NonNull @NotNull ID id);
+    Mono<Boolean> existsById(@NonNull ID id);
 
     @NonNull
     @Override
@@ -67,15 +64,15 @@ public interface ReactorCrudRepository<E, ID> extends ReactiveStreamsCrudReposit
 
     @NonNull
     @Override
-    Mono<Long> deleteById(@NonNull @NotNull ID id);
+    Mono<Long> deleteById(@NonNull ID id);
 
     @NonNull
     @Override
-    Mono<Long> delete(@NonNull @NotNull E entity);
+    Mono<Long> delete(@NonNull E entity);
 
     @NonNull
     @Override
-    Mono<Long> deleteAll(@NonNull @NotNull Iterable<? extends E> entities);
+    Mono<Long> deleteAll(@NonNull Iterable<? extends E> entities);
 
     @NonNull
     @Override

--- a/data-model/src/main/java/io/micronaut/data/repository/reactive/RxJavaCrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/reactive/RxJavaCrudRepository.java
@@ -22,9 +22,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
 /**
  * Interface for CRUD using RxJava 2.
  *
@@ -40,11 +37,10 @@ public interface RxJavaCrudRepository<E, ID> extends GenericRepository<E, ID> {
      *
      * @param entity The entity to save. Must not be {@literal null}.
      * @return The saved entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> Single<S> save(@Valid @NotNull @NonNull S entity);
+    <S extends E> Single<S> save(@NonNull S entity);
 
     /**
      * Saves all given entities, possibly returning new instances representing the saved state.
@@ -52,51 +48,46 @@ public interface RxJavaCrudRepository<E, ID> extends GenericRepository<E, ID> {
      * @param entities The entities to saved. Must not be {@literal null}.
      * @param <S> The generic type
      * @return The saved entities objects. will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entities are {@literal null}.
      */
     @NonNull
-    <S extends E> Flowable<S> saveAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> Flowable<S> saveAll(@NonNull Iterable<S> entities);
 
     /**
      * Retrieves an entity by its id.
      *
      * @param id The ID of the entity to retrieve. Must not be {@literal null}.
      * @return the entity with the given id or {@literal Optional#empty()} if none found
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
     @NonNull
-    Maybe<E> findById(@NotNull @NonNull ID id);
+    Maybe<E> findById(@NonNull ID id);
 
     /**
      * This method issues an explicit update for the given entity. The method differs from {@link #save(Object)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entity The entity to update. Must not be {@literal null}.
      * @return The updated entity will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> Single<S> update(@Valid @NotNull @NonNull S entity);
+    <S extends E> Single<S> update(@NonNull S entity);
 
     /**
      * This method issues an explicit update for the given entities. The method differs from {@link #saveAll(Iterable)} in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
      *
      * @param entities The entities to update. Must not be {@literal null}.
      * @return The updated entities will never be {@literal null}.
-     * @throws jakarta.validation.ConstraintViolationException if entities is {@literal null} or invalid.
      * @param <S> The generic type
      */
     @NonNull
-    <S extends E> Flowable<S> updateAll(@Valid @NotNull @NonNull Iterable<S> entities);
+    <S extends E> Flowable<S> updateAll(@NonNull Iterable<S> entities);
 
     /**
      * Returns whether an entity with the given id exists.
      *
      * @param id must not be {@literal null}.
      * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-     * @throws jakarta.validation.ConstraintViolationException if the id is {@literal null}.
      */
-    @NonNull Single<Boolean> existsById(@NotNull @NonNull ID id);
+    @NonNull Single<Boolean> existsById(@NonNull ID id);
 
     /**
      * Returns all instances of the type.
@@ -117,28 +108,25 @@ public interface RxJavaCrudRepository<E, ID> extends GenericRepository<E, ID> {
      *
      * @param id must not be {@literal null}.
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
     @NonNull
-    Completable deleteById(@NonNull @NotNull ID id);
+    Completable deleteById(@NonNull ID id);
 
     /**
      * Deletes a given entity.
      *
      * @param entity The entity to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    @NonNull Completable delete(@NonNull @NotNull E entity);
+    @NonNull Completable delete(@NonNull E entity);
 
     /**
      * Deletes the given entities.
      *
      * @param entities The entities to delete
      * @return A future that executes the delete operation
-     * @throws jakarta.validation.ConstraintViolationException if the entity is {@literal null}.
      */
-    @NonNull Completable deleteAll(@NonNull @NotNull Iterable<? extends E> entities);
+    @NonNull Completable deleteAll(@NonNull Iterable<? extends E> entities);
 
     /**
      * Deletes all entities managed by the repository.

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/FindersUtils.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/FindersUtils.java
@@ -78,7 +78,6 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import org.reactivestreams.Publisher;
 
-import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Array;
 import java.lang.reflect.Modifier;
 import java.util.AbstractMap;
@@ -228,7 +227,7 @@ public interface FindersUtils {
     }
 
     static Map.Entry<ClassElement, Class<? extends DataInterceptor>> resolveSyncFindInterceptor(@NonNull MethodMatchContext matchContext,
-                                                                                                @NotNull ClassElement returnType) {
+                                                                                                @NonNull ClassElement returnType) {
         ClassElement firstTypeArgument = returnType.getFirstTypeArgument().orElse(null);
         if (isPage(matchContext, returnType)) {
             return typeAndInterceptorEntry(firstTypeArgument, FindPageInterceptor.class);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -41,7 +41,6 @@ import io.micronaut.data.model.runtime.convert.AttributeConverter;
 import io.micronaut.data.runtime.convert.DataConversionService;
 import io.micronaut.data.runtime.mapper.ResultReader;
 
-import jakarta.validation.constraints.NotNull;
 import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -730,7 +729,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             return associations.computeIfAbsent(association, a -> joinAssociation(joinPaths, association));
         }
 
-        public <K> MappingContext<K> associate(MappingContext<K> ctx, @NotNull Object associationId, @NotNull Object entity) {
+        public <K> MappingContext<K> associate(MappingContext<K> ctx, @NonNull Object associationId, @NonNull Object entity) {
             ctx.entity = (K) entity;
             if (manyAssociations == null) {
                 manyAssociations = new LinkedHashMap<>();

--- a/data-tck/build.gradle
+++ b/data-tck/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     annotationProcessor mnValidation.micronaut.validation.processor
     annotationProcessor projects.dataProcessor
 
+    implementation mnValidation.micronaut.validation
     implementation mn.micronaut.http.client
     implementation mn.micronaut.http.server.netty
     implementation projects.dataModel

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/MealRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/MealRepository.java
@@ -19,8 +19,9 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.Join;
 import io.micronaut.data.repository.CrudRepository;
 import io.micronaut.data.tck.entities.Meal;
+import jakarta.validation.Valid;
 
-public interface MealRepository extends CrudRepository<Meal, Long> {
+public interface MealRepository extends CrudRepository<@Valid Meal, Long> {
 
     @Nullable
     @Join("foods")

--- a/doc-examples/hibernate-example-groovy/build.gradle
+++ b/doc-examples/hibernate-example-groovy/build.gradle
@@ -14,11 +14,17 @@ micronaut {
 }
 
 dependencies {
+    compileOnly project(":data-processor")
+    compileOnly 'io.micronaut.validation:micronaut-validation-processor'
+
+    implementation projects.dataModel
+    implementation mnValidation.micronaut.validation
     implementation project(":data-hibernate-jpa")
     implementation "io.micronaut:micronaut-http-client"
     implementation 'io.micronaut.rxjava2:micronaut-rxjava2'
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
-    compileOnly project(":data-processor")
+    implementation 'io.micronaut.validation:micronaut-validation'
+
     runtimeOnly "ch.qos.logback:logback-classic"
     runtimeOnly "com.h2database:h2"
 }

--- a/doc-examples/hibernate-example-groovy/src/main/groovy/example/AccountRepository.groovy
+++ b/doc-examples/hibernate-example-groovy/src/main/groovy/example/AccountRepository.groovy
@@ -4,5 +4,5 @@ import io.micronaut.data.annotation.Repository
 import io.micronaut.data.repository.CrudRepository
 
 @Repository
-interface AccountRepository extends CrudRepository<Account, Long> {
+interface AccountRepository extends CrudRepository<@jakarta.validation.Valid Account, @jakarta.validation.constraints.Min(0) Long> {
 }

--- a/doc-examples/hibernate-example-java/build.gradle
+++ b/doc-examples/hibernate-example-java/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
     runtimeOnly "ch.qos.logback:logback-classic"
     runtimeOnly "com.h2database:h2"
+    runtimeOnly 'io.micronaut.validation:micronaut-validation'
 }

--- a/doc-examples/hibernate-example-java/src/main/java/example/AccountRepository.java
+++ b/doc-examples/hibernate-example-java/src/main/java/example/AccountRepository.java
@@ -4,5 +4,5 @@ import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.repository.CrudRepository;
 
 @Repository
-public interface AccountRepository extends CrudRepository<Account, Long> {
+public interface AccountRepository extends CrudRepository<@jakarta.validation.Valid Account, @jakarta.validation.constraints.Min(0) Long> {
 }

--- a/doc-examples/hibernate-example-kotlin/build.gradle
+++ b/doc-examples/hibernate-example-kotlin/build.gradle
@@ -19,10 +19,11 @@ dependencies {
     implementation project(":data-hibernate-jpa")
     implementation "io.micronaut.sql:micronaut-jdbc-tomcat"
     implementation mnKotlin.micronaut.kotlin.runtime
+    implementation 'io.micronaut.validation:micronaut-validation'
+    implementation libs.kotlin.coroutines
 
     kapt "io.micronaut.validation:micronaut-validation"
     kapt project(":data-processor")
     runtimeOnly "ch.qos.logback:logback-classic"
     runtimeOnly "com.h2database:h2"
-    implementation libs.kotlin.coroutines
 }

--- a/doc-examples/hibernate-example-kotlin/src/main/kotlin/example/AccountRepository.kt
+++ b/doc-examples/hibernate-example-kotlin/src/main/kotlin/example/AccountRepository.kt
@@ -4,4 +4,4 @@ import io.micronaut.data.annotation.Repository
 import io.micronaut.data.repository.CrudRepository
 
 @Repository
-interface AccountRepository : CrudRepository<Account, Long>
+interface AccountRepository : CrudRepository<@jakarta.validation.Valid Account, @jakarta.validation.constraints.Min(0) Long>

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AbstractBookRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AbstractBookRepository.kt
@@ -13,7 +13,7 @@ import kotlin.streams.toList
 abstract class AbstractBookRepository(private val jdbcOperations: JdbcOperations) : CrudRepository<Book, Long> {
 
     @Transactional
-    fun findByTitle(title: String): List<Book> {
+    open fun findByTitle(title: String): List<Book> {
         val sql = "SELECT * FROM Book AS book WHERE book.title = ?"
         return jdbcOperations.prepareStatement(sql) { statement ->
             statement.setString(1, title)

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/UserRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/UserRepository.kt
@@ -5,13 +5,12 @@ import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.CrudRepository
-import jakarta.validation.constraints.NotNull
 
 @JdbcRepository(dialect = Dialect.H2)
 interface UserRepository : CrudRepository<User, Long> { // <1>
 
     @Query("UPDATE user SET enabled = false WHERE id = :id") // <2>
-    override fun deleteById(@NotNull id: Long)
+    override fun deleteById(id: Long)
 
     @Query("SELECT * FROM user WHERE enabled = false") // <3>
     fun findDisabled(): List<User>

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,0 +1,15 @@
+This section documents breaking changes between Micronaut versions
+
+== 4.0.0
+
+===== Repositories validation
+
+Default repository interfaces no longer have Jakarta Validation annotations to validate the entity and the ID.
+To add the validation, annotate the repository's generic type argument with Jakarta Validation annotations:
+
+[source,java]
+----
+@Repository
+public interface BookRepository implements CrudRepository<@jakarta.validation.Valid Book, @jakarta.validation.constraints.NotNull Long> {
+}
+----

--- a/src/main/docs/guide/shared/validation.adoc
+++ b/src/main/docs/guide/shared/validation.adoc
@@ -1,0 +1,5 @@
+Repositories can have the entity and the ID values validated.
+To add the validation, annotate the repository's generic type argument with Jakarta Validation annotations:
+
+snippet::example.AccountRepository[project-base="doc-examples/hibernate-example", source="main"]
+

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -9,6 +9,8 @@ shared:
   title: Shared Concepts
   repositories:
     title: Repository Interfaces
+  validation:
+    title: Validation
   querying:
     title: Writing Queries
     criteria: Query Criteria

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,6 +1,7 @@
 introduction:
   title: Introduction
   whatsNew: What's New?
+  breaks: Breaking Changes
   releaseHistory: Release History
 buildConfig:
   title: Build Configuration


### PR DESCRIPTION
This removes implicit Jakarta Validation from repositories for performance reasons. With type annotations adding the functionality back is very easy.

Requires next validation milestone.