### PR TITLE
Allow dynamic sorting for native queries using Sort/Pageable

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
@@ -339,7 +339,8 @@ public abstract class AbstractHibernateOperations<S, Q, P extends Q> implements 
         if (pageable != Pageable.UNPAGED) {
             Sort sort = pageable.getSort();
             if (sort.isSorted()) {
-                queryStr += QUERY_BUILDER.buildOrderBy(queryStr, getEntity(preparedQuery.getRootEntity()), AnnotationMetadata.EMPTY_METADATA, sort).getQuery();
+                queryStr += QUERY_BUILDER.buildOrderBy(queryStr, getEntity(preparedQuery.getRootEntity()), AnnotationMetadata.EMPTY_METADATA, sort,
+                    preparedQuery.isNative()).getQuery();
             }
         }
         collectResults(session, queryStr, preparedQuery, collector);

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
@@ -314,12 +314,21 @@ abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
 
     void "author dto result from native query"() {
         when:
-        def author = authorRepository.getAuthorsByNativeQuery()
+        def sort = Sort.of(Sort.Order.desc("authorName"))
+        def authors = authorRepository.getAuthorsByNativeQuery(sort)
 
         then:
-        author
-        author.authorId
-        author.authorName
+        authors
+        authors.size() == 3
+        authors[0].authorId
+        authors[0].authorName
+        authors[1].authorId
+        authors[1].authorName
+        authors[2].authorId
+        authors[2].authorName
+        // verify sorted desc by authorName
+        authors[0].authorName >= authors[1].authorName
+        authors[1].authorName >= authors[2].authorName
     }
 
     void "entity with id class"() {

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/PostgresDbInit.java
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/PostgresDbInit.java
@@ -38,7 +38,7 @@ public class PostgresDbInit implements BeanCreatedEventListener<BasicJdbcConfigu
         try {
             try (Connection connection = DriverManager.getConnection(configuration.getUrl(), info)) {
                 try (CallableStatement st = connection.prepareCall("""
-CREATE PROCEDURE add1(IN myInput integer, OUT myOutput integer)
+CREATE OR REPLACE PROCEDURE add1(IN myInput integer, OUT myOutput integer)
 LANGUAGE plpgsql
 AS $$
 BEGIN

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/AuthorRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/AuthorRepository.java
@@ -20,6 +20,7 @@ import io.micronaut.data.annotation.Query;
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.hibernate.entities.AuthorDto;
 import io.micronaut.data.jpa.annotation.EntityGraph;
+import io.micronaut.data.model.Sort;
 import io.micronaut.data.tck.entities.Author;
 
 import jakarta.transaction.Transactional;
@@ -45,6 +46,6 @@ public interface AuthorRepository extends io.micronaut.data.tck.repositories.Aut
     List<Long> longs();
 
     @Query(value = "select id as authorId, name as authorName from Author", nativeQuery = true)
-    List<AuthorDto> getAuthorsByNativeQuery();
+    List<AuthorDto> getAuthorsByNativeQuery(Sort sort);
 
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OraceXEDbInit.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OraceXEDbInit.java
@@ -31,7 +31,7 @@ public class OraceXEDbInit implements BeanCreatedEventListener<BasicJdbcConfigur
         try {
             try (Connection connection = DriverManager.getConnection(configuration.getUrl(), info)) {
                 try (CallableStatement st = connection.prepareCall("""
-CREATE PROCEDURE add1(myInput IN number, myOutput OUT number) IS
+CREATE OR REPLACE PROCEDURE add1(myInput IN number, myOutput OUT number) IS
 BEGIN
 myOutput := myInput + 1;
 END;

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresDbInit.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresDbInit.java
@@ -51,7 +51,7 @@ public class PostgresDbInit implements BeanCreatedEventListener<BasicJdbcConfigu
                     // Ignore if already exists
                 }
                 try (CallableStatement st = connection.prepareCall("""
-CREATE PROCEDURE add1(IN myInput integer, OUT myOutput integer)
+CREATE OR REPLACE PROCEDURE add1(IN myInput integer, OUT myOutput integer)
 LANGUAGE plpgsql
 AS $$
 BEGIN

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.data.jdbc.postgres
 
 import groovy.transform.Memoized
+import io.micronaut.data.model.Sort
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.repositories.*
 import io.micronaut.data.tck.tests.AbstractRepositorySpec
@@ -179,15 +180,25 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
         given:
             setupBooks()
         when:
-            def books1 = bookRepository.listNativeBooksNullableSearch(null)
+            def books1 = bookRepository.listNativeBooksNullableSearch(null, null)
+            def books1Sorted = bookRepository.listNativeBooksNullableSearch(null, Sort.of(Sort.Order.asc("title")))
         then:
             books1.size() == 8
+            books1Sorted.size() == 8
+            // verify native query with given sort returned sorted results as expected
+            def book1Titles = books1.stream().map(b -> b.title).sorted().toList()
+            book1Titles.size() == 8
+            for (int i = 0; i < book1Titles.size(); i++) {
+                def title = book1Titles[i]
+                def book1Sorted = books1Sorted[i]
+                title == book1Sorted.title
+            }
         when:
-            def books2 = bookRepository.listNativeBooksNullableSearch("The Stand")
+            def books2 = bookRepository.listNativeBooksNullableSearch("The Stand", null)
         then:
             books2.size() == 1
         when:
-            def books3 = bookRepository.listNativeBooksNullableSearch("Xyz")
+            def books3 = bookRepository.listNativeBooksNullableSearch("Xyz", null)
         then:
             books3.size() == 0
         when:

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresBookRepository.java
@@ -23,6 +23,7 @@ import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.annotation.sql.Procedure;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.DataType;
+import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.tck.entities.Book;
 import io.micronaut.data.tck.repositories.BookRepository;
@@ -37,7 +38,7 @@ public abstract class PostgresBookRepository extends BookRepository {
     }
 
     @Query(value = "select * from book where (CASE WHEN :arg0 is not null THEN title = :arg0 ELSE true END)", nativeQuery = true)
-    public abstract List<Book> listNativeBooksNullableSearch(@TypeDef(type = DataType.STRING) @Nullable String arg0);
+    public abstract List<Book> listNativeBooksNullableSearch(@TypeDef(type = DataType.STRING) @Nullable String arg0, @Nullable Sort sort);
 
     @Query(value = "select * from book where (CASE WHEN exists ( select (:arg0) ) THEN title IN (:arg0) ELSE true END)", nativeQuery = true)
     public abstract List<Book> listNativeBooksNullableListSearch(@Nullable List<String> arg0);

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -1917,7 +1917,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
      * @deprecated use {@link #buildOrderBy(String, PersistentEntity, AnnotationMetadata, Sort, boolean)}
      */
     @NonNull
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "4.2.0")
     public QueryResult buildOrderBy(String query, @NonNull PersistentEntity entity, @NonNull AnnotationMetadata annotationMetadata, @NonNull Sort sort) {
         return buildOrderBy(query, entity, annotationMetadata, sort, false);
     }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEDbInit.java
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEDbInit.java
@@ -46,7 +46,7 @@ public class OracleXEDbInit implements BeanCreatedEventListener<DefaultBasicR2db
         try {
             try (Connection connection = DriverManager.getConnection(url, info)) {
                 try (CallableStatement st = connection.prepareCall("""
-CREATE PROCEDURE add1(myInput IN number, myOutput OUT number) IS
+CREATE OR REPLACE PROCEDURE add1(myInput IN number, myOutput OUT number) IS
 BEGIN
 myOutput := myInput + 1;
 END;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -158,11 +158,11 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
             StringBuilder added = new StringBuilder();
             Sort sort = pageable.getSort();
             if (sort.isSorted()) {
-                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort).getQuery());
+                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()).getQuery());
             } else if (isSqlServerWithoutOrderBy(query, sqlStoredQuery.getDialect())) {
                 // SQL server requires order by
                 sort = sortById(persistentEntity);
-                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort).getQuery());
+                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()).getQuery());
             }
             if (isSingleResult && pageable.getOffset() > 0) {
                 pageable = Pageable.from(pageable.getNumber(), 1);


### PR DESCRIPTION
This is attempt to add support for the use case reported in [this issue](https://github.com/micronaut-projects/micronaut-data/issues/2338).
The idea is that for native queries, user can specify sort fields as they wish in `Pageable/Sort` parameter. Before this, buildOrder method expected property to exist on the entity and this change adds check if native query then just use field as specified by the user for sort. I guess this shouldn't break anything and allows users to specify sort fields specific for native queries.