### PR TITLE
Fix criteria specification issue where association identity is in the criteria

### DIFF
--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
@@ -15,60 +15,9 @@
  */
 package io.micronaut.data.hibernate
 
-import io.micronaut.data.hibernate.entities.RelPerson
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
-import spock.lang.Shared
 
 @MicronautTest(packages = "io.micronaut.data.tck.entities", rollback = false, transactional = false)
 @H2DBProperties
 class HibernateQuerySpec extends AbstractHibernateQuerySpec {
-
-    @Shared
-    @Inject
-    RelPersonRepository relPersonRepo
-
-    void "test relations person repository and joins"() {
-        given:
-        def parent = new RelPerson()
-        parent.name = 'RelParent'
-        relPersonRepo.save(parent)
-        def child1Friend1 = new RelPerson()
-        child1Friend1.name = 'Child1Friend1'
-        relPersonRepo.save(child1Friend1)
-        def child1Friend2 = new RelPerson()
-        child1Friend2.name = 'Child1Friend2'
-        relPersonRepo.save(child1Friend2)
-        def child2Friend1 = new RelPerson()
-        child2Friend1.name = 'Child2Friend1'
-        relPersonRepo.save(child2Friend1)
-        def child1 = new RelPerson()
-        child1.name = 'Child1'
-        child1.parent = parent
-        child1.friends = [child1Friend1, child1Friend2]
-        relPersonRepo.save(child1)
-        def child2 = new RelPerson()
-        child2.name = 'Child2'
-        child2.parent = parent
-        child2.friends = [child2Friend1]
-        relPersonRepo.save(child2)
-        when:
-        def result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByParentAndFriends(parent.id, List.of(child1Friend1.id, child1Friend2.id)))
-        then:
-        result.size() == 1
-        result[0].id == child1.id
-        when:
-        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByParentAndFriends(parent.id, List.of(child1Friend1.id, child1Friend2.id, child2Friend1.id)))
-        then:
-        result.size() == 2
-        when:
-        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByChildren(List.of(child1.id, child2.id)))
-        then:
-        result.size() == 1
-        result[0].id == parent.id
-        when:
-        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByChildren(List.of(child1Friend1.id, child1Friend2.id, child2Friend1.id)))
-        then:
-        result.size() == 0
-    }
 }

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/HibernateQuerySpec.groovy
@@ -15,9 +15,60 @@
  */
 package io.micronaut.data.hibernate
 
+import io.micronaut.data.hibernate.entities.RelPerson
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Shared
 
 @MicronautTest(packages = "io.micronaut.data.tck.entities", rollback = false, transactional = false)
 @H2DBProperties
 class HibernateQuerySpec extends AbstractHibernateQuerySpec {
+
+    @Shared
+    @Inject
+    RelPersonRepository relPersonRepo
+
+    void "test relations person repository and joins"() {
+        given:
+        def parent = new RelPerson()
+        parent.name = 'RelParent'
+        relPersonRepo.save(parent)
+        def child1Friend1 = new RelPerson()
+        child1Friend1.name = 'Child1Friend1'
+        relPersonRepo.save(child1Friend1)
+        def child1Friend2 = new RelPerson()
+        child1Friend2.name = 'Child1Friend2'
+        relPersonRepo.save(child1Friend2)
+        def child2Friend1 = new RelPerson()
+        child2Friend1.name = 'Child2Friend1'
+        relPersonRepo.save(child2Friend1)
+        def child1 = new RelPerson()
+        child1.name = 'Child1'
+        child1.parent = parent
+        child1.friends = [child1Friend1, child1Friend2]
+        relPersonRepo.save(child1)
+        def child2 = new RelPerson()
+        child2.name = 'Child2'
+        child2.parent = parent
+        child2.friends = [child2Friend1]
+        relPersonRepo.save(child2)
+        when:
+        def result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByParentAndFriends(parent.id, List.of(child1Friend1.id, child1Friend2.id)))
+        then:
+        result.size() == 1
+        result[0].id == child1.id
+        when:
+        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByParentAndFriends(parent.id, List.of(child1Friend1.id, child1Friend2.id, child2Friend1.id)))
+        then:
+        result.size() == 2
+        when:
+        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByChildren(List.of(child1.id, child2.id)))
+        then:
+        result.size() == 1
+        result[0].id == parent.id
+        when:
+        result = (List<RelPerson>) relPersonRepo.findAll(RelPersonRepository.Specifications.findRelPersonByChildren(List.of(child1Friend1.id, child1Friend2.id, child2Friend1.id)))
+        then:
+        result.size() == 0
+    }
 }

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RelPersonRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/RelPersonRepository.java
@@ -1,0 +1,41 @@
+package io.micronaut.data.hibernate;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.annotation.RepositoryConfiguration;
+import io.micronaut.data.hibernate.entities.RelPerson;
+import io.micronaut.data.jpa.repository.JpaRepository;
+import io.micronaut.data.model.query.builder.jpa.JpaQueryBuilder;
+import io.micronaut.data.repository.jpa.JpaSpecificationExecutor;
+import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
+import io.micronaut.transaction.annotation.Transactional;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.SetJoin;
+
+import java.util.List;
+
+@Repository
+@RepositoryConfiguration(queryBuilder = JpaQueryBuilder.class)
+public interface RelPersonRepository extends JpaRepository<RelPerson, Long>, JpaSpecificationExecutor<RelPerson> {
+
+    @Override
+    @Transactional
+    List<RelPerson> findAll(PredicateSpecification<RelPerson> spec);
+
+    class Specifications {
+
+        public static PredicateSpecification<RelPerson> findRelPersonByParentAndFriends(Long parentId, List<Long> friendsId) {
+            return (root, criteriaBuilder) -> {
+                Join parentJoin = root.join("parent");
+                SetJoin friendsJoin = root.joinSet("friends");
+                return criteriaBuilder.and(criteriaBuilder.equal(parentJoin.get("id"), parentId), friendsJoin.get("id").in(friendsId));
+            };
+        }
+
+        public static PredicateSpecification<RelPerson> findRelPersonByChildren(List<Long> childrenId) {
+            return (root, criteriaBuilder) -> {
+                SetJoin children = root.joinSet("children");
+                return children.get("id").in(childrenId);
+            };
+        }
+    }
+}

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/RelPerson.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/entities/RelPerson.java
@@ -1,0 +1,81 @@
+package io.micronaut.data.hibernate.entities;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * The person class with various relation between persona (child, parent, friends).
+ */
+@Entity
+public class RelPerson {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToMany
+    @JoinTable(name = "person_friends")
+    private Set<RelPerson> friends = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "parent")
+    private Set<RelPerson> children = new LinkedHashSet<>();
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private RelPerson parent;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<RelPerson> getFriends() {
+        return friends;
+    }
+
+    public void setFriends(Set<RelPerson> friends) {
+        this.friends = friends;
+    }
+
+    public Set<RelPerson> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<RelPerson> children) {
+        this.children = children;
+    }
+
+    public RelPerson getParent() {
+        return parent;
+    }
+
+    public void setParent(RelPerson parent) {
+        this.parent = parent;
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/util/Joiner.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/util/Joiner.java
@@ -94,8 +94,7 @@ public class Joiner implements SelectionVisitor, PredicateVisitor {
     }
 
     private void joinAssociation(Path<?> path) {
-        if (path instanceof PersistentAssociationPath) {
-            PersistentAssociationPath<?, ?> associationPath = (PersistentAssociationPath) path;
+        if (path instanceof PersistentAssociationPath<?, ?> associationPath) {
             if (associationPath.getAssociation().getKind() == Relation.Kind.EMBEDDED) {
                 // Cannot join embedded
 
@@ -103,13 +102,13 @@ public class Joiner implements SelectionVisitor, PredicateVisitor {
             } else {
                 join(associationPath);
             }
-        } else if (path instanceof PersistentPropertyPath persistentPropertyPath) {
-            Path parentPath = persistentPropertyPath.getParentPath();
-            if (parentPath instanceof PersistentAssociationPath parent) {
-                if (parent.getAssociation().getAssociatedEntity().getIdentity() == persistentPropertyPath.getProperty()) {
-                    // We don't need a join to access the ID
-                    return;
-                }
+        } else if (path instanceof PersistentPropertyPath<?> persistentPropertyPath) {
+            Path<?> parentPath = persistentPropertyPath.getParentPath();
+            if (parentPath instanceof PersistentAssociationPath<?, ?> parent
+                    && parent.getAssociation().getAssociatedEntity().getIdentity() == persistentPropertyPath.getProperty()
+                    && !parent.getAssociation().isForeignKey()) {
+                // We don't need a join to access the ID
+                return;
             }
             joinAssociation(parentPath);
         }
@@ -141,7 +140,7 @@ public class Joiner implements SelectionVisitor, PredicateVisitor {
 
     private void visitJoins(Set<? extends jakarta.persistence.criteria.Join<?, ?>> joins) {
         for (jakarta.persistence.criteria.Join<?, ?> join : joins) {
-            if (join instanceof PersistentAssociationPath persistentAssociationPath) {
+            if (join instanceof PersistentAssociationPath<?, ?> persistentAssociationPath) {
                 if (persistentAssociationPath.getAssociationJoinType() == null) {
                     continue;
                 }

--- a/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
+++ b/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
@@ -141,6 +141,23 @@ class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuild
     }
 
     @Test
+    fun testCriteriaAndJoinWithAssociationId() {
+        val query = query<TestEntity, String> {
+            select(root[TestEntity::name])
+            val others = root.joinMany(TestEntity::others)
+            where {
+                and {
+                    others[OtherEntity::id] gt root[TestEntity::id]
+                }
+            }
+        }
+        val criteriaQuery = query.build(runtimeCriteriaBuilder) as QueryResultPersistentEntityCriteriaQuery
+        val q = criteriaQuery.buildQuery(SqlQueryBuilder()).query
+
+        Assertions.assertEquals("""SELECT test_entity_."name" FROM "test_entity" test_entity_ INNER JOIN "other_entity" test_entity_others_ ON test_entity_."id"=test_entity_others_."test_id" WHERE (test_entity_others_."id">test_entity_."id")""", q)
+    }
+
+    @Test
     fun testMultiselect() {
         val query = query<OtherEntity, Any> {
             multiselect(avg(OtherEntity::age), max(OtherEntity::age), min(OtherEntity::age), greatest(OtherEntity::name), least(OtherEntity::name))


### PR DESCRIPTION
There was an [older PR](https://github.com/micronaut-projects/micronaut-data/pull/2365) that I closed as there was no test.
I have the same fix and now came up with the test so this should fix #2364 and I also validated it against original reproducing app.