### PR TITLE
Potential fix for kotlin r2dbc mariadb example

### DIFF
--- a/doc-examples/r2dbc-example-kotlin/build.gradle
+++ b/doc-examples/r2dbc-example-kotlin/build.gradle
@@ -1,3 +1,5 @@
+import io.micronaut.testresources.buildtools.KnownModules
+
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
@@ -15,6 +17,7 @@ micronaut {
     runtime "netty"
     testRuntime "junit5"
     testResources {
+        additionalModules.add(KnownModules.R2DBC_MARIADB)
         clientTimeout = 300
         version = libs.versions.micronaut.testresources.get()
     }
@@ -38,5 +41,7 @@ dependencies {
 
     testImplementation "io.micronaut:micronaut-http-client"
     compileOnly mnSerde.micronaut.serde.api
+
+    testResourcesService mnSql.mariadb.java.client
 }
 


### PR DESCRIPTION
@dstepanov This seems to fixes r2dbc-example-kotlin. Looks like it's needed because r2dbc is imported like this
```
implementation projects.dataR2dbc
```
vs r2dbc-example-java which imports is this way
```
implementation("io.micronaut.data:micronaut-data-r2dbc")
```
so for some reason libs are not found on test resources classpath. The same happens when r2dbc import is switched to 
```
implementation projects.dataR2dbc
```
in r2dbc-example-java example