### PR TITLE
doc - to use Criteria API you need the dependency jakarta.persistence-api

### DIFF
--- a/src/main/docs/guide/azureCosmos/azureCosmosCriteriaSpecifications.adoc
+++ b/src/main/docs/guide/azureCosmos/azureCosmosCriteriaSpecifications.adoc
@@ -1,4 +1,6 @@
-In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data Azure Cosmos features.
+In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data Azure Cosmos features. To utilize this feature add the following dependency:
+
+dependency:jakarta.persistence:jakarta.persistence-api[]
 
 To implement queries that cannot be defined at the compile-time Micronaut Data introduces api:data.repository.JpaSpecificationExecutor[] repository interface that can be used to extend your repository interface:
 

--- a/src/main/docs/guide/dbc/dbcCriteriaSpecifications.adoc
+++ b/src/main/docs/guide/dbc/dbcCriteriaSpecifications.adoc
@@ -1,4 +1,6 @@
-In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data JDBC and R2DBC features.
+In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data JDBC and R2DBC features. To utilize this feature add the following dependency:
+
+dependency:jakarta.persistence:jakarta.persistence-api[]
 
 To implement queries that cannot be defined at the compile-time Micronaut Data introduces api:data.repository.JpaSpecificationExecutor[] repository interface that can be used to extend your repository interface:
 

--- a/src/main/docs/guide/dbc/jdbc/jdbcQuickStart.adoc
+++ b/src/main/docs/guide/dbc/jdbc/jdbcQuickStart.adoc
@@ -75,7 +75,7 @@ dependency:jakarta.persistence:jakarta.persistence-api[scope="compileOnly"]
 
 To use JPA annotations in the `javax.persistence` package use:
 
-dependency:jakarta.persistence:jakarta.persistence-api[version="3.0.0", scope="compileOnly"]
+dependency:jakarta.persistence:jakarta.persistence-api[scope="compileOnly"]
 
 WARNING: If you want to use JPA annotations in your entities with Micronaut Data JDBC, we strongly recommend you use `jakarta.persistence` annotations.  Micronaut Data will remove support for `javax.persistence` annotations in the future.
 

--- a/src/main/docs/guide/mongo/mongoCriteriaSpecifications.adoc
+++ b/src/main/docs/guide/mongo/mongoCriteriaSpecifications.adoc
@@ -1,4 +1,6 @@
-In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data MongoDB features.
+In some cases, you need to build a query programmatically and at the runtime; for that, Micronaut Data implements a subset of Jakarta Persistence Criteria API 3.0, which can be used for Micronaut Data MongoDB features. To utilize this feature add the following dependency:
+
+dependency:jakarta.persistence:jakarta.persistence-api[]
 
 To implement queries that cannot be defined at the compile-time Micronaut Data introduces api:data.repository.JpaSpecificationExecutor[] repository interface that can be used to extend your repository interface:
 


### PR DESCRIPTION
closes #1835

@dstepanov @sdelamo 
These three files (for azure, dbc, mongo) say almost the exact same thing. I'm wondering if we want to refactor to the "Shared Concepts" section, or is this not that generalized?