### PR TITLE
Implement reactive MongoQueryExecutor

### DIFF
--- a/data-document-model/src/main/java/io/micronaut/data/document/mongo/MongoAnnotations.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/mongo/MongoAnnotations.java
@@ -45,6 +45,7 @@ public interface MongoAnnotations {
     String DELETE_OPTIONS_ROLE = "deleteOptions";
 
     String EXECUTOR_REPOSITORY = "io.micronaut.data.mongodb.repository.MongoQueryExecutor";
+    String REACTIVE_EXECUTOR_REPOSITORY = "io.micronaut.data.mongodb.repository.MongoReactiveQueryExecutor";
 
     String BSON = "org.bson.conversions.Bson";
     String FIND_OPTIONS_BEAN = "io.micronaut.data.mongodb.operations.options.MongoFindOptions";

--- a/data-document-processor/src/main/java/io/micronaut/data/document/processor/matchers/MongoExecutorQueryMethodMatcher.java
+++ b/data-document-processor/src/main/java/io/micronaut/data/document/processor/matchers/MongoExecutorQueryMethodMatcher.java
@@ -54,6 +54,10 @@ public class MongoExecutorQueryMethodMatcher implements MethodMatcher {
         if (executor.isPresent() && executor.get().isAssignable(matchContext.getRepositoryClass())) {
             return null;
         }
+        Optional<ClassElement> reactiveExecutor = matchContext.getVisitorContext().getClassElement(MongoAnnotations.REACTIVE_EXECUTOR_REPOSITORY);
+        if (reactiveExecutor.isPresent() && reactiveExecutor.get().isAssignable(matchContext.getRepositoryClass())) {
+            return null;
+        }
         String methodName = matchContext.getMethodElement().getName();
         if ("findAll".equals(methodName) || "findOne".equals(methodName)) {
             ParameterElement[] parameters = matchContext.getParameters();

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/repository/MongoReactiveQueryExecutor.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/repository/MongoReactiveQueryExecutor.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.mongodb.repository;
+
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.UpdateOptions;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.mongodb.operations.options.MongoAggregationOptions;
+import io.micronaut.data.mongodb.operations.options.MongoFindOptions;
+import org.bson.conversions.Bson;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * MongoDB specific reactive repository that allows to use direct BSON objects reactive way.
+ * Essentially, the same as {@link MongoQueryExecutor} just reactive implementation.
+ *
+ * @param <E> The entity type
+ * @author radovanradic
+ * @since 4.2
+ */
+public interface MongoReactiveQueryExecutor<E> {
+
+    /**
+     * Finds one result.
+     *
+     * @param filter The filter to be applied
+     * @return The single result
+     */
+    Mono<E> findOne(@Nullable Bson filter);
+
+    /**
+     * Finds one result.
+     *
+     * @param options The options
+     * @return The single result
+     */
+    Mono<E> findOne(@NonNull MongoFindOptions options);
+
+    /**
+     * Finds all results.
+     *
+     * @param filter The filter to be applied
+     * @return The records
+     */
+    @NonNull
+    Flux<E> findAll(@Nullable Bson filter);
+
+    /**
+     * Finds all results.
+     *
+     * @param options The options
+     * @return The records
+     */
+    @NonNull
+    Flux<E> findAll(@NonNull MongoFindOptions options);
+
+    /**
+     * Finds a page of records.
+     *
+     * @param filter   The filter
+     * @param pageable The pageable
+     * @return The page
+     */
+    @NonNull
+    Mono<Page<E>> findAll(@Nullable Bson filter, @NonNull Pageable pageable);
+
+    /**
+     * Finds a page of records.
+     *
+     * @param options  The options
+     * @param pageable The pageable
+     * @return The page
+     */
+    @NonNull
+    Mono<Page<E>> findAll(@NonNull MongoFindOptions options, @NonNull Pageable pageable);
+
+    /**
+     * Finds a page of records.
+     *
+     * @param pipeline The pipeline to be applied
+     * @return The single result
+     */
+    Mono<E> findOne(@NonNull Iterable<Bson> pipeline);
+
+    /**
+     * Finds one result.
+     *
+     * @param pipeline The pipeline to be applied
+     * @param options  The aggregation options
+     * @return The single result
+     */
+    Mono<E> findOne(@NonNull Iterable<Bson> pipeline, @NonNull MongoAggregationOptions options);
+
+    /**
+     * Finds all results.
+     *
+     * @param pipeline The pipeline to be applied
+     * @return The results
+     */
+    @NonNull
+    Flux<E> findAll(@NonNull Iterable<Bson> pipeline);
+
+    /**
+     * Finds all results.
+     *
+     * @param pipeline The pipeline to be applied
+     * @param options  The options
+     * @return The results
+     */
+    @NonNull
+    Flux<E> findAll(@NonNull Iterable<Bson> pipeline, @NonNull MongoAggregationOptions options);
+
+    /**
+     * Count the records.
+     *
+     * @param filter The filter to be applied
+     * @return The count
+     */
+    Mono<Long> count(@Nullable Bson filter);
+
+    /**
+     * Delete the records matching the filter.
+     *
+     * @param filter The filter to be applied
+     * @return The deleted count
+     */
+    Mono<Long> deleteAll(@NonNull Bson filter);
+
+    /**
+     * Delete the records matching the filter.
+     *
+     * @param filter  The filter to be applied
+     * @param options The delete options
+     * @return The deleted count
+     */
+    Mono<Long> deleteAll(@NonNull Bson filter, @NonNull DeleteOptions options);
+
+    /**
+     * Update the records matching the filter.
+     *
+     * @param filter The filter to be applied
+     * @param update The update modification
+     * @return The updated count
+     */
+    Mono<Long> updateAll(@NonNull Bson filter, @NonNull Bson update);
+
+    /**
+     * Update the records matching the filter.
+     *
+     * @param filter  The filter to be applied
+     * @param update  The update modification
+     * @param options The update options
+     * @return The updated count
+     */
+    Mono<Long> updateAll(@NonNull Bson filter, @NonNull Bson update, @NonNull UpdateOptions options);
+}

--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/reactive/MongoReactiveDocumentRepositorySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/reactive/MongoReactiveDocumentRepositorySpec.groovy
@@ -1,6 +1,188 @@
 package io.micronaut.data.document.mongodb.reactive
 
+import com.mongodb.client.model.Aggregates
+import com.mongodb.client.model.DeleteOptions
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.model.Updates
+import groovy.transform.Memoized
 import io.micronaut.data.document.mongodb.MongoDocumentRepositorySpec
+import io.micronaut.data.document.mongodb.repositories.MongoReactiveExecutorPersonRepository
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.mongodb.operations.options.MongoAggregationOptions
+import io.micronaut.data.mongodb.operations.options.MongoFindOptions
 
 class MongoReactiveDocumentRepositorySpec extends MongoDocumentRepositorySpec implements MongoSelectReactiveDriver {
+
+    @Memoized
+    MongoReactiveExecutorPersonRepository getMongoReactiveExecutorPersonRepository() {
+        return context.getBean(MongoReactiveExecutorPersonRepository)
+    }
+
+    void "test reactive query executor counts"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def count = mongoReactiveExecutorPersonRepository.count(Filters.eq("name", "Jeff")).block()
+        then:
+        count == 1
+        when:
+        count = mongoReactiveExecutorPersonRepository.count(Filters.regex("name", /J.*/)).block()
+        then:
+        count == 2
+    }
+
+    void "test reactive query executor finds"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll(Filters.eq("name", "Jeff")).collectList().block()
+        then:
+        people.size() == 1
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(new MongoFindOptions().filter(Filters.eq("name", "Jeff"))).collectList().block()
+        then:
+        people.size() == 1
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll([Aggregates.match(Filters.eq("name", "Jeff"))]).collectList().block()
+        then:
+        people.size() == 1
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll([Aggregates.match(Filters.eq("name", "Jeff"))], new MongoAggregationOptions()).collectList().block()
+        then:
+        people.size() == 1
+        when:
+        def person = mongoReactiveExecutorPersonRepository.findOne(Filters.eq("name", "Jeff"))
+        then:
+        person.block().name == "Jeff"
+        when:
+        person = mongoReactiveExecutorPersonRepository.findOne(new MongoFindOptions().filter(Filters.eq("name", "Jeff")))
+        then:
+        person.block().name == "Jeff"
+        when:
+        person = mongoReactiveExecutorPersonRepository.findOne([Aggregates.match(Filters.eq("name", "Jeff"))])
+        then:
+        person.block().name == "Jeff"
+        when:
+        person = mongoReactiveExecutorPersonRepository.findOne([Aggregates.match(Filters.eq("name", "Jeff"))], new MongoAggregationOptions())
+        then:
+        person.block().name == "Jeff"
+    }
+
+    void "test reactive query executor finds page"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll(Filters.regex("name", /J.*/), Pageable.from(0, 1)).block()
+        then:
+        people.size() == 1
+        people.getTotalPages() == 2
+        people[0].name == "Jeff"
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(Filters.regex("name", /J.*/), Pageable.from(1, 1)).block()
+        then:
+        people.size() == 1
+        people.getTotalPages() == 2
+        people[0].name == "James"
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(Filters.regex("name", /J.*/), Pageable.from(0, 1).order("name")).block()
+        then:
+        people.size() == 1
+        people.getTotalPages() == 2
+        people[0].name == "James"
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(Filters.regex("name", /J.*/), Pageable.from(0, 2).order("name")).block()
+        then:
+        people.size() == 2
+        people.getTotalPages() == 1
+        people[0].name == "James"
+        people[1].name == "Jeff"
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(null, Pageable.from(0, 2).order("name")).block()
+        then:
+        people.size() == 2
+        people.getTotalPages() == 2
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll(new MongoFindOptions()
+                .filter(Filters.regex("name", /J.*/))
+                .sort(Sorts.ascending("name")), Pageable.from(0, 2)).block()
+        then:
+        people.size() == 2
+        people.getTotalPages() == 1
+        people[0].name == "James"
+        people[1].name == "Jeff"
+    }
+
+    void "test reactive query executor deletes"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 4
+        when:
+        long deleted = mongoReactiveExecutorPersonRepository.deleteAll(Filters.regex("name", /J.*/)).block()
+        then:
+        deleted == 2
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 2
+    }
+
+    void "test reactive query executor deletes2"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 4
+        when:
+        long deleted = mongoReactiveExecutorPersonRepository.deleteAll(Filters.regex("name", /J.*/), new DeleteOptions()).block()
+        then:
+        deleted == 2
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 2
+    }
+
+    void "test reactive query executor updates"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 4
+        when:
+        long updated = mongoReactiveExecutorPersonRepository.updateAll(Filters.regex("name", /J.*/), Updates.set("name", "UPDATED")).block()
+        then:
+        updated == 2
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.count{ it.name == "UPDATED" } == 2
+    }
+
+    void "test reactive query executor updates2"() {
+        given:
+        savePersons(["Dennis", "Jeff", "James", "Dennis"])
+        when:
+        def people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.size() == 4
+        when:
+        long updated = mongoReactiveExecutorPersonRepository.updateAll(
+                Filters.regex("name", /J.*/),
+                Updates.set("name", "UPDATED"), new UpdateOptions()
+        ).block()
+        then:
+        updated == 2
+        when:
+        people = mongoReactiveExecutorPersonRepository.findAll().collectList().block()
+        then:
+        people.count{ it.name == "UPDATED" } == 2
+    }
+
 }

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/MongoReactiveExecutorPersonRepository.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/MongoReactiveExecutorPersonRepository.java
@@ -1,0 +1,20 @@
+package io.micronaut.data.document.mongodb.repositories;
+
+import io.micronaut.data.document.tck.entities.Person;
+import io.micronaut.data.mongodb.annotation.MongoAggregateOptions;
+import io.micronaut.data.mongodb.annotation.MongoDeleteOptions;
+import io.micronaut.data.mongodb.annotation.MongoFindOptions;
+import io.micronaut.data.mongodb.annotation.MongoRepository;
+import io.micronaut.data.mongodb.annotation.MongoUpdateOptions;
+import io.micronaut.data.mongodb.repository.MongoQueryExecutor;
+import io.micronaut.data.mongodb.repository.MongoReactiveQueryExecutor;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.repository.reactive.ReactorCrudRepository;
+
+@MongoAggregateOptions(bypassDocumentValidation = true, allowDiskUse = true)
+@MongoFindOptions(batchSize = 3, allowDiskUse = true)
+@MongoDeleteOptions()
+@MongoUpdateOptions(bypassDocumentValidation = true)
+@MongoRepository
+public interface MongoReactiveExecutorPersonRepository extends ReactorCrudRepository<Person, String>, MongoReactiveQueryExecutor<Person> {
+}

--- a/src/main/docs/guide/mongo/mongoRepositories.adoc
+++ b/src/main/docs/guide/mongo/mongoRepositories.adoc
@@ -24,7 +24,7 @@ snippet::example.AbstractBookRepository[project-base="doc-examples/mongo-example
 
 NOTE: You can specify MongoDB's database name using the repository annotation: `@MongoRepository(databaseName = "mydb")` or in the connection url: `mongodb://username:password@localhost:27017/mydb`
 
-Micronaut Data MongoDB introduces one special repository interface api:data.mongodb.repository.MongoQueryExecutor[] which accepts `Bson`/`List<Bson>` filter/pipeline/update parameters intended to be used in combination with MongoDB DSL API:
+Micronaut Data MongoDB introduces one special repository interface api:data.mongodb.repository.MongoQueryExecutor[] (and corresponding reactive interface api:data.mongodb.repository.MongoReactiveQueryExecutor[]) which accepts `Bson`/`List<Bson>` filter/pipeline/update parameters intended to be used in combination with MongoDB DSL API:
 
  - `com.mongodb.client.model.Filters`
  - `com.mongodb.client.model.Aggregates`


### PR DESCRIPTION
As requested from the user in [the issue](https://github.com/micronaut-projects/micronaut-data/issues/2445) I thought we could add it now. Basically just copied from `MongoQueryExecutor` and updated for reactive. Hope did not miss something, reactive tests are passing.