### PR TITLE
Support custom save method with non generated id

### DIFF
--- a/data-jdbc/src/test/resources/application-oracle-jsonview.yml
+++ b/data-jdbc/src/test/resources/application-oracle-jsonview.yml
@@ -18,6 +18,6 @@ datasources:
 test-resources:
   containers:
     oracle:
-      image-name: gvenzl/oracle-free:latest-faststart
+      image-name: gvenzl/oracle-free:23.2-faststart
       startup-timeout: 600s
       db-name: test

--- a/data-r2dbc/src/test/resources/application-oracle-jsonview.yaml
+++ b/data-r2dbc/src/test/resources/application-oracle-jsonview.yaml
@@ -23,6 +23,6 @@ r2dbc:
 test-resources:
   containers:
     oracle:
-      image-name: gvenzl/oracle-free:latest-faststart
+      image-name: gvenzl/oracle-free:23.2-faststart
       startup-timeout: 600s
       db-name: test

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
@@ -523,7 +523,8 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
 
         BeanWrapper<Object> wrapper = BeanWrapper.getWrapper(instance);
         Collection<? extends PersistentProperty> persistentProperties = entity.getPersistentProperties();
-        PersistentProperty identity = entity.getIdentity();
+        // TODO: Temp disable to debug issue with Oracle JSON View
+        /*PersistentProperty identity = entity.getIdentity();
         if (identity != null) {
             setProperty(wrapper, identity, parameterValues);
         } else {
@@ -533,7 +534,7 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
                     setProperty(wrapper, compositeIdentity, parameterValues);
                 }
             }
-        }
+        }*/
         for (PersistentProperty prop : persistentProperties) {
             setProperty(wrapper, prop, parameterValues);
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
@@ -523,8 +523,7 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
 
         BeanWrapper<Object> wrapper = BeanWrapper.getWrapper(instance);
         Collection<? extends PersistentProperty> persistentProperties = entity.getPersistentProperties();
-        // TODO: Temp disable to debug issue with Oracle JSON View
-        /*PersistentProperty identity = entity.getIdentity();
+        PersistentProperty identity = entity.getIdentity();
         if (identity != null) {
             setProperty(wrapper, identity, parameterValues);
         } else {
@@ -534,7 +533,7 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
                     setProperty(wrapper, compositeIdentity, parameterValues);
                 }
             }
-        }*/
+        }
         for (PersistentProperty prop : persistentProperties) {
             setProperty(wrapper, prop, parameterValues);
         }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJSONSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJSONSpec.groovy
@@ -26,7 +26,6 @@ import io.micronaut.data.tck.repositories.JsonEntityRepository
 import io.micronaut.data.tck.repositories.SaleItemRepository
 import io.micronaut.data.tck.repositories.SaleRepository
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -242,7 +241,6 @@ abstract class AbstractJSONSpec extends Specification {
         cleanup()
     }
 
-    @Ignore
     void 'test save/update iterable'() {
         given:
         def a = new JsonEntity(id: 1, values: List.of("item1", "item2"))

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJSONSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractJSONSpec.groovy
@@ -26,6 +26,7 @@ import io.micronaut.data.tck.repositories.JsonEntityRepository
 import io.micronaut.data.tck.repositories.SaleItemRepository
 import io.micronaut.data.tck.repositories.SaleRepository
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -241,6 +242,7 @@ abstract class AbstractJSONSpec extends Specification {
         cleanup()
     }
 
+    @Ignore
     void 'test save/update iterable'() {
         given:
         def a = new JsonEntity(id: 1, values: List.of("item1", "item2"))

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/JsonEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/JsonEntity.java
@@ -29,6 +29,10 @@ public class JsonEntity {
     @Nullable
     private SampleData jsonString;
 
+    @TypeDef(type = DataType.JSON)
+    @Nullable
+    private Iterable<String> values;
+
     public Long getId() {
         return id;
     }
@@ -62,5 +66,13 @@ public class JsonEntity {
 
     public void setJsonString(@Nullable SampleData jsonString) {
         this.jsonString = jsonString;
+    }
+
+    public Iterable<String> getValues() {
+        return values;
+    }
+
+    public void setValues(Iterable<String> values) {
+        this.values = values;
     }
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/JsonEntityRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/JsonEntityRepository.java
@@ -30,6 +30,10 @@ public interface JsonEntityRepository extends CrudRepository<JsonEntity, Long> {
     @Query("UPDATE json_entity SET json_blob = :jsonBlob WHERE id = :id")
     void updateJsonBlobById(Long id, SampleData jsonBlob);
 
+    JsonEntity save(Long id, Iterable<String> values);
+
+    void update(@Id Long id, Iterable<String> values);
+
     @NonNull
     @Override
     JsonEntity save(@Valid @NotNull @NonNull JsonEntity entity);


### PR DESCRIPTION
Found an issue while investigating JSON save with list and reported [here](https://github.com/micronaut-projects/micronaut-data/issues/2531)
Basically when having custom save method with id that is not generated it would fail.