### PR TITLE
Use oracle database ojdbc dependency from micronaut-sql

### DIFF
--- a/data-connection-jdbc/build.gradle
+++ b/data-connection-jdbc/build.gradle
@@ -35,14 +35,14 @@ dependencies {
     testRuntimeOnly mnSql.micronaut.jdbc.tomcat
     testRuntimeOnly mnSql.h2
     testRuntimeOnly mnSql.mariadb.java.client
-    testRuntimeOnly libs.drivers.jdbc.oracle
+    testRuntimeOnly mnSql.ojdbc11
     testRuntimeOnly mnSql.mysql.connector.java
     testRuntimeOnly mnSql.postgresql
     testRuntimeOnly mnSql.mssql.jdbc
     testRuntimeOnly mn.snakeyaml
 
     testResourcesService mnSql.mariadb.java.client
-    testResourcesService libs.drivers.jdbc.oracle
+    testResourcesService mnSql.ojdbc11
     testResourcesService mnSql.mysql.connector.java
     testResourcesService mnSql.postgresql
     testResourcesService mnSql.mssql.jdbc

--- a/data-jdbc/build.gradle
+++ b/data-jdbc/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     compileOnly mnRxjava2.micronaut.rxjava2
     compileOnly projects.micronautDataHibernateJpa
-    compileOnly libs.drivers.jdbc.oracle
+    compileOnly mnSql.ojdbc11
 
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.micronautDataProcessor
@@ -53,14 +53,14 @@ dependencies {
     testRuntimeOnly mnSql.micronaut.jdbc.tomcat
     testRuntimeOnly mnSql.h2
     testRuntimeOnly mnSql.mariadb.java.client
-    testRuntimeOnly libs.drivers.jdbc.oracle
+    testRuntimeOnly mnSql.ojdbc11
     testRuntimeOnly mnSql.mysql.connector.java
     testRuntimeOnly mnSql.postgresql
     testRuntimeOnly mnSql.mssql.jdbc
     testRuntimeOnly mn.snakeyaml
 
     testResourcesService mnSql.mariadb.java.client
-    testResourcesService libs.drivers.jdbc.oracle
+    testResourcesService mnSql.ojdbc11
     testResourcesService mnSql.mysql.connector.java
     testResourcesService mnSql.postgresql
     testResourcesService mnSql.mssql.jdbc

--- a/data-r2dbc/build.gradle
+++ b/data-r2dbc/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     testCompileOnly projects.micronautDataProcessor
 
     testResourcesService mnSql.mariadb.java.client
-    testResourcesService libs.drivers.jdbc.oracle
+    testResourcesService mnSql.ojdbc11
     testResourcesService mnSql.mysql.connector.java
     testResourcesService mnSql.postgresql
     testResourcesService mnSql.mssql.jdbc

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,11 +28,6 @@ managed-jakarta-transaction-api = "2.0.1"
 
 spring-data = "3.2.0"
 
-# JDBC Drivers
-
-# Need to leave it here because micronaut-sql uses older version. When it's upgraded there then we can remove this declaration here
-oracle-jdbc-driver = "23.3.0.23.09"
-
 # Testing and benchmarking
 
 benchmark-spring-data = "2023.1.0"
@@ -96,10 +91,6 @@ managed-jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persis
 
 spring-data-jpa = { module = "org.springframework.data:spring-data-jpa", version.ref = "spring-data" }
 spring-data-commons = { module = "org.springframework.data:spring-data-commons", version.ref = "spring-data" }
-
-# JDBC
-
-drivers-jdbc-oracle = { module = "com.oracle.database.jdbc:ojdbc8", version.ref = "oracle-jdbc-driver" }
 
 # AZURE COSMOS
 


### PR DESCRIPTION
This was only remaining dependency not used from micronaut-sql because odjbc driver was having issues with ucp in micronaut-sql and now it is passing so we can clean this up.