### PR TITLE
Fix count query for Page response and criteria

### DIFF
--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder.java
@@ -100,6 +100,11 @@ public final class CosmosSqlQueryBuilder extends SqlQueryBuilder {
     }
 
     @Override
+    public boolean supportsCountDistinct() {
+        return false;
+    }
+
+    @Override
     protected NamingStrategy getNamingStrategy(PersistentEntity entity) {
         return entity.findNamingStrategy().orElse(RAW_NAMING_STRATEGY);
     }

--- a/data-model/src/main/java/io/micronaut/data/model/query/DefaultProjectionList.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/DefaultProjectionList.java
@@ -81,6 +81,12 @@ class DefaultProjectionList implements ProjectionList {
     }
 
     @Override
+    public ProjectionList countDistinct() {
+        add(Projections.countDistinctRoot());
+        return this;
+    }
+
+    @Override
     public ProjectionList countDistinct(String property) {
         add(Projections.countDistinct(property));
         return this;

--- a/data-model/src/main/java/io/micronaut/data/model/query/ProjectionList.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/ProjectionList.java
@@ -37,6 +37,12 @@ public interface ProjectionList {
     ProjectionList count();
 
     /**
+     * Distinct count the number of records returned.
+     * @return The projection list
+     */
+    ProjectionList countDistinct();
+
+    /**
      * Count the number of records returned.
      * @param property The property name to count
      * @return The projection list

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder.java
@@ -200,4 +200,14 @@ public interface QueryBuilder {
     default boolean supportsForUpdate() {
         return false;
     }
+
+    /**
+     * Gets an indicator telling COUNT DISTINCT (against root, which will count ids) is supported by the query builder.
+     * By default, it is supported.
+     *
+     * @return true if query builder supports COUNT DISTINCT, otherwise false
+     */
+    default boolean supportsCountDistinct() {
+        return true;
+    }
 }

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
@@ -21,7 +21,6 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.data.annotation.Join;
 import io.micronaut.data.annotation.TypeRole;
 import io.micronaut.data.intercept.annotation.DataMethod;
-import io.micronaut.data.model.Association;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaBuilder;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaQuery;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -750,11 +750,11 @@ interface AuthorRepository extends GenericRepository<Author, Long> {
 
         expect:
         findAllQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
-        findAllCountQuery == 'SELECT COUNT(*) FROM `author` author_'
+        findAllCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
         findByNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND (author_.nick_name =?))'
-        findByNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ WHERE (author_.`name` = ? AND (author_.nick_name =?))'
+        findByNameCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND (author_.nick_name =?))'
         findByNickNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name` FROM `author` author_ WHERE (author_.`nick_name` = ? AND (author_.name =?))'
-        findByNickNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ WHERE (author_.`nick_name` = ? AND (author_.name =?))'
+        findByNickNameCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ WHERE (author_.`nick_name` = ? AND (author_.name =?))'
         getResultDataType(findAllMethod) == DataType.ENTITY
         getResultDataType(findByNameMethod) == DataType.ENTITY
         getResultDataType(findByNickNameMethod) == DataType.ENTITY
@@ -1093,7 +1093,7 @@ interface TestRepository extends GenericRepository<ActivityPeriodEntity, UUID> {
         def result = builder.buildQuery(AnnotationMetadata.EMPTY_METADATA, test)
         def query = result.query
         then:
-        query == queryFindAll
+        query == 'SELECT activity_period_entity_.`id`,activity_period_entity_.`name`,activity_period_entity_.`description`,activity_period_entity_.`type` FROM `activity_period` activity_period_entity_ LEFT JOIN `activity_period_person` activity_period_entity_persons_ ON activity_period_entity_.`id`=activity_period_entity_persons_.`activity_period_id` LEFT JOIN `activity_person` activity_period_entity_persons_id_person_ ON activity_period_entity_persons_.`person_id`=activity_period_entity_persons_id_person_.`id`'
     }
 
     void "test project enum"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/PageSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/PageSpec.groovy
@@ -104,9 +104,7 @@ interface MyInterface extends GenericRepository<Person, Long> {
         then:"it is configured correctly"
         listAnn.interceptor() == FindPageInterceptor
         findAnn.interceptor() == FindPageInterceptor
-        findMethod.getValue(Query.class, "countQuery", String).get() == "SELECT COUNT($alias) FROM io.micronaut.data.model.entities.Person AS $alias WHERE (${alias}.name = :p1)"
-//        findMethod.stringValues(DataMethod.class, DataMethod.META_MEMBER_COUNT_PARAMETERS + "Names") == ['p1'] as String[]
-
+        findMethod.getValue(Query.class, "countQuery", String).get() == "SELECT COUNT(DISTINCT($alias)) FROM io.micronaut.data.model.entities.Person AS $alias WHERE (${alias}.name = :p1)"
     }
 
     void "test count query with join many to one"() {
@@ -215,7 +213,7 @@ interface MyInterface extends GenericRepository<Author, Long> {
         query.contains(expectedJoin)
         println(query)
         countQuery.contains("$alias")
-        !countQuery.contains(expectedJoin)
+        countQuery.contains(expectedJoin)
         println(countQuery)
 
         where:

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/AbstractAsyncSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/AbstractAsyncSpecificationInterceptor.java
@@ -92,7 +92,7 @@ public abstract class AbstractAsyncSpecificationInterceptor<T, R> extends Abstra
     protected final CompletionStage<Number> countAsync(RepositoryMethodKey methodKey, MethodInvocationContext<T, R> context) {
         Set<JoinPath> methodJoinPaths = getMethodJoinPaths(methodKey, context);
         if (asyncCriteriaOperations != null) {
-            return asyncCriteriaOperations.findOne(buildCountQuery(context)).thenApply(n -> n);
+            return asyncCriteriaOperations.findOne(buildCountQuery(context, false)).thenApply(n -> n);
         }
         return asyncOperations.findOne(preparedQueryForCriteria(methodKey, context, Type.COUNT, methodJoinPaths));
     }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
@@ -87,7 +87,7 @@ public abstract class AbstractReactiveSpecificationInterceptor<T, R> extends Abs
     protected final Publisher<Long> countReactive(RepositoryMethodKey methodKey, MethodInvocationContext<T, R> context) {
         Set<JoinPath> methodJoinPaths = getMethodJoinPaths(methodKey, context);
         if (reactiveCriteriaOperations != null) {
-            return reactiveCriteriaOperations.findOne(buildCountQuery(context));
+            return reactiveCriteriaOperations.findOne(buildCountQuery(context, false));
         }
         return reactiveOperations.findOne(preparedQueryForCriteria(methodKey, context, Type.COUNT, methodJoinPaths));
     }


### PR DESCRIPTION
Changes fix for an [earlier issue](https://github.com/micronaut-projects/micronaut-data/issues/1882) and adds fix for  [recently reported issue](https://github.com/micronaut-projects/micronaut-data/issues/2707). 
Basically, when returning `Page` model will execute `DISTINCT COUNT <identity>` because when there are joins, results return more rows and we cannot count that since will return more results (while returning results using mapper returns correct number of records). 