### PR TITLE
Transaction API improvements

### DIFF
--- a/data-spring-jdbc/src/main/java/io/micronaut/data/spring/tx/AbstractSpringTransactionOperations.java
+++ b/data-spring-jdbc/src/main/java/io/micronaut/data/spring/tx/AbstractSpringTransactionOperations.java
@@ -22,7 +22,6 @@ import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.TransactionCallback;
 import io.micronaut.transaction.TransactionDefinition;
 import io.micronaut.transaction.TransactionStatus;
-import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.support.AbstractPropagatedStatusTransactionOperations;
 import io.micronaut.transaction.support.ExceptionUtil;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -147,16 +146,6 @@ public abstract class AbstractSpringTransactionOperations
             return transactionDefinition;
         }
 
-        @Override
-        public boolean hasSavepoint() {
-            return springStatus.hasSavepoint();
-        }
-
-        @Override
-        public void flush() {
-            springStatus.flush();
-        }
-
         @NonNull
         @Override
         public Object getTransaction() {
@@ -175,41 +164,11 @@ public abstract class AbstractSpringTransactionOperations
         }
 
         @Override
-        public Object createSavepoint() throws TransactionException {
-            return springStatus.createSavepoint();
-        }
-
-        @Override
-        public void rollbackToSavepoint(Object savepoint) throws TransactionException {
-            springStatus.rollbackToSavepoint(savepoint);
-        }
-
-        @Override
-        public void releaseSavepoint(Object savepoint) throws TransactionException {
-            springStatus.releaseSavepoint(savepoint);
-        }
-
-        @Override
         public void registerSynchronization(@NonNull io.micronaut.transaction.support.TransactionSynchronization synchronization) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public int getOrder() {
                     return synchronization.getOrder();
-                }
-
-                @Override
-                public void suspend() {
-                    synchronization.suspend();
-                }
-
-                @Override
-                public void resume() {
-                    synchronization.resume();
-                }
-
-                @Override
-                public void flush() {
-                    synchronization.flush();
                 }
 
                 @Override

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
@@ -78,10 +78,6 @@ public final class SpringHibernateTransactionOperations implements TransactionOp
     @Override
     public <R> R execute(TransactionDefinition definition, TransactionCallback<Session, R> callback) {
         return transactionOperations.execute(definition, status -> callback.call(new TransactionStatus<>() {
-            @Override
-            public boolean hasSavepoint() {
-                return status.hasSavepoint();
-            }
 
             @Override
             public Object getTransaction() {
@@ -96,21 +92,6 @@ public final class SpringHibernateTransactionOperations implements TransactionOp
             @Override
             public ConnectionStatus<Session> getConnectionStatus() {
                 throw new IllegalStateException("Connection status is not supported for Spring Hibernate TX manager!");
-            }
-
-            @Override
-            public Object createSavepoint() throws TransactionException {
-                return status.createSavepoint();
-            }
-
-            @Override
-            public void rollbackToSavepoint(Object savepoint) throws TransactionException {
-                status.releaseSavepoint(savepoint);
-            }
-
-            @Override
-            public void releaseSavepoint(Object savepoint) throws TransactionException {
-                status.releaseSavepoint(savepoint);
             }
 
             @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionExecution.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionExecution.java
@@ -19,12 +19,10 @@ package io.micronaut.transaction;
 import io.micronaut.core.annotation.NonNull;
 
 /**
- * NOTICE: This is a fork of Spring's {@code PlatformTransactionManager} modernizing it
- * to use enums, Slf4j and decoupling from Spring.
- *
  * Common representation of the current state of a transaction.
  * Serves as base interface for {@link TransactionStatus} as well as
  * {@link io.micronaut.transaction.reactive.ReactiveTransactionStatus}.
+ * Partially based on https://github.com/spring-projects/spring-framework/blob/main/spring-tx/src/main/java/org/springframework/transaction/TransactionExecution.java
  *
  * @author Juergen Hoeller
  * @author graemerocher

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
@@ -21,60 +21,18 @@ import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.exceptions.TransactionUsageException;
 import io.micronaut.transaction.support.TransactionSynchronization;
 
-import java.io.Flushable;
-
 /**
- * NOTICE: This is a fork of Spring's {@code TransactionStatus} modernizing it
- * to use enums, Slf4j and decoupling from Spring.
- * <p>
- * Representation of the status of a transaction.
- *
- * <p>Transactional code can use this to retrieve status information,
- * and to programmatically request a rollback (instead of throwing
- * an exception that causes an implicit rollback).
- *
- * <p>Includes the {@link SavepointManager} interface to provide access
- * to savepoint management facilities. Note that savepoint management
- * is only available if supported by the underlying transaction manager.
+ * The transaction status.
  *
  * @param <T> The native transaction type
- * @author Juergen Hoeller
- * @see #setRollbackOnly()
- * @see SynchronousTransactionManager#getTransaction
- * @since 27.03.2003
+ * @author graemerocher
+ * @author Denis Stepanov
+ * @since 1.0.0
  */
-public interface TransactionStatus<T> extends TransactionExecution, SavepointManager, Flushable {
+public interface TransactionStatus<T> extends TransactionExecution {
 
     /**
-     * Return whether this transaction internally carries a savepoint,
-     * that is, has been created as nested transaction based on a savepoint.
-     * <p>This method is mainly here for diagnostic purposes, alongside
-     * {@link #isNewTransaction()}. For programmatic handling of custom
-     * savepoints, use the operations provided by {@link SavepointManager}.
-     *
-     * @return Whether a save point is present
-     * @see #isNewTransaction()
-     * @see #createSavepoint()
-     * @see #rollbackToSavepoint(Object)
-     * @see #releaseSavepoint(Object)
-     */
-    boolean hasSavepoint();
-
-    /**
-     * Flush the underlying session to the datastore, if applicable:
-     * for example, all affected Hibernate/JPA sessions.
-     * <p>This is effectively just a hint and may be a no-op if the underlying
-     * transaction manager does not have a flush concept. A flush signal may
-     * get applied to the primary resource or to transaction synchronizations,
-     * depending on the underlying resource.
-     */
-    @Override
-    default void flush() {
-        // Default is no-op
-    }
-
-    /**
-     * @return The underlying transaction object.
+     * @return The underlying transaction object if exists.
      */
     @Nullable
     Object getTransaction();

--- a/data-tx/src/main/java/io/micronaut/transaction/impl/AbstractInternalTransaction.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/impl/AbstractInternalTransaction.java
@@ -17,7 +17,6 @@ package io.micronaut.transaction.impl;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.OrderUtil;
-import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.support.TransactionSynchronization;
 
 import java.util.ArrayList;
@@ -36,7 +35,7 @@ public abstract class AbstractInternalTransaction<C> implements InternalTransact
     private boolean globalRollbackOnly = false;
     private boolean completed = false;
 
-    private List<TransactionSynchronization> synchronizations;
+    protected List<TransactionSynchronization> synchronizations;
 
     /**
      * Set global rollback only.
@@ -68,27 +67,6 @@ public abstract class AbstractInternalTransaction<C> implements InternalTransact
     @Override
     public boolean isCompleted() {
         return completed;
-    }
-
-    @Override
-    public boolean hasSavepoint() {
-        return false;
-    }
-
-    public void releaseHeldSavepoint() throws TransactionException {
-    }
-
-    @Override
-    public Object createSavepoint() throws TransactionException {
-        return null;
-    }
-
-    @Override
-    public void rollbackToSavepoint(Object savepoint) throws TransactionException {
-    }
-
-    @Override
-    public void releaseSavepoint(Object savepoint) throws TransactionException {
     }
 
     @Override
@@ -130,15 +108,6 @@ public abstract class AbstractInternalTransaction<C> implements InternalTransact
 
     @Override
     public void cleanupAfterCompletion() {
-    }
-
-    @Override
-    public void flush() {
-        if (synchronizations != null) {
-            for (TransactionSynchronization synchronization : synchronizations) {
-                synchronization.flush();
-            }
-        }
     }
 
     @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/impl/InternalTransaction.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/impl/InternalTransaction.java
@@ -64,7 +64,5 @@ public interface InternalTransaction<T> extends TransactionStatus<T> {
 
     void triggerAfterCompletion(TransactionSynchronization.Status status);
 
-    void releaseHeldSavepoint();
-
     void cleanupAfterCompletion();
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/TransactionSynchronization.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/TransactionSynchronization.java
@@ -18,24 +18,18 @@ package io.micronaut.transaction.support;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.Ordered;
 
-import java.io.Flushable;
-
 /**
  * Interface for transaction synchronization callbacks.
- * Supported by AbstractPlatformTransactionManager.
  *
  * <p>TransactionSynchronization implementations can implement the Ordered interface
  * to influence their execution order. A synchronization that does not implement the
  * Ordered interface is appended to the end of the synchronization chain.
  *
- * <p>System synchronizations performed by Spring itself use specific order values,
- * allowing for fine-grained interaction with their execution order (if necessary).
- *
  * @author Juergen Hoeller
  * @since 02.06.2003
- * @see org.springframework.jdbc.datasource.DataSourceUtils#CONNECTION_SYNCHRONIZATION_ORDER
+ * @see io.micronaut.transaction.TransactionStatus#registerSynchronization(TransactionSynchronization)
  */
-public interface TransactionSynchronization extends Flushable, Ordered {
+public interface TransactionSynchronization extends Ordered {
 
     /**
      * Transaction synchronization status.
@@ -47,28 +41,6 @@ public interface TransactionSynchronization extends Flushable, Ordered {
         ROLLED_BACK,
         /** Completion status in case of heuristic mixed completion or system errors. */
         UNKNOWN
-    }
-
-    /**
-     * Suspend this synchronization.
-     * Supposed to unbind resources from TransactionSynchronizationManager if managing any.
-     */
-    default void suspend() {
-    }
-
-    /**
-     * Resume this synchronization.
-     */
-    default void resume() {
-    }
-
-    /**
-     * Flush the underlying session to the datastore, if applicable:
-     * for example, a Hibernate/JPA session.
-     * @see org.springframework.transaction.TransactionStatus#flush()
-     */
-    @Override
-    default void flush() {
     }
 
     /**

--- a/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
@@ -24,7 +24,6 @@ import io.micronaut.transaction.TransactionCallback;
 import io.micronaut.transaction.TransactionDefinition;
 import io.micronaut.transaction.TransactionOperations;
 import io.micronaut.transaction.TransactionStatus;
-import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus;
 import io.micronaut.transaction.reactive.ReactorReactiveTransactionOperations;
 import reactor.core.publisher.Mono;
@@ -99,21 +98,6 @@ public final class SynchronousTransactionOperationsFromReactiveTransactionOperat
         }
 
         @Override
-        public Object createSavepoint() throws TransactionException {
-            throw noSupported();
-        }
-
-        @Override
-        public void rollbackToSavepoint(Object savepoint) throws TransactionException {
-            throw noSupported();
-        }
-
-        @Override
-        public void releaseSavepoint(Object savepoint) throws TransactionException {
-            throw noSupported();
-        }
-
-        @Override
         public boolean isNewTransaction() {
             return transactionStatus.isNewTransaction();
         }
@@ -136,16 +120,6 @@ public final class SynchronousTransactionOperationsFromReactiveTransactionOperat
         @Override
         public TransactionDefinition getTransactionDefinition() {
             return transactionStatus.getTransactionDefinition();
-        }
-
-        @Override
-        public boolean hasSavepoint() {
-            throw noSupported();
-        }
-
-        @Override
-        public void flush() {
-            throw noSupported();
         }
 
         @Override


### PR DESCRIPTION
Removed some of the API from the transaction status that is not needed, flush and savepoint can be done from the status of the newly exposed connection status.