### PR TITLE
Correct repositories with custom id entities

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2NoIdEntityRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2NoIdEntityRepositorySpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2
+
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Shared
+import spock.lang.Specification
+
+@MicronautTest
+@H2DBProperties
+class H2NoIdEntityRepositorySpec extends Specification {
+
+    @Inject
+    @Shared H2NoIdEntityRepository noIdEntityRepository
+
+    void "test the repository works"() {
+        expect:
+            noIdEntityRepository.findById(123456L).isEmpty()
+    }
+
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2NoIdEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2NoIdEntityRepository.java
@@ -1,0 +1,9 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2NoIdEntityRepository extends CrudRepository<NoIdEntity, Long> {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/NoIdEntity.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/NoIdEntity.java
@@ -1,0 +1,39 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class NoIdEntity {
+
+    @Id
+    private Long uid;
+
+    private String name;
+
+    private String id;
+
+    public Long getUid() {
+        return uid;
+    }
+
+    public void setUid(Long uid) {
+        this.uid = uid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractCriteriaMethodMatch.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/AbstractCriteriaMethodMatch.java
@@ -590,12 +590,12 @@ public abstract class AbstractCriteriaMethodMatch implements MethodMatcher.Metho
 
     @NonNull
     protected final <T> Expression<?> getProperty(PersistentEntityRoot<T> root, String propertyName) {
+        if (TypeRole.ID.equals(NameUtils.decapitalize(propertyName)) && (root.getPersistentEntity().hasIdentity() || root.getPersistentEntity().hasCompositeIdentity())) {
+            return root.id();
+        }
         io.micronaut.data.model.jpa.criteria.PersistentPropertyPath<Object> property = findProperty(root, propertyName);
         if (property != null) {
             return property;
-        }
-        if (TypeRole.ID.equals(NameUtils.decapitalize(propertyName)) && (root.getPersistentEntity().hasIdentity() || root.getPersistentEntity().hasCompositeIdentity())) {
-            return root.id();
         }
         throw new MatchFailedException("Cannot query entity [" + root.getPersistentEntity().getSimpleName() + "] on non-existent property: " + propertyName);
     }

--- a/data-processor/src/test/groovy/io/micronaut/data/model/entities/NoIdEntity.java
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/entities/NoIdEntity.java
@@ -1,0 +1,39 @@
+package io.micronaut.data.model.entities;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class NoIdEntity {
+
+    @Id
+    private Long uid;
+
+    private String name;
+
+    private String id;
+
+    public Long getUid() {
+        return uid;
+    }
+
+    public void setUid(Long uid) {
+        this.uid = uid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -19,6 +19,8 @@ import io.micronaut.data.intercept.annotation.DataMethod
 import io.micronaut.data.model.DataType
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.entities.Invoice
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder
 import io.micronaut.data.processor.visitors.AbstractDataSpec
 import io.micronaut.data.tck.entities.Author
 import io.micronaut.data.tck.entities.Restaurant
@@ -269,8 +271,8 @@ interface CustomIdEntityRepository extends CrudRepository<CustomIdEntity, Long> 
         "existsByCustomId" | 'SELECT TRUE FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`custom_id` = ?)'
         "deleteByCustomId" | 'DELETE  FROM `custom_id_entity`  WHERE (`custom_id` = ?)'
         "findByCustomId"   | 'SELECT custom_id_entity_.`custom_id`,custom_id_entity_.`id`,custom_id_entity_.`name` FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`custom_id` = ?)'
-        "existsById"       | 'SELECT TRUE FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`id` = ?)'
-        "findById"         | 'SELECT custom_id_entity_.`custom_id`,custom_id_entity_.`id`,custom_id_entity_.`name` FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`id` = ?)'
+        "existsById"       | 'SELECT TRUE FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`custom_id` = ?)'
+        "findById"         | 'SELECT custom_id_entity_.`custom_id`,custom_id_entity_.`id`,custom_id_entity_.`name` FROM `custom_id_entity` custom_id_entity_ WHERE (custom_id_entity_.`custom_id` = ?)'
 
     }
 
@@ -1023,5 +1025,25 @@ interface BookRepository extends GenericRepository<Book, Long> {
         then:
         Throwable ex = thrown()
         ex.message.contains('Invalid path [SpecName] of [io.micronaut.data.tck.entities.Author]')
+    }
+
+    void "test entity with different id mapping"() {
+        when:
+            def repository = buildRepository('test.H2NoIdEntityRepository', '''
+import io.micronaut.data.annotation.MappedProperty;
+import java.sql.Time;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.model.entities.NoIdEntity;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2NoIdEntityRepository extends CrudRepository<NoIdEntity, Long> {
+}
+
+''')
+        then:
+            noExceptionThrown()
     }
 }


### PR DESCRIPTION
The `id` property in repositories should always reference the entity's `@Id` property.
It looks like it was tested incorrectly.

We need to figure out how to actually query the property named id maybe if it's `findBy_id`.

Fixes https://github.com/micronaut-projects/micronaut-data/issues/2501