### PR TITLE
fix: @Version type support primitive

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListener.java
@@ -105,11 +105,11 @@ public class VersionGeneratingEntityEventListener implements EntityEventListener
         }
         if (Temporal.class.isAssignableFrom(type)) {
             return newTemporal(type);
-        } else if (type == Integer.class) {
+        } else if (type == Integer.class || type == int.class) {
             return (Integer) previousValue + 1;
-        } else if (type == Long.class) {
+        } else if (type == Long.class || type == long.class) {
             return (Long) previousValue + 1L;
-        } else if (type == Short.class) {
+        } else if (type == Short.class || type == short.class) {
             return (Short) previousValue + (short) 1;
         } else {
             throw new DataAccessException("Unsupported @Version type: " + type);
@@ -119,11 +119,11 @@ public class VersionGeneratingEntityEventListener implements EntityEventListener
     private Object init(Class<?> valueType) {
         if (Temporal.class.isAssignableFrom(valueType)) {
             return newTemporal(valueType);
-        } else if (valueType == Integer.class) {
+        } else if (valueType == Integer.class || valueType == int.class) {
             return 0;
-        } else if (valueType == Long.class) {
+        } else if (valueType == Long.class || valueType == long.class) {
             return 0L;
-        } else if (valueType == Short.class) {
+        } else if (valueType == Short.class || valueType == short.class) {
             return (short) 0;
         } else {
             throw new DataAccessException("Unsupported @Version type: " + valueType);

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListenerSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/event/listeners/VersionGeneratingEntityEventListenerSpec.groovy
@@ -30,6 +30,19 @@ class VersionGeneratingEntityEventListenerSpec extends Specification {
         then:
             entity.ver
     }
+
+    void "test primitive version set"() {
+        when:
+            def entity = new ThePrimitiveEntity()
+            def mockEvent = new DefaultEntityEventContext(PersistentEntity.of(ThePrimitiveEntity), entity)
+            entityEventListener.prePersist(mockEvent)
+        then:
+            entity.ver == 0
+        when:
+            entityEventListener.preUpdate(mockEvent)
+        then:
+            entity.ver == 1
+    }
 }
 
 @MappedEntity
@@ -40,4 +53,14 @@ class TheEntity {
 
     @Version
     Instant ver
+}
+
+@MappedEntity
+class ThePrimitiveEntity {
+    @Id
+    @AutoPopulated
+    UUID uuid
+
+    @Version
+    long ver
 }


### PR DESCRIPTION
`@Version` annotated not null field in Kotlin

```Kotlin
@Entity
data class Student(
        @Id @GeneratedValue
        var id: Long?,
        @Version
        val version: Long,
)
```

will throw `DataAccessException` with `Unsupported @Version type: long`