### PR TITLE
Use schema for many to many join table creation, select and insert

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/annotation/sql/JoinTable.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/sql/JoinTable.java
@@ -52,4 +52,9 @@ public @interface JoinTable {
      * @return The alias to use for the query
      */
     String alias() default "";
+
+    /**
+     * @return The schema of the join table
+     */
+    String schema() default "";
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -287,7 +287,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
                     );
             joinTableName = quote(joinTableName);
             String joinTableSchema = annotationMetadata
-                    .stringValue(ANN_JOIN_TABLE, "schema")
+                    .stringValue(ANN_JOIN_TABLE, SqlMembers.SCHEMA)
                     .orElse(getSchemaName(entity));
             if (StringUtils.isNotEmpty(joinTableSchema)) {
                 joinTableSchema = quote(joinTableSchema);
@@ -1229,7 +1229,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
 
     private String getSchemaName(PersistentEntity entity) {
         return entity.getAnnotationMetadata().stringValue(MappedEntity.class, SqlMembers.SCHEMA).orElseGet(() ->
-            entity.getAnnotationMetadata().stringValue(MappedEntity.class, "schema").orElse(null)
+            entity.getAnnotationMetadata().stringValue(MappedEntity.class, SqlMembers.SCHEMA).orElse(null)
         );
     }
 
@@ -1438,12 +1438,10 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
             }
 
             String joinTableSchema = annotationMetadata
-                .stringValue(ANN_JOIN_TABLE, "schema")
+                .stringValue(ANN_JOIN_TABLE, SqlMembers.SCHEMA)
                 .orElse(getSchemaName(associationOwner));
-            if (StringUtils.isNotEmpty(joinTableSchema)) {
-                if (escape) {
-                    joinTableSchema = quote(joinTableSchema);
-                }
+            if (StringUtils.isNotEmpty(joinTableSchema) && escape) {
+                joinTableSchema = quote(joinTableSchema);
             }
             String joinTableName = annotationMetadata
                     .stringValue(ANN_JOIN_TABLE, "name")


### PR DESCRIPTION
Fix for [issue 1325](https://github.com/micronaut-projects/micronaut-data/issues/1325) 
Script for table creation, join and insert were not taking into account schema name from related entities and it was not possible to specify it in `@JoinTable`