### PR TITLE
Enable R2dbc multitenancy schema tests

### DIFF
--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresMultitenancySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresMultitenancySpec.groovy
@@ -22,10 +22,4 @@ class PostgresMultitenancySpec extends AbstractR2dbcMultitenancySpec implements 
                 'dialect'        : 'POSTGRES'
         ]
     }
-
-    @Override
-    boolean supportsSchemaMultitenancy() {
-        // TODO: Remove this after changes for reactive context propagation
-        return false
-    }
 }

--- a/doc-examples/r2dbc-multitenancy-schema-example-java/build.gradle
+++ b/doc-examples/r2dbc-multitenancy-schema-example-java/build.gradle
@@ -1,3 +1,5 @@
+import io.micronaut.testresources.buildtools.KnownModules
+
 plugins {
     id "io.micronaut.build.internal.data-native-example"
 }
@@ -11,6 +13,7 @@ micronaut {
     runtime "netty"
     testRuntime "junit5"
     testResources {
+        additionalModules.add(KnownModules.R2DBC_MARIADB)
         clientTimeout = 300
         version = libs.versions.micronaut.testresources.get()
     }
@@ -20,19 +23,16 @@ dependencies {
     annotationProcessor projects.dataDocumentProcessor
 
     implementation mnMultitenancy.micronaut.multitenancy
-    implementation 'io.micronaut.reactor:micronaut-reactor'
-    implementation 'io.micronaut:micronaut-http-client'
-    implementation 'io.micronaut.data:micronaut-data-r2dbc'
+    implementation mnReactor.micronaut.reactor
+    implementation mn.micronaut.http.client
+    implementation projects.dataR2dbc
     implementation mnSerde.micronaut.serde.jackson
 
     implementation libs.jakarta.persistence.api
     implementation libs.jakarta.transaction.api
 
     runtimeOnly mnR2dbc.r2dbc.mariadb
-
-    testImplementation "io.micronaut:micronaut-http-client"
-
-    runtimeOnly "ch.qos.logback:logback-classic"
+    runtimeOnly mnLogging.logback.classic
 
     testResourcesService mnSql.mariadb.java.client
 }

--- a/doc-examples/r2dbc-multitenancy-schema-example-java/src/test/java/example/BookR2dbcSchemaMultiTenancySpec.java
+++ b/doc-examples/r2dbc-multitenancy-schema-example-java/src/test/java/example/BookR2dbcSchemaMultiTenancySpec.java
@@ -10,7 +10,6 @@ import io.r2dbc.spi.Result;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import reactor.core.publisher.Flux;
@@ -24,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @MicronautTest(transactional = false)
-// TODO: Enable after changes for reactive context propagation
-@Disabled("Might need different logic for R2DBC and context propagation")
 class BookR2dbcSchemaMultiTenancySpec {
 
     @Inject

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,6 @@ micronautBuild {
     importMicronautCatalog("micronaut-multitenancy")
     importMicronautCatalog("micronaut-testresources")
     importMicronautCatalog("micronaut-validation")
-    importMicronautCatalog("micronaut-logging")
     importMicronautCatalog("micronaut-mongo")
     importMicronautCatalog("micronaut-flyway")
 }


### PR DESCRIPTION
It looks like with latest Micronaut version, R2dbc multitenancy schema tests are passing so we can enable them.