### PR TITLE
Use JoinColumn column when specified vs association id

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/many2one/MultiManyToOneJoinSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/many2one/MultiManyToOneJoinSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.data.jdbc.h2.many2one
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.data.annotation.*
+import io.micronaut.data.annotation.sql.JoinColumn
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.jdbc.h2.H2DBProperties
 import io.micronaut.data.jdbc.h2.H2TestPropertyProvider
@@ -27,6 +28,10 @@ class MultiManyToOneJoinSpec extends Specification implements H2TestPropertyProv
     @Shared
     @Inject
     RefARepository refARepository = applicationContext.getBean(RefARepository)
+
+    @Shared
+    @Inject
+    CustomBookRepository customBookRepository = applicationContext.getBean(CustomBookRepository)
 
     void 'test many-to-one hierarchy'() {
         given:
@@ -53,6 +58,25 @@ class MultiManyToOneJoinSpec extends Specification implements H2TestPropertyProv
         then:
             refA.id
             refA.refB.refC.name == "TestXyz"
+    }
+
+    void "test join via non identity join column"() {
+        given:
+        def customAuthor = new CustomAuthor()
+        customAuthor.name = "author1"
+        customAuthor.id2 = 20
+        def customBook = new CustomBook()
+        customBook.title = "book1"
+        customBook.pages = 100
+        customBook.author = customAuthor
+        customBookRepository.save(customBook)
+        when:
+        def books = customBookRepository.findAll()
+        then:
+        books.size() == 1
+        books[0].author.id2 == 20
+        cleanup:
+        customBookRepository.deleteAll()
     }
 }
 
@@ -97,4 +121,46 @@ class RefC {
     @GeneratedValue
     Long id
     String name
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+@Join("author")
+interface CustomBookRepository extends CrudRepository<CustomBook, Long> {
+}
+
+@MappedEntity(value = "custauthor1")
+class CustomAuthor {
+    @GeneratedValue
+    @Id
+    private Long id
+    private Long id2
+    private String name
+
+    Long getId() { return id }
+    void setId(Long id) { this.id = id }
+    Long getId2() { return id2 }
+    void setId2(Long id2) { this.id2 = id2 }
+    String getName() { return name }
+    void setName(String name) { this.name = name }
+}
+
+@MappedEntity(value = "custbook1")
+class CustomBook {
+    @GeneratedValue
+    @Id
+    private Long id
+    private String title
+    private int pages
+    @Relation(value = Relation.Kind.MANY_TO_ONE, cascade = Relation.Cascade.ALL)
+    @JoinColumn(name = "author_id2", referencedColumnName = "id2")
+    private CustomAuthor author
+
+    Long getId() { return id }
+    void setId(Long id) { this.id = id }
+    String getTitle() { return title }
+    void setTitle(String title) { this.title = title }
+    int getPages() { return pages }
+    void setPages(int pages) { this.pages = pages }
+    CustomAuthor getAuthor() { return author }
+    void setAuthor(CustomAuthor author) { this.author = author }
 }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -795,4 +795,61 @@ interface EmployeeGroupRepository extends GenericRepository<EmployeeGroup, Long>
         saveQuery == 'INSERT INTO `employee_group` (`name`,`category_id`,`employer_id`) VALUES (?,?,?)'
         findByCategoryIdQuery == 'SELECT employee_group_.`id`,employee_group_.`name`,employee_group_.`category_id`,employee_group_.`employer_id`,employee_.`id` AS employee_id,employee_.`name` AS employee_name,employee_.`category_id` AS employee_category_id,employee_.`employer_id` AS employee_employer_id FROM `employee_group` employee_group_ LEFT JOIN `employee` employee_ ON employee_group_.`employer_id`=employee_.`employer_id` AND employee_group_.`category_id`=employee_.`category_id` WHERE (employee_group_.`category_id` = ? AND (employee_group_.category_id =?))'
     }
+
+    void "test many-to-one with join column"() {
+        given:
+        def repository = buildRepository('test.CustomBookRepository', """
+import io.micronaut.data.annotation.*;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.GenericRepository;
+import jakarta.persistence.JoinColumn;
+@JdbcRepository(dialect = Dialect.H2)
+@Join("author")
+interface CustomBookRepository extends GenericRepository<CustomBook, Long> {
+    List<CustomBook> findAll();
+
+    CustomBook save(CustomBook book);
+}
+@MappedEntity
+class CustomAuthor {
+    @GeneratedValue
+    @Id
+    private Long id;
+    private Long id2;
+    private String name;
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getId2() { return id2; }
+    public void setId2(Long id2) { this.id2 = id2; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}
+@MappedEntity
+class CustomBook {
+    @GeneratedValue
+    @Id
+    private Long id;
+    private String title;
+    private int pages;
+    @Relation(Relation.Kind.MANY_TO_ONE)
+    @JoinColumn(name = "author_id2", referencedColumnName = "id2")
+    private CustomAuthor author;
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public int getPages() { return pages; }
+    public void setPages(int pages) { this.pages = pages; }
+    public CustomAuthor getAuthor() { return author; }
+    public void setAuthor(CustomAuthor author) { this.author = author; }
+}
+""")
+
+        def findAllMethod = repository.getRequiredMethod("findAll")
+        def findAllQuery = getQuery(findAllMethod)
+
+        expect:
+        findAllQuery == 'SELECT custom_book_.`id`,custom_book_.`title`,custom_book_.`pages`,custom_book_.`author_id2`,custom_book_author_.`id2` AS author_id2,custom_book_author_.`name` AS author_name FROM `custom_book` custom_book_ INNER JOIN `custom_author` custom_book_author_ ON custom_book_.`author_id2`=custom_book_author_.`id2`'
+    }
 }


### PR DESCRIPTION
This is another attempt to fix #1793. I had different PR earlier, but this one looks a bit more safe.
As you suggested @dstepanov [earlier](https://github.com/micronaut-projects/micronaut-data/pull/1796#issuecomment-1288570738), I have added logic in `MappedEntityVisitor` to generate `MappedProperty` value (if not specified by the user already) using `@JoinColumn` value but that alone was not enough because binding was also using association default identity vs join column reference column name so this change includes that as well.