### PR TITLE
Eliminate `EmptyResultException` from async and reactive repositories

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/operations/async/AsyncRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/async/AsyncRepositoryOperations.java
@@ -46,7 +46,6 @@ public interface AsyncRepositoryOperations {
      * @param id The id
      * @param <T> The generic type
      * @return A completion stage that emits the result
-     * @throws io.micronaut.data.exceptions.EmptyResultException if the result couldn't be retrieved
      */
     @NonNull
     <T> CompletionStage<T> findOne(@NonNull Class<T> type, @NonNull Serializable id);
@@ -67,7 +66,6 @@ public interface AsyncRepositoryOperations {
      * @param <T> The generic resultType
      * @param <R> The result type
      * @return A completion stage that emits the result
-     * @throws io.micronaut.data.exceptions.EmptyResultException if the result couldn't be retrieved
      */
     @NonNull <T, R> CompletionStage<R> findOne(@NonNull PreparedQuery<T, R> preparedQuery);
 

--- a/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactiveRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactiveRepositoryOperations.java
@@ -39,7 +39,6 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param id The id
      * @param <T> The generic type
      * @return A publisher that emits the result
-     * @throws io.micronaut.data.exceptions.EmptyResultException if the result couldn't be retrieved
      */
     @NonNull
     @SingleResult
@@ -51,6 +50,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The declaring type
      * @return True if it exists
      */
+    @NonNull
+    @SingleResult
     <T> Publisher<Boolean> exists(@NonNull PreparedQuery<T, Boolean> preparedQuery);
 
     /**
@@ -60,10 +61,10 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic resultType
      * @param <R> The result type
      * @return A publisher that emits the result
-     * @throws io.micronaut.data.exceptions.EmptyResultException if the result couldn't be retrieved
      */
+    @NonNull
     @SingleResult
-    @NonNull <T, R> Publisher<R> findOne(@NonNull PreparedQuery<T, R> preparedQuery);
+    <T, R> Publisher<R> findOne(@NonNull PreparedQuery<T, R> preparedQuery);
 
     /**
      * Find one by ID.
@@ -72,7 +73,6 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param id The id
      * @param <T> The generic type
      * @return A publisher that emits zero or one result
-     * @throws io.micronaut.data.exceptions.EmptyResultException if the result couldn't be retrieved
      */
     @NonNull
     @SingleResult
@@ -86,8 +86,9 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <R> The result type
      * @return A publisher that emits the zero or one result
      */
+    @NonNull
     @SingleResult
-    @NonNull <T, R> Publisher<R> findOptional(@NonNull PreparedQuery<T, R> preparedQuery);
+    <T, R> Publisher<R> findOptional(@NonNull PreparedQuery<T, R> preparedQuery);
 
     /**
      * Finds all results for the given query.
@@ -95,7 +96,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the results
      */
-    @NonNull <T> Publisher<T> findAll(PagedQuery<T> pagedQuery);
+    @NonNull
+    <T> Publisher<T> findAll(PagedQuery<T> pagedQuery);
 
     /**
      * Counts all results for the given query.
@@ -103,8 +105,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the count as a long
      */
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Publisher<Long> count(PagedQuery<T> pagedQuery);
 
     /**
@@ -114,7 +116,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <R> The result type
      * @return A publisher that emits an iterable with all results
      */
-    @NonNull <T, R> Publisher<R> findAll(@NonNull PreparedQuery<T, R> preparedQuery);
+    @NonNull
+    <T, R> Publisher<R> findAll(@NonNull PreparedQuery<T, R> preparedQuery);
 
     /**
      * Persist the entity returning a possibly new entity.
@@ -122,8 +125,9 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the entity
      */
+    @NonNull
     @SingleResult
-    @NonNull <T> Publisher<T> persist(@NonNull InsertOperation<T> operation);
+    <T> Publisher<T> persist(@NonNull InsertOperation<T> operation);
 
     /**
      * Updates the entity returning a possibly new entity.
@@ -131,8 +135,9 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the entity
      */
+    @NonNull
     @SingleResult
-    @NonNull <T> Publisher<T> update(@NonNull UpdateOperation<T> operation);
+    <T> Publisher<T> update(@NonNull UpdateOperation<T> operation);
 
     /**
      * Updates the entities for the given operation.
@@ -141,9 +146,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return The updated entities
      */
-    default @NonNull <T> Publisher<T> updateAll(@NonNull UpdateBatchOperation<T> operation) {
-        throw new UnsupportedOperationException("The updateAll is required to be implemented.");
-    }
+    @NonNull
+    <T> Publisher<T> updateAll(@NonNull UpdateBatchOperation<T> operation);
 
     /**
      * Persist all the given entities.
@@ -151,7 +155,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return The entities, possibly mutated
      */
-    @NonNull <T> Publisher<T> persistAll(@NonNull InsertBatchOperation<T> operation);
+    @NonNull
+    <T> Publisher<T> persistAll(@NonNull InsertBatchOperation<T> operation);
 
     /**
      * Executes an update for the given query and parameter values. If it is possible to
@@ -185,8 +190,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the number of entities deleted
      */
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Publisher<Number> delete(@NonNull DeleteOperation<T> operation);
 
     /**
@@ -195,8 +200,8 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <T> The generic type
      * @return A publisher that emits the number of entities deleted
      */
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Publisher<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation);
 
     /**
@@ -205,7 +210,7 @@ public interface ReactiveRepositoryOperations extends ConversionServiceProvider 
      * @param <R> The entity generic type
      * @return The page type
      */
-    @SingleResult
     @NonNull
+    @SingleResult
     <R> Publisher<Page<R>> findPage(@NonNull PagedQuery<R> pagedQuery);
 }

--- a/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactorReactiveRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/reactive/ReactorReactiveRepositoryOperations.java
@@ -43,36 +43,38 @@ public interface ReactorReactiveRepositoryOperations extends ReactiveRepositoryO
     @SingleResult
     <T> Mono<T> findOne(@NonNull Class<T> type, @NonNull Serializable id);
 
+    @NonNull
+    @SingleResult
     <T> Mono<Boolean> exists(@NonNull PreparedQuery<T, Boolean> preparedQuery);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T, R> Mono<R> findOne(@NonNull PreparedQuery<T, R> preparedQuery);
 
     @NonNull
     @SingleResult
     <T> Mono<T> findOptional(@NonNull Class<T> type, @NonNull Serializable id);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T, R> Mono<R> findOptional(@NonNull PreparedQuery<T, R> preparedQuery);
 
     @NonNull
     <T> Flux<T> findAll(PagedQuery<T> pagedQuery);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Mono<Long> count(PagedQuery<T> pagedQuery);
 
     @NonNull
     <T, R> Flux<R> findAll(@NonNull PreparedQuery<T, R> preparedQuery);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Mono<T> persist(@NonNull InsertOperation<T> operation);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Mono<T> update(@NonNull UpdateOperation<T> operation);
 
     @NonNull
@@ -89,16 +91,16 @@ public interface ReactorReactiveRepositoryOperations extends ReactiveRepositoryO
     @SingleResult
     Mono<Number> executeDelete(@NonNull PreparedQuery<?, Number> preparedQuery);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Mono<Number> delete(@NonNull DeleteOperation<T> operation);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <T> Mono<Number> deleteAll(@NonNull DeleteBatchOperation<T> operation);
 
-    @SingleResult
     @NonNull
+    @SingleResult
     <R> Mono<Page<R>> findPage(@NonNull PagedQuery<R> pagedQuery);
 
 }

--- a/data-model/src/main/java/io/micronaut/data/repository/async/AsyncCrudRepository.java
+++ b/data-model/src/main/java/io/micronaut/data/repository/async/AsyncCrudRepository.java
@@ -75,7 +75,7 @@ public interface AsyncCrudRepository<E, ID> extends GenericRepository<E, ID> {
      * Retrieves an entity by its id.
      *
      * @param id The ID of the entity to retrieve. Must not be {@literal null}.
-     * @return the entity with the given id or emits an {@link io.micronaut.data.exceptions.EmptyResultException} if it the entity is not found
+     * @return the entity with the given id or null
      * @throws io.micronaut.data.exceptions.EmptyResultException if no entity exists for the ID
      */
     @NonNull

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
@@ -25,7 +25,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.data.annotation.Repository;
-import io.micronaut.data.exceptions.EmptyResultException;
 import io.micronaut.data.intercept.DataInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.runtime.convert.DataConversionService;
@@ -103,11 +102,7 @@ public final class DataIntroductionAdvice implements MethodInterceptor<Object, O
                     if (finalThrowable instanceof CompletionException) {
                         finalThrowable = finalThrowable.getCause();
                     }
-                    if (finalThrowable instanceof EmptyResultException && context.isSuspend() && context.isNullable()) {
-                        completableFuture.complete(null);
-                    } else {
-                        completableFuture.completeExceptionally(finalThrowable);
-                    }
+                    completableFuture.completeExceptionally(finalThrowable);
                 }
             }
         });

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
@@ -18,11 +18,17 @@ package io.micronaut.data.runtime.operations;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.data.model.runtime.*;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.runtime.DeleteBatchOperation;
+import io.micronaut.data.model.runtime.DeleteOperation;
+import io.micronaut.data.model.runtime.InsertBatchOperation;
+import io.micronaut.data.model.runtime.InsertOperation;
+import io.micronaut.data.model.runtime.PagedQuery;
+import io.micronaut.data.model.runtime.PreparedQuery;
+import io.micronaut.data.model.runtime.UpdateBatchOperation;
+import io.micronaut.data.model.runtime.UpdateOperation;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.operations.async.AsyncRepositoryOperations;
-import io.micronaut.data.exceptions.EmptyResultException;
-import io.micronaut.data.model.Page;
 
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
@@ -80,14 +86,7 @@ public class ExecutorAsyncOperations implements AsyncRepositoryOperations {
     @NonNull
     @Override
     public <T> CompletableFuture<T> findOne(@NonNull Class<T> type, @NonNull Serializable id) {
-        return supplyAsync(() -> {
-                    T r = datastore.findOne(type, id);
-                    if (r != null) {
-                        return r;
-                    } else {
-                        throw new EmptyResultException();
-                    }
-                }
+        return supplyAsync(() -> datastore.findOne(type, id)
         );
     }
 
@@ -99,27 +98,13 @@ public class ExecutorAsyncOperations implements AsyncRepositoryOperations {
     @NonNull
     @Override
     public <T, R> CompletableFuture<R> findOne(@NonNull PreparedQuery<T, R> preparedQuery) {
-        return supplyAsync(() -> {
-                    R r = datastore.findOne(preparedQuery);
-                    if (r != null) {
-                        return r;
-                    } else {
-                        throw new EmptyResultException();
-                    }
-                });
+        return supplyAsync(() -> datastore.findOne(preparedQuery));
     }
 
     @NonNull
     @Override
     public <T> CompletableFuture<T> findOptional(@NonNull Class<T> type, @NonNull Serializable id) {
-        return supplyAsync(() -> {
-                    T r = datastore.findOne(type, id);
-                    if (r != null) {
-                        return r;
-                    } else {
-                        throw new EmptyResultException();
-                    }
-                });
+        return supplyAsync(() -> datastore.findOne(type, id));
     }
 
     @NonNull

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -29,4 +29,8 @@ public TransactionOperations<org.hibernate.Session> hibernateTransactionOperatio
 Micronaut 4 comes with a rewritten transaction propagation and management. It replaces the previous implementation forked form Spring Framework.
 The new implementation has a newly added connection management, allowing to share a connection between multiple repositories and services without an open transaction. The are new method supporting extracting the current transaction status `TransactionOperations#findTransactionStatus`. The `TransactionStatus` now includes information about the connection and the transaction definition.
 
+===== Async and Reactive repositories
+
+Async and reactive repositories are no longer throw `EmptyResultException` if the entity is not found.
+
 

--- a/src/main/docs/guide/shared/querying.adoc
+++ b/src/main/docs/guide/shared/querying.adoc
@@ -19,6 +19,9 @@ The above examples return a single instance of an entity, the supported return t
 |*Return Type*
 |*Description*
 
+|`Book`
+|If `null` is retrieved only if the return type is nullable otherwise a api:data.exceptions.EmptyResultException[] is thrown
+
 |`List<Book>`
 |A `java.util.List` or any common `Iterable` type
 
@@ -26,7 +29,7 @@ The above examples return a single instance of an entity, the supported return t
 |A Java 8 `java.util.stream.Stream` instance
 
 |`Optional<Book>`
-|An optional value, if `null` is retrieved otherwise a api:data.exceptions.EmptyResultException[] is thrown
+|An optional value
 
 |`Page<Book>`
 |An instance of api:data.model.Page[] for pagination.


### PR DESCRIPTION
The default should be null for async as it's easier to work with, and publishers do support not producing a value.

To throw that error, we should support annotating `@NonNull` on the generic argument.