### PR TITLE
Remove version compat suppressions now 4.1.1 is released

### DIFF
--- a/data-bom/build.gradle
+++ b/data-bom/build.gradle
@@ -9,15 +9,6 @@ micronautBom {
     excludeProject.set({ p ->
         p.name.contains('benchmark') || p.name.contains('example') || p.name.endsWith('-tck')
     } as Spec<String>)
-
-    suppressions {
-        // Renaming versions for 4.1.1 to fix platform. Can be removed once 4.1.1 is released
-        // https://github.com/micronaut-projects/micronaut-platform/pull/898
-        acceptedVersionRegressions.addAll(
-                "jakarta-transaction",
-                "jakarta-persistence",
-        )
-    }
 }
 
 


### PR DESCRIPTION
To fix platform we had to change the version names in the catalog and ignore the change.

See https://github.com/micronaut-projects/micronaut-platform/issues/893 for context

Now 4.1.1 is out, we can remove this suppression as the names will be correct moving forward.