### PR TITLE
Add Kotlin Criteria API that implements QuerySpecification

### DIFF
--- a/data-runtime/src/main/kotlin/io/micronaut/data/runtime/criteria/KCriteriaBuilderExt.kt
+++ b/data-runtime/src/main/kotlin/io/micronaut/data/runtime/criteria/KCriteriaBuilderExt.kt
@@ -20,6 +20,7 @@ import io.micronaut.data.repository.jpa.criteria.CriteriaDeleteBuilder
 import io.micronaut.data.repository.jpa.criteria.CriteriaQueryBuilder
 import io.micronaut.data.repository.jpa.criteria.CriteriaUpdateBuilder
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
+import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import jakarta.persistence.criteria.*
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
@@ -42,6 +43,24 @@ fun <E, I, K : Collection<I>?> From<*, E>.joinMany(prop: KProperty1<out E, K>, j
 }
 
 @Experimental
+fun <E, I, K : List<I>?> From<*, E>.joinMany(prop: KProperty1<out E, K>, joinType: JoinType? = null): ListJoin<E, I> {
+    return if (joinType == null) {
+        this.joinList(prop.name)
+    } else {
+        this.joinList(prop.name, joinType)
+    }
+}
+
+@Experimental
+fun <E, I, K : Set<I>?> From<*, E>.joinMany(prop: KProperty1<out E, K>, joinType: JoinType? = null): SetJoin<E, I> {
+    return if (joinType == null) {
+        this.joinSet(prop.name)
+    } else {
+        this.joinSet(prop.name, joinType)
+    }
+}
+
+@Experimental
 fun <E, I> From<*, E>.joinOne(prop: KProperty1<out E, I>, joinType: JoinType? = null): Join<E, I> {
     return if (joinType == null) {
         this.join(prop.name)
@@ -52,6 +71,9 @@ fun <E, I> From<*, E>.joinOne(prop: KProperty1<out E, I>, joinType: JoinType? = 
 
 @Experimental
 inline fun <reified E> where(noinline dsl: Where<E>.() -> Unit) = WherePredicate(dsl)
+
+@Experimental
+inline fun <reified E> query(noinline dsl: SelectQuery<E, *>.() -> Unit) = QueryPredicate(dsl)
 
 @Experimental
 inline fun <reified E, reified R> query(noinline dsl: SelectQuery<E, R>.() -> Unit) = QueryBuilder(dsl, E::class.java, R::class.java)
@@ -104,6 +126,17 @@ class WherePredicate<T>(var where: Where<T>.() -> Unit) : PredicateSpecification
         val query = Where(root, criteriaBuilder)
         where.invoke(query)
         return query.toPredicate(true)
+    }
+
+}
+
+@Experimental
+class QueryPredicate<T>(var query: SelectQuery<T, *>.() -> Unit) : QuerySpecification<T> {
+
+    override fun toPredicate(root: Root<T>, criteriaQuery: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder): Predicate {
+        val selectQuery = SelectQuery(root, criteriaQuery, criteriaBuilder)
+        query.invoke(selectQuery)
+        return requireNotNull(selectQuery.predicate)
     }
 
 }

--- a/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
+++ b/data-runtime/src/test/kotlin/io/micronaut/data/runtime/criteria/ext/KCriteriaBuilderExtKtTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 @MicronautTest
-class KCriteriaBuilderExtKtTest(var runtimeCriteriaBuilder: RuntimeCriteriaBuilder) {
+class KCriteriaBuilderExtKtTest(private val runtimeCriteriaBuilder: RuntimeCriteriaBuilder) {
 
     @Test
     fun testBasic() {

--- a/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -97,12 +97,17 @@ interface PersonRepository : CrudRepository<Person, String>, JpaSpecificationExe
         // end::where[]
 
         // tag::or[]
-        fun nameOrAgeMatches(age: Int, name: String?) = query<Person> {
+        fun nameOrAgeMatches(age: Int, name: String?) = where<Person> {
+            or {
+                root[Person::name] eq name
+                root[Person::age] lt age
+            }
+        }
+
+        fun nameAndAgeMatch(age: Int, name: String) = query<Person> {
             where {
-                or {
-                    root[Person::name] eq name
-                    root[Person::age] lt age
-                }
+                root[Person::name] eq name
+                root[Person::age] lt age
             }
         }
         // end::or[]

--- a/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -11,6 +11,7 @@ import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
 import io.micronaut.data.runtime.criteria.get
+import io.micronaut.data.runtime.criteria.query
 import io.micronaut.data.runtime.criteria.update
 import io.micronaut.data.runtime.criteria.where
 import java.util.*
@@ -96,10 +97,12 @@ interface PersonRepository : CrudRepository<Person, String>, JpaSpecificationExe
         // end::where[]
 
         // tag::or[]
-        fun nameOrAgeMatches(age: Int, name: String?) = where<Person> {
-            or {
-                root[Person::name] eq name
-                root[Person::age] lt age
+        fun nameOrAgeMatches(age: Int, name: String?) = query<Person> {
+            where {
+                or {
+                    root[Person::name] eq name
+                    root[Person::age] lt age
+                }
             }
         }
         // end::or[]

--- a/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -2,11 +2,8 @@ package example
 
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.nameEquals
-<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
-=======
 import example.PersonRepository.Specifications.nameOrAgeMatches
->>>>>>> Stashed changes
 import example.PersonRepository.Specifications.updateName
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -56,15 +53,17 @@ class PersonRepositorySpec : AbstractAzureCosmosTest() {
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan(30).and(not(nameEquals("Denis"))))
 
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh"))))
-
-        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Denis"))
         // end::find[]
-
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
+    }
+
+    @Test
+    fun testNameOrAgeMatches() {
+        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh"))
         Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 

--- a/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -2,7 +2,11 @@ package example
 
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.nameEquals
+<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
+=======
+import example.PersonRepository.Specifications.nameOrAgeMatches
+>>>>>>> Stashed changes
 import example.PersonRepository.Specifications.updateName
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -52,12 +56,16 @@ class PersonRepositorySpec : AbstractAzureCosmosTest() {
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan(30).and(not(nameEquals("Denis"))))
 
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh"))))
+
+        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Denis"))
         // end::find[]
+
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
+        Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 
     @Test

--- a/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/azure-cosmos-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -1,9 +1,9 @@
 package example
 
 import example.PersonRepository.Specifications.ageIsLessThan
+import example.PersonRepository.Specifications.nameAndAgeMatch
 import example.PersonRepository.Specifications.nameEquals
 import example.PersonRepository.Specifications.nameInList
-import example.PersonRepository.Specifications.nameOrAgeMatches
 import example.PersonRepository.Specifications.updateName
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -62,8 +62,9 @@ class PersonRepositorySpec : AbstractAzureCosmosTest() {
     }
 
     @Test
-    fun testNameOrAgeMatches() {
-        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh"))
+    fun testNameAndAgeMatch() {
+        personRepository.save(Person("Josh", 14))
+        val peopleWithNameOrAge = personRepository.findAll(nameAndAgeMatch(25, "Josh"))
         Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Child.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/Child.kt
@@ -7,16 +7,12 @@ import io.micronaut.data.annotation.Relation
 
 @MappedEntity
 data class Child(
+    val name: String,
 
-        val name: String,
-
-        @Relation(Relation.Kind.MANY_TO_ONE)
+    @Relation(Relation.Kind.MANY_TO_ONE)
     val parent: Parent? = null,
 
-        @field:Id @GeneratedValue val id: Int? = null
-
-
-
+    @field:Id @GeneratedValue val id: Int? = null
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentSuspendRepositoryTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentSuspendRepositoryTest.kt
@@ -1,11 +1,15 @@
 package example
 
+import example.ParentSuspendRepository.Specifications.childNameInList
+import io.micronaut.data.model.Pageable
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import jakarta.inject.Inject
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @MicronautTest
 class ParentSuspendRepositoryTest {
@@ -38,5 +42,33 @@ class ParentSuspendRepositoryTest {
         val found2 = repository.findById(saved.id!!).get()
         assertTrue(found2.name.endsWith(" mod!"))
         assertTrue(found2.children.size == 3)
+    }
+
+    @Test
+    fun `findAll with specifications`() = runBlocking {
+        val denis = Parent(
+            "Denis",
+            listOf(
+                Child("A"),
+                Child("B"),
+                Child("C")
+            )
+        )
+        repository.save(denis)
+
+        val josh = Parent(
+            "Josh",
+            listOf(
+                Child("B"),
+                Child("C"),
+                Child("D")
+            )
+        )
+        repository.save(josh)
+
+        val result = repository.findAll(childNameInList(listOf("A", "B", "D")), Pageable.from(0, 1))
+
+        assertEquals(1, result.content.size)
+        assertEquals(2, result.totalSize)
     }
 }

--- a/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -104,7 +104,7 @@ interface PersonRepository : CrudRepository<Person, ObjectId>, JpaSpecificationE
         // end::where[]
 
         // tag::or[]
-        fun nameOrAgeMatches(age: Int, name: String?) = query<Person> {
+        fun nameOrAgeMatches(age: Int, name: String) = query<Person> {
             where {
                 or {
                     root[Person::name] eq name

--- a/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/mongo-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -12,6 +12,7 @@ import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
 import io.micronaut.data.runtime.criteria.get
+import io.micronaut.data.runtime.criteria.query
 import io.micronaut.data.runtime.criteria.update
 import io.micronaut.data.runtime.criteria.where
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -103,10 +104,12 @@ interface PersonRepository : CrudRepository<Person, ObjectId>, JpaSpecificationE
         // end::where[]
 
         // tag::or[]
-        fun nameOrAgeMatches(age: Int, name: String?) = where<Person> {
-            or {
-                root[Person::name] eq name
-                root[Person::age] lt age
+        fun nameOrAgeMatches(age: Int, name: String?) = query<Person> {
+            where {
+                or {
+                    root[Person::name] eq name
+                    root[Person::age] lt age
+                }
             }
         }
         // end::or[]

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -3,7 +3,11 @@ package example
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.interestsContains
 import example.PersonRepository.Specifications.nameEquals
+<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
+=======
+import example.PersonRepository.Specifications.nameOrAgeMatches
+>>>>>>> Stashed changes
 import example.PersonRepository.Specifications.updateName
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification.not
@@ -54,12 +58,16 @@ class PersonRepositorySpec : AbstractMongoSpec() {
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan(30).and(not(nameEquals("Denis"))))
 
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh"))))
+
+        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh"))
+
         // end::find[]
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
+        Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 
     @Test

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -3,11 +3,8 @@ package example
 import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.interestsContains
 import example.PersonRepository.Specifications.nameEquals
-<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
-=======
 import example.PersonRepository.Specifications.nameOrAgeMatches
->>>>>>> Stashed changes
 import example.PersonRepository.Specifications.updateName
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification.not
@@ -17,7 +14,6 @@ import io.micronaut.data.runtime.criteria.where
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.*
-import java.util.*
 
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -58,15 +54,17 @@ class PersonRepositorySpec : AbstractMongoSpec() {
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan(30).and(not(nameEquals("Denis"))))
 
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh"))))
-
-        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh"))
-
         // end::find[]
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
+    }
+
+    @Test
+    fun testNameOrAgeMatches() {
+        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh"))
         Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
@@ -4,7 +4,11 @@ import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.ageIsLessThan2
 import example.PersonRepository.Specifications.nameEquals
 import example.PersonRepository.Specifications.nameEquals2
+<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
+=======
+import example.PersonRepository.Specifications.nameOrAgeMatches
+>>>>>>> Stashed changes
 import example.PersonRepository.Specifications.setNewName2
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -47,12 +51,14 @@ internal class PersonSuspendRepositorySpec : AbstractMongoSpec() {
         val countAgeLess20: Long = personRepository.count(ageIsLessThan(20))
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan2(30).and(not(nameEquals2("Denis"))))
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh")))).toList()
+        val peopleWithAgeOrName = personRepository.findAll(nameOrAgeMatches(22, "Josh")).toList()
         // end::find[]
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
+        Assertions.assertEquals(2, peopleWithAgeOrName.size)
     }
 
     @Test

--- a/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
+++ b/doc-examples/mongo-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
@@ -4,11 +4,8 @@ import example.PersonRepository.Specifications.ageIsLessThan
 import example.PersonRepository.Specifications.ageIsLessThan2
 import example.PersonRepository.Specifications.nameEquals
 import example.PersonRepository.Specifications.nameEquals2
-<<<<<<< Updated upstream
 import example.PersonRepository.Specifications.nameInList
-=======
 import example.PersonRepository.Specifications.nameOrAgeMatches
->>>>>>> Stashed changes
 import example.PersonRepository.Specifications.setNewName2
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
@@ -51,14 +48,18 @@ internal class PersonSuspendRepositorySpec : AbstractMongoSpec() {
         val countAgeLess20: Long = personRepository.count(ageIsLessThan(20))
         val countAgeLess30NotDenis: Long = personRepository.count(ageIsLessThan2(30).and(not(nameEquals2("Denis"))))
         val people = personRepository.findAll(PredicateSpecification.where(nameEquals("Denis").or(nameEquals("Josh")))).toList()
-        val peopleWithAgeOrName = personRepository.findAll(nameOrAgeMatches(22, "Josh")).toList()
         // end::find[]
         Assertions.assertNotNull(denis)
         Assertions.assertEquals(2, countAgeLess30)
         Assertions.assertEquals(1, countAgeLess20)
         Assertions.assertEquals(1, countAgeLess30NotDenis)
         Assertions.assertEquals(2, people.size)
-        Assertions.assertEquals(2, peopleWithAgeOrName.size)
+    }
+
+    @Test
+    fun testNameOrAgeMatches() = runBlocking {
+        val peopleWithNameOrAge = personRepository.findAll(nameOrAgeMatches(22, "Josh")).toList()
+        Assertions.assertEquals(2, peopleWithNameOrAge.size)
     }
 
     @Test


### PR DESCRIPTION
The PR adds to the Kotlin Criteria API the following parameterized method:

```
inline fun <reified E> query(noinline dsl: SelectQuery<E, *>.() -> Unit) = QueryPredicate(dsl)
```

The method returns an instance of the new class `QueryPredicate` which is a concrete implementation of the `QuerySpecification` interface.

The purpose of the API is to provide a Kotlin intuitive way for building queries through the `QuerySpecification` interface.

It addresses the gap between the existing `where<E>`, which returns a `PredicateSpecification<E>`, and `query<E, R>`, which returns a `CriteriaQueryBuilder<R>`.
