### PR TITLE
Support opening reactive transaction in tests

### DIFF
--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/reactive/MongoReactiveAsSyncTransactionSpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/reactive/MongoReactiveAsSyncTransactionSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.data.document.mongodb.reactive
+
+import io.micronaut.data.document.mongodb.repositories.MongoBookRepository
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.bson.types.ObjectId
+import spock.lang.Shared
+import spock.lang.Specification
+
+@MicronautTest
+class MongoReactiveAsSyncTransactionSpec extends Specification implements MongoSelectReactiveDriver {
+
+    @Shared @Inject MongoBookRepository repository
+
+    void 'test TX operation in test'() {
+        when:
+            repository.queryById(new ObjectId().toHexString())
+        then:
+            noExceptionThrown()
+    }
+}

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/MongoBookRepository.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/MongoBookRepository.java
@@ -1,8 +1,12 @@
 package io.micronaut.data.document.mongodb.repositories;
 
+import io.micronaut.data.document.tck.entities.Book;
 import io.micronaut.data.document.tck.repositories.AuthorRepository;
 import io.micronaut.data.document.tck.repositories.BookRepository;
 import io.micronaut.data.mongodb.annotation.MongoRepository;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
 
 @MongoRepository
 public abstract class MongoBookRepository extends BookRepository {
@@ -11,6 +15,6 @@ public abstract class MongoBookRepository extends BookRepository {
         super(authorRepository);
     }
 
-//    @Join("author.books")
-//    public abstract Iterable<BsonDocument> queryAll();
+    @Transactional(Transactional.TxType.MANDATORY)
+    public abstract Optional<Book> queryById(String id);
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2ReactiveAsSyncTransactionalTest.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2ReactiveAsSyncTransactionalTest.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.data.r2dbc.h2
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class H2ReactiveAsSyncTransactionalTest extends Specification implements H2TestPropertyProvider {
+
+    @Inject H2BookRepository repository
+
+    void 'test TX operation in test'() {
+        when:
+            repository.queryById(123456)
+        then:
+            noExceptionThrown()
+    }
+}

--- a/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/h2/H2BookRepository.java
+++ b/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/h2/H2BookRepository.java
@@ -2,11 +2,18 @@ package io.micronaut.data.r2dbc.h2;
 
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.r2dbc.annotation.R2dbcRepository;
+import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
 
 @R2dbcRepository(dialect = Dialect.H2)
 public abstract class H2BookRepository extends BookRepository {
     public H2BookRepository(H2AuthorRepository authorRepository) {
         super(authorRepository);
     }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    public abstract Optional<Book> queryById(Long id);
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
@@ -26,11 +26,17 @@ import io.micronaut.spring.tx.test.SpringTransactionTestExecutionListener;
 import io.micronaut.test.annotation.TransactionMode;
 import io.micronaut.test.context.TestContext;
 import io.micronaut.test.context.TestExecutionListener;
+import io.micronaut.test.context.TestMethodInterceptor;
+import io.micronaut.test.context.TestMethodInvocationContext;
 import io.micronaut.test.extensions.AbstractMicronautExtension;
 import io.micronaut.transaction.SynchronousTransactionManager;
 import io.micronaut.transaction.TransactionDefinition;
+import io.micronaut.transaction.TransactionOperations;
 import io.micronaut.transaction.TransactionStatus;
+import io.micronaut.transaction.support.ExceptionUtil;
+import io.micronaut.transaction.sync.SynchronousTransactionOperationsFromReactiveTransactionOperations;
 
+import java.io.UncheckedIOException;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,36 +47,63 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author graemerocher
  * @since 1.0.0
  */
-@EachBean(SynchronousTransactionManager.class)
+@EachBean(TransactionOperations.class)
 @Requires(classes = TestExecutionListener.class)
 @Requires(property = AbstractMicronautExtension.TEST_TRANSACTIONAL, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 @Replaces(SpringTransactionTestExecutionListener.class)
 @Internal
-public class DefaultTestTransactionExecutionListener implements TestExecutionListener {
-    private final SynchronousTransactionManager<Object> transactionManager;
+public class DefaultTestTransactionExecutionListener implements TestExecutionListener, TestMethodInterceptor<Object> {
+    @Nullable
+    private final SynchronousTransactionManager<Object> synchronousTransactionManager;
+    private final TransactionOperations<Object> transactionManager;
     private final TransactionMode transactionMode;
     private TransactionStatus<Object> tx;
     private final AtomicInteger counter = new AtomicInteger();
     private final AtomicInteger setupCounter = new AtomicInteger();
     private final boolean rollback;
+    private boolean skipSynchronousTransactionManagerExecution;
     @Nullable
     private final SpockMethodTransactionDefinitionProvider spockMethodTransactionDefinitionProvider;
 
     /**
-     * @param transactionManager                       Spring's {@code PlatformTransactionManager}
+     * @param transactionManager                       The transaction manager
      * @param rollback                                 {@code true} if the transaction should be rollback
      * @param transactionMode                          The transaction mode
      * @param spockMethodTransactionDefinitionProvider The spock method name extractor
      */
     protected DefaultTestTransactionExecutionListener(
-        SynchronousTransactionManager<Object> transactionManager,
+        TransactionOperations<Object> transactionManager,
         @Property(name = AbstractMicronautExtension.TEST_ROLLBACK, defaultValue = "true") boolean rollback,
         @Property(name = AbstractMicronautExtension.TEST_TRANSACTION_MODE, defaultValue = "SEPARATE_TRANSACTIONS") TransactionMode transactionMode,
         @Nullable SpockMethodTransactionDefinitionProvider spockMethodTransactionDefinitionProvider) {
         this.spockMethodTransactionDefinitionProvider = spockMethodTransactionDefinitionProvider;
         this.transactionManager = transactionManager;
+        this.synchronousTransactionManager = transactionManager instanceof SynchronousTransactionManager<Object> syncTx ? syncTx : null;
+        if (transactionMode == TransactionMode.SINGLE_TRANSACTION && transactionManager instanceof SynchronousTransactionOperationsFromReactiveTransactionOperations) {
+            throw new IllegalStateException("Transaction mode SINGLE_TRANSACTION is not supported when the transaction manager doesn't support detached transaction!");
+        }
         this.rollback = rollback;
         this.transactionMode = transactionMode;
+    }
+
+
+    @Override
+    public Object interceptTest(TestMethodInvocationContext<Object> methodInvocationContext) {
+        // Not all testing frameworks supports intercepting the invocation
+        skipSynchronousTransactionManagerExecution = true;
+        try {
+            return transactionManager.execute(TransactionDefinition.DEFAULT, status -> {
+                try {
+                    return TestMethodInterceptor.super.interceptTest(methodInvocationContext);
+                } catch (Throwable e) {
+                    throw new UncheckedException(e);
+                }
+            });
+        } catch (UncheckedException e) {
+            return ExceptionUtil.sneakyThrow(e.getCause());
+        } finally {
+            skipSynchronousTransactionManagerExecution = false;
+        }
     }
 
     @Override
@@ -108,6 +141,13 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
     @Override
     public void beforeTestExecution(TestContext testContext) {
         if (counter.getAndIncrement() == 0) {
+            if (skipSynchronousTransactionManagerExecution) {
+                // Already being executed
+                return;
+            }
+            if (synchronousTransactionManager == null) {
+                throw new IllegalStateException("Transaction manager doesn't support detached transaction and the testing framework doesn't support intercepting the test invocation!");
+            }
             TransactionDefinition definition;
             AnnotatedElement annotatedElement = testContext.getTestMethod();
             if (spockMethodTransactionDefinitionProvider != null) {
@@ -118,17 +158,32 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
             } else {
                 definition = TransactionDefinition.DEFAULT;
             }
-            tx = transactionManager.getTransaction(definition);
+            tx = synchronousTransactionManager.getTransaction(definition);
         }
     }
 
     private void afterTestExecution(boolean rollback) {
         if (counter.decrementAndGet() == 0) {
+            if (skipSynchronousTransactionManagerExecution) {
+                // Already being executed
+                return;
+            }
+            if (synchronousTransactionManager == null) {
+                return;
+            }
             if (rollback) {
-                transactionManager.rollback(tx);
+                synchronousTransactionManager.rollback(tx);
             } else {
-                transactionManager.commit(tx);
+                synchronousTransactionManager.commit(tx);
             }
         }
+    }
+
+    private static class UncheckedException extends RuntimeException {
+
+        UncheckedException(Throwable e) {
+            super(e);
+        }
+
     }
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
@@ -36,7 +36,6 @@ import io.micronaut.transaction.TransactionStatus;
 import io.micronaut.transaction.support.ExceptionUtil;
 import io.micronaut.transaction.sync.SynchronousTransactionOperationsFromReactiveTransactionOperations;
 
-import java.io.UncheckedIOException;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -85,7 +84,6 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
         this.rollback = rollback;
         this.transactionMode = transactionMode;
     }
-
 
     @Override
     public Object interceptTest(TestMethodInvocationContext<Object> methodInvocationContext) {


### PR DESCRIPTION
In some limited cases, we can support `@MicronautTest(transactional = true) for reactive transaction managers