### PR TITLE
Fix documentation example as batch update cannot return list of results

### DIFF
--- a/data-document-processor/src/test/groovy/io/micronaut/data/document/processor/BuildMongoQuerySpec.groovy
+++ b/data-document-processor/src/test/groovy/io/micronaut/data/document/processor/BuildMongoQuerySpec.groovy
@@ -287,7 +287,7 @@ import io.micronaut.data.document.tck.entities.Book;
 interface MyInterface2 extends GenericRepository<Book, String> {
 
     @MongoUpdateQuery(filter = \"{title:{\$eq: :t}}\", update = \"{\$set:{name: \\"tom\\"}}\", collation = \"{ locale: 'en_US', numericOrdering: true}\")
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
 }
 """
@@ -315,7 +315,7 @@ import io.micronaut.data.document.tck.entities.Book;
 interface MyInterface2 extends GenericRepository<Book, String> {
 
     @MongoUpdateQuery(filter = \"{title:{\$eq: :t}}\", update = \"{\$set:{name: \\"tom\\"}}\")
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
 }
 """
@@ -344,7 +344,7 @@ import io.micronaut.data.document.tck.entities.Book;
 interface MyInterface2 extends GenericRepository<Book, String> {
 
     @MongoUpdateQuery(update = \"{\$set:{name: \\"tom\\"}}\")
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
 }
 """

--- a/doc-examples/mongo-example-groovy/src/main/groovy/example/BookRepository.groovy
+++ b/doc-examples/mongo-example-groovy/src/main/groovy/example/BookRepository.groovy
@@ -104,7 +104,7 @@ interface BookRepository extends CrudRepository<Book, ObjectId> { // <2>
     List<Person> customAggregate(String t)
 
     @MongoUpdateQuery(filter = '{title:{$regex: :t}}', update = '{$set:{name: "tom"}}')
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
     @MongoDeleteQuery(filter = '{title:{$regex: :t}}', collation = "{locale:'en_US', numericOrdering:true}")
     void customDelete(String t);

--- a/doc-examples/mongo-example-java/src/main/java/example/BookRepository.java
+++ b/doc-examples/mongo-example-java/src/main/java/example/BookRepository.java
@@ -107,7 +107,7 @@ interface BookRepository extends CrudRepository<Book, ObjectId> { // <2>
     List<Person> customAggregate(String t);
 
     @MongoUpdateQuery(filter = "{title:{$regex: :t}}", update = "{$set:{name: 'tom'}}")
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
     @MongoDeleteQuery(filter = "{title:{$regex: :t}}", collation = "{locale:'en_US', numericOrdering:true}")
     void customDelete(String t);

--- a/doc-examples/mongo-example-kotlin-ksp/src/main/kotlin/example/BookRepository.kt
+++ b/doc-examples/mongo-example-kotlin-ksp/src/main/kotlin/example/BookRepository.kt
@@ -102,7 +102,7 @@ interface BookRepository : CrudRepository<Book, ObjectId> { // <2>
     fun customAggregate(t: String): List<Person>
 
     @MongoUpdateQuery(filter = "{title:{\$regex: :t}}", update = "{\$set:{name: 'tom'}}")
-    fun customUpdate(t: String): List<Book>
+    fun customUpdate(t: String)
 
     @MongoDeleteQuery(filter = "{title:{\$regex: :t}}", collation = "{locale:'en_US', numericOrdering:true}")
     fun customDelete(t: String)

--- a/doc-examples/mongo-example-kotlin/src/main/kotlin/example/BookRepository.kt
+++ b/doc-examples/mongo-example-kotlin/src/main/kotlin/example/BookRepository.kt
@@ -102,7 +102,7 @@ interface BookRepository : CrudRepository<Book, ObjectId> { // <2>
     fun customAggregate(t: String): List<Person>
 
     @MongoUpdateQuery(filter = "{title:{\$regex: :t}}", update = "{\$set:{name: 'tom'}}")
-    fun customUpdate(t: String): List<Book>
+    fun customUpdate(t: String)
 
     @MongoDeleteQuery(filter = "{title:{\$regex: :t}}", collation = "{locale:'en_US', numericOrdering:true}")
     fun customDelete(t: String)

--- a/doc-examples/mongo-example-records-java/src/main/java/example/BookRepository.java
+++ b/doc-examples/mongo-example-records-java/src/main/java/example/BookRepository.java
@@ -107,7 +107,7 @@ interface BookRepository extends CrudRepository<Book, ObjectId> { // <2>
     List<Person> customAggregate(String t);
 
     @MongoUpdateQuery(filter = "{title:{$regex: :t}}", update = "{$set:{name: 'tom'}}")
-    List<Book> customUpdate(String t);
+    void customUpdate(String t);
 
     @MongoDeleteQuery(filter = "{title:{$regex: :t}}", collation = "{locale:'en_US', numericOrdering:true}")
     void customDelete(String t);


### PR DESCRIPTION
This is just to remove confusion as documentation indicated update could return list of entities when it returns void.
There is separate feature request to implement update and return results in Mongo, this is just documentation PR.