### PR TITLE
Issue 2710: Add inList as a Kotlin Criteria Function

### DIFF
--- a/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
+++ b/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 @MicronautTest
-class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuilder) {
+class KCriteriaBuilderExtKtTest(private var runtimeCriteriaBuilder: RuntimeCriteriaBuilder) {
 
     @Test
     fun testBasic() {
@@ -65,12 +65,13 @@ class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuild
                     (root[TestEntity::age] lt 40)
                     (root[TestEntity::age] le 50)
                 }
+                root[TestEntity::name] inList listOf("AAA", "BBB")
             }
         }
         val criteriaQuery = query.build(runtimeCriteriaBuilder) as QueryResultPersistentEntityCriteriaQuery
         val q = criteriaQuery.buildQuery(SqlQueryBuilder()).query
 
-        Assertions.assertEquals( """SELECT MIN(test_entity_."name") FROM "test_entity" test_entity_ WHERE ((test_entity_."enabled" = TRUE OR test_entity_."enabled" = FALSE OR test_entity_."enabled" IS NULL OR test_entity_."enabled" IS NOT NULL) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND (test_entity_."name" < ? OR test_entity_."name" <= ?) AND test_entity_."name" > ? AND test_entity_."name" >= ? AND ((test_entity_."age" >= ? AND test_entity_."age" <= ?) OR test_entity_."age" > ? OR test_entity_."age" >= ? OR test_entity_."age" < ? OR test_entity_."age" <= ?))""", q)
+        Assertions.assertEquals( """SELECT MIN(test_entity_."name") FROM "test_entity" test_entity_ WHERE ((test_entity_."enabled" = TRUE OR test_entity_."enabled" = FALSE OR test_entity_."enabled" IS NULL OR test_entity_."enabled" IS NOT NULL) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND (test_entity_."name" < ? OR test_entity_."name" <= ?) AND test_entity_."name" > ? AND test_entity_."name" >= ? AND ((test_entity_."age" >= ? AND test_entity_."age" <= ?) OR test_entity_."age" > ? OR test_entity_."age" >= ? OR test_entity_."age" < ? OR test_entity_."age" <= ?) AND test_entity_."name" IN (?))""", q)
     }
 
     @Test
@@ -85,6 +86,7 @@ class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuild
                     root[TestEntity::enabled].ne(bool)
                     root[TestEntity::enabled].equal(bool)
                     root[TestEntity::enabled].notEqual(bool)
+                    root[TestEntity::name] inList listOf("AAA", "BBB")
                 }
                 or {
                     root[TestEntity::enabled].eq(str)
@@ -103,7 +105,7 @@ class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuild
         val criteriaQuery = query.build(runtimeCriteriaBuilder) as QueryResultPersistentEntityCriteriaQuery
         val q = criteriaQuery.buildQuery(SqlQueryBuilder()).query
 
-        Assertions.assertEquals("""SELECT MIN(test_entity_."name") FROM "test_entity" test_entity_ WHERE (NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND (test_entity_."enabled" = ? OR test_entity_."enabled" != ? OR test_entity_."enabled" = ? OR test_entity_."enabled" != ?) AND test_entity_."description" = ? AND test_entity_."description" != ? AND test_entity_."description" = ? AND test_entity_."description" != ?)""", q)
+        Assertions.assertEquals("""SELECT MIN(test_entity_."name") FROM "test_entity" test_entity_ WHERE (NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND NOT(test_entity_."enabled" = ?) AND NOT(test_entity_."enabled" != ?) AND test_entity_."name" NOT IN (?) AND (test_entity_."enabled" = ? OR test_entity_."enabled" != ? OR test_entity_."enabled" = ? OR test_entity_."enabled" != ?) AND test_entity_."description" = ? AND test_entity_."description" != ? AND test_entity_."description" = ? AND test_entity_."description" != ?)""", q)
     }
 
     @Test

--- a/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -100,6 +100,10 @@ interface PersonRepository : CrudRepository<Person, String>, JpaSpecificationExe
                 root[Person::age] lt age
             }
         }
+
+        fun nameInList(names: List<String>) = where<Person> {
+            root[Person::name] inList names
+        }
         // end::or[]
 
         // end::specifications[]
@@ -134,4 +138,3 @@ interface PersonRepository : CrudRepository<Person, String>, JpaSpecificationExe
     // end::specifications[]
     // tag::repository[]
 }
-

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -11,6 +11,8 @@ import io.micronaut.data.repository.jpa.criteria.DeleteSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
+import io.micronaut.data.runtime.criteria.get
+import io.micronaut.data.runtime.criteria.where
 import java.util.*
 
 // tag::repository[]
@@ -92,6 +94,10 @@ interface PersonRepository : CrudRepository<Person, Long>, JpaSpecificationExecu
 
         fun ageIsLessThan(age: Int) = PredicateSpecification<Person> { root, criteriaBuilder ->
             criteriaBuilder.lessThan(root.get("age"), age)
+        }
+
+        fun nameInList(names: List<String>) = where<Person> {
+            root[Person::name] inList names
         }
 
         // end::specifications[]

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -20,14 +20,14 @@ internal class PersonRepositorySpec {
     @BeforeEach
     fun beforeEach() {
         personRepository.saveAll(listOf(
-                Person(
-                        "Denis",
-                        13
-                ),
-                Person(
-                        "Josh",
-                        22
-                )
+            Person(
+                "Denis",
+                13
+            ),
+            Person(
+                "Josh",
+                22
+            )
         ))
     }
 

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
@@ -2,6 +2,7 @@ package example
 
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.nameEquals
+import example.PersonRepository.Specifications.nameInList
 import example.PersonRepository.Specifications.setNewName
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
@@ -25,14 +26,14 @@ internal class PersonSuspendRepositorySpec {
     fun beforeEach() {
         runBlocking {
             personRepository.saveAll(listOf(
-                    Person(
-                            "Denis",
-                            13
-                    ),
-                    Person(
-                            "Josh",
-                            22
-                    )
+                Person(
+                    "Denis",
+                    13
+                ),
+                Person(
+                    "Josh",
+                    22
+                )
             )).toList()
         }
     }
@@ -116,5 +117,17 @@ internal class PersonSuspendRepositorySpec {
         Assertions.assertEquals(2, countAgeLess30Page.totalPages)
         Assertions.assertEquals(1, countAgeLess30Page.content.size)
         Assertions.assertEquals("Denis", countAgeLess30Page.content[0].name)
+    }
+
+    @Test
+    fun testInListWithPagination() = runBlocking {
+        val people = personRepository.findAll(nameInList(listOf("Denis", "Josh")), Sort.of(Sort.Order.asc("name"))).toList()
+        val peoplePage = personRepository.findAll(nameInList(listOf("Denis", "Josh")),  Pageable.from(0,1, Sort.of(Sort.Order.asc("name"))))
+        Assertions.assertEquals(2, people.size)
+        Assertions.assertEquals("Denis", people[0].name)
+        Assertions.assertEquals("Josh", people[1].name)
+        Assertions.assertEquals(2, peoplePage.totalPages)
+        Assertions.assertEquals(1, peoplePage.content.size)
+        Assertions.assertEquals("Denis", peoplePage.content[0].name)
     }
 }

--- a/doc-examples/mongo-example-kotlin-ksp/src/main/kotlin/example/ProductRepository.kt
+++ b/doc-examples/mongo-example-kotlin-ksp/src/main/kotlin/example/ProductRepository.kt
@@ -47,6 +47,14 @@ interface ProductRepository : CrudRepository<Product, ObjectId>, JpaSpecificatio
             manufacturer[Manufacturer::name] eq name
         }
 
+        fun nameInList(names: List<String>) = where<Product> {
+            val manufacturer = root.joinOne(Product::manufacturer)
+            or {
+                root[Product::name] inList names
+                manufacturer[Manufacturer::name] inList names
+            }
+        }
+
         // tag::specifications[]
     }
 

--- a/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -98,6 +98,8 @@ interface PersonRepository : CrudRepository<Person, ObjectId>, JpaSpecificationE
         fun nameEquals(name: String?) = where<Person> { root[Person::name] eq name }
 
         fun ageIsLessThan(age: Int) = where<Person> { root[Person::age] lt age }
+
+        fun nameInList(names: List<String>) = where<Person> { root[Person::name] inList names }
         // end::where[]
 
         // tag::or[]
@@ -145,7 +147,6 @@ interface PersonRepository : CrudRepository<Person, ObjectId>, JpaSpecificationE
             // end::setUpdate[]
             null
         }
-
         // tag::specifications[]
         // tag::repository[]
     }
@@ -153,4 +154,3 @@ interface PersonRepository : CrudRepository<Person, ObjectId>, JpaSpecificationE
     // end::specifications[]
     // end::repository[]
 }
-

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -3,6 +3,7 @@ package example
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.interestsContains
 import example.PersonRepository.Specifications.nameEquals
+import example.PersonRepository.Specifications.nameInList
 import example.PersonRepository.Specifications.updateName
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification.not
@@ -12,7 +13,6 @@ import io.micronaut.data.runtime.criteria.where
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.*
-import java.util.*
 
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -23,16 +23,16 @@ class PersonRepositorySpec : AbstractMongoSpec() {
     @BeforeEach
     fun beforeEach() {
         personRepository.saveAll(listOf(
-                Person(
-                        "Denis",
-                        13
-                ),
-                Person(
-                    null,
-                    "Josh",
-                    22,
-                    listOf("music", "sports", "hiking")
-                )
+            Person(
+                "Denis",
+                13
+            ),
+            Person(
+                null,
+                "Josh",
+                22,
+                listOf("music", "sports", "hiking")
+            )
         ))
     }
 
@@ -65,9 +65,9 @@ class PersonRepositorySpec : AbstractMongoSpec() {
     fun testFindDto() {
         val stats = personRepository.findOne(query<Person, PersonAgeStatsDto> {
             multiselect(
-                    max(Person::age).alias(PersonAgeStatsDto::maxAge),
-                    min(Person::age).alias(PersonAgeStatsDto::minAge),
-                    avg(Person::age).alias(PersonAgeStatsDto::avgAge)
+                max(Person::age).alias(PersonAgeStatsDto::maxAge),
+                min(Person::age).alias(PersonAgeStatsDto::minAge),
+                avg(Person::age).alias(PersonAgeStatsDto::avgAge)
             )
             where {
                 or {
@@ -159,5 +159,18 @@ class PersonRepositorySpec : AbstractMongoSpec() {
         people = personRepository.findAll(interestsContains( "hiking"))
         Assertions.assertEquals(1, people.size)
         Assertions.assertEquals("Josh", people[0].name)
+    }
+
+    @Test
+    fun testFindInList() {
+        val twoPeople = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Denis", "Josh"))))
+        val denis = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Denis"))))
+        val josh = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Josh"))))
+
+        Assertions.assertEquals(2, twoPeople.size)
+        Assertions.assertEquals(1, denis.size)
+        Assertions.assertEquals("Denis", denis.first().name)
+        Assertions.assertEquals(1, josh.size)
+        Assertions.assertEquals("Josh", josh.first().name)
     }
 }

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
@@ -4,6 +4,7 @@ import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.ageIsLessThan2
 import example.PersonRepository.Specifications.nameEquals
 import example.PersonRepository.Specifications.nameEquals2
+import example.PersonRepository.Specifications.nameInList
 import example.PersonRepository.Specifications.setNewName2
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -22,14 +23,14 @@ internal class PersonSuspendRepositorySpec : AbstractMongoSpec() {
     @BeforeEach
     fun beforeEach() {
         personRepository.saveAll(listOf(
-                Person(
-                        "Denis",
-                        13
-                ),
-                Person(
-                        "Josh",
-                        22
-                )
+            Person(
+                "Denis",
+                13
+            ),
+            Person(
+                "Josh",
+                22
+            )
         ))
     }
 
@@ -84,5 +85,18 @@ internal class PersonSuspendRepositorySpec : AbstractMongoSpec() {
         Assertions.assertEquals(2, all.size)
         Assertions.assertTrue(all.stream().anyMatch { p: Person -> p.name == "Steven" })
         Assertions.assertTrue(all.stream().anyMatch { p: Person -> p.name == "Josh" })
+    }
+
+    @Test
+    fun testFindInList() = runBlocking {
+        val twoPeople = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Denis", "Josh")))).toList()
+        val denis = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Denis")))).toList()
+        val josh = personRepository.findAll(PredicateSpecification.where(nameInList(listOf("Josh")))).toList()
+
+        Assertions.assertEquals(2, twoPeople.size)
+        Assertions.assertEquals(1, denis.size)
+        Assertions.assertEquals("Denis", denis.first().name)
+        Assertions.assertEquals(1, josh.size)
+        Assertions.assertEquals("Josh", josh.first().name)
     }
 }


### PR DESCRIPTION
This PR adds a new Kotlin Extension Function to the Experimental Kotlin Criteria API; namely `inList`. The `inList` function should correspond to the DB operation `IN`.

The `inList` API accepts a `Collection` as an argument, and the way it works is that it calls the `criteriaBuilder::in` function with the Expression as an argument, and passes the Collection Values to the `In::value` API.

The end result is a generated predicate in the like of: `IN (?, ?, ?)`

I have added some specs to make sure it works across the different DB Engines (JDBC, Mongo, and Cosmos). Would appreciate your feedback