### PR TITLE
Removed hardcoded version of metadata repo

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.data-native-example.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.data-native-example.gradle
@@ -32,7 +32,6 @@ graalvmNative {
     testSupport = true
     metadataRepository {
         enabled = true
-        version = "0.3.2"
     }
 }
 


### PR DESCRIPTION
The latest version which comes via micronaut gradle and native build tool plugins needs to be used.