### PR TITLE
Support underscore in repo methods to avoid mapped properties ambiguity

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractCriteriaMethodMatch.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractCriteriaMethodMatch.java
@@ -35,6 +35,7 @@ import io.micronaut.data.intercept.DataInterceptor;
 import io.micronaut.data.intercept.annotation.DataMethod;
 import io.micronaut.data.model.Association;
 import io.micronaut.data.model.PersistentEntity;
+import io.micronaut.data.model.PersistentEntityUtils;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.PersistentPropertyPath;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaDelete;
@@ -606,7 +607,7 @@ public abstract class AbstractCriteriaMethodMatch implements MethodMatcher.Metho
         PersistentProperty prop = entity.getPropertyByName(propertyName);
         PersistentPropertyPath pp;
         if (prop == null) {
-            Optional<String> propertyPath = entity.getPath(propertyName);
+            Optional<String> propertyPath = PersistentEntityUtils.getPersistentPropertyPath(entity, propertyName);
             if (propertyPath.isPresent()) {
                 String path = propertyPath.get();
                 pp = entity.getPropertyPath(path);

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/Projections.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/Projections.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.data.model.PersistentEntityUtils;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaBuilder;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;
 import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
@@ -57,7 +58,7 @@ public final class Projections {
                                     String value,
                                     BiFunction<PersistentEntityRoot<?>, String, PersistentPropertyPath<?>> findFunction) {
         String decapitalized = NameUtils.decapitalize(value);
-        Optional<String> path = entityRoot.getPersistentEntity().getPath(decapitalized);
+        Optional<String> path = PersistentEntityUtils.getPersistentPropertyPath(entityRoot.getPersistentEntity(), decapitalized);
         if (path.isPresent()) {
             return entityRoot.get(path.get());
         }


### PR DESCRIPTION
This allows writing repo methods to use `_` and indicate how paths should be traversed, in case of ambiguous properties like in reported issue #2474 