### PR TITLE
Apply count distinct to the criteria query when specified in the paging count query

### DIFF
--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/JpaSpecificationCrudRepositorySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/JpaSpecificationCrudRepositorySpec.groovy
@@ -102,6 +102,10 @@ class JpaSpecificationCrudRepositorySpec extends Specification {
         results.size() == 4
         results.every({ it instanceof Person})
 
+        def pageReq = Pageable.from(0, 2, Sort.of(Sort.Order.asc("age")))
+        def page = crudRepository.findAll(JpaSpecificationCrudRepository.Specifications.ageGreaterThanThirty(true), pageReq)
+        page.totalSize <= 4
+
         def sorted = crudRepository.findAll(JpaSpecificationCrudRepository.Specifications.ageGreaterThanThirty(), Sort.of(Sort.Order.asc("age")))
 
         sorted.first().name == "James"

--- a/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/JpaSpecificationCrudRepository.java
+++ b/data-hibernate-jpa/src/test/java/io/micronaut/data/hibernate/JpaSpecificationCrudRepository.java
@@ -72,9 +72,18 @@ public interface JpaSpecificationCrudRepository extends CrudRepository<Person, L
 
     class Specifications {
         public static Specification<Person> ageGreaterThanThirty() {
-            return (root, query, criteriaBuilder) -> criteriaBuilder.greaterThan(
+            return ageGreaterThanThirty(false);
+        }
+
+        public static Specification<Person> ageGreaterThanThirty(boolean countDistinct) {
+            return (root, query, criteriaBuilder) -> {
+                if (countDistinct && query.getResultType() == Long.class) {
+                    query.distinct(true);
+                }
+                return criteriaBuilder.greaterThan(
                     root.get("age"), 30
-            );
+                );
+            };
         }
 
         public static Specification<Person> nameEquals(String name) {

--- a/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/repository/jpa/intercept/ReactiveFindPageSpecificationInterceptor.java
+++ b/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/repository/jpa/intercept/ReactiveFindPageSpecificationInterceptor.java
@@ -97,7 +97,11 @@ public class ReactiveFindPageSpecificationInterceptor extends AbstractSpecificat
                 if (countPredicate != null) {
                     countQuery.where(countPredicate);
                 }
-                countQuery.select(criteriaBuilder.count(countRoot));
+                if (countQuery.isDistinct()) {
+                    countQuery.select(criteriaBuilder.countDistinct(countRoot));
+                } else {
+                    countQuery.select(criteriaBuilder.count(countRoot));
+                }
                 return Mono.fromCompletionStage(() -> session.createQuery(countQuery).getSingleResult())
                     .map(total -> Page.of(results, pageable, total));
             });

--- a/data-jpa/src/main/java/io/micronaut/data/jpa/repository/intercept/FindPageSpecificationInterceptor.java
+++ b/data-jpa/src/main/java/io/micronaut/data/jpa/repository/intercept/FindPageSpecificationInterceptor.java
@@ -107,7 +107,11 @@ public class FindPageSpecificationInterceptor extends AbstractSpecificationInter
             if (countPredicate != null) {
                 countQuery.where(countPredicate);
             }
-            countQuery.select(criteriaBuilder.count(countRoot));
+            if (countQuery.isDistinct()) {
+                countQuery.select(criteriaBuilder.countDistinct(countRoot));
+            } else {
+                countQuery.select(criteriaBuilder.count(countRoot));
+            }
             Long singleResult = entityManager.createQuery(countQuery).getSingleResult();
 
             return Page.of(

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindPageSpecificationInterceptor.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/intercept/FindPageSpecificationInterceptor.java
@@ -101,9 +101,13 @@ public final class FindPageSpecificationInterceptor extends AbstractQueryInterce
                     final List<Object> results = typedQuery.getResultList();
                     final CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
                     final Root<?> countRoot = countQuery.from(getRequiredRootEntity(context));
-                    final Predicate countPredicate = specification.toPredicate(countRoot, query, criteriaBuilder);
+                    final Predicate countPredicate = specification.toPredicate(countRoot, countQuery, criteriaBuilder);
                     countQuery.where(countPredicate);
-                    countQuery.select(criteriaBuilder.count(countRoot));
+                    if (countQuery.isDistinct()) {
+                        countQuery.select(criteriaBuilder.countDistinct(countRoot));
+                    } else {
+                        countQuery.select(criteriaBuilder.count(countRoot));
+                    }
 
                     return new PageImpl<>(
                             results,

--- a/data-spring-jpa/src/test/groovy/io/micronaut/data/spring/hibernate/SpringCrudRepositoryJpaSpec.groovy
+++ b/data-spring-jpa/src/test/groovy/io/micronaut/data/spring/hibernate/SpringCrudRepositoryJpaSpec.groovy
@@ -81,6 +81,10 @@ class SpringCrudRepositoryJpaSpec extends Specification implements H2Properties 
         results.size() == 4
         results.every({ it instanceof Person})
 
+        def pageReq = PageRequest.of(0, 2, Sort.by("age"))
+        def page = crudRepository.findAll(SpringCrudRepository.Specifications.ageGreaterThanThirty(true), pageReq)
+        page.totalElements <= 4
+
         def sorted = crudRepository.findAll(SpringCrudRepository.Specifications.ageGreaterThanThirty(), Sort.by("age"))
 
         sorted.first().name == "James"

--- a/data-spring-jpa/src/test/java/io/micronaut/data/spring/hibernate/spring/SpringCrudRepository.java
+++ b/data-spring-jpa/src/test/java/io/micronaut/data/spring/hibernate/spring/SpringCrudRepository.java
@@ -73,9 +73,18 @@ public interface SpringCrudRepository extends CrudRepository<Person, Long>, JpaS
 
     class Specifications {
         public static Specification<Person> ageGreaterThanThirty() {
-            return (root, query, criteriaBuilder) -> criteriaBuilder.greaterThan(
+            return ageGreaterThanThirty(false);
+        }
+
+        public static Specification<Person> ageGreaterThanThirty(boolean countDistinct) {
+            return (root, query, criteriaBuilder) -> {
+                if (countDistinct && query.getResultType() == Long.class) {
+                    query.distinct(true);
+                }
+                return criteriaBuilder.greaterThan(
                     root.get("age"), 30
-            );
+                );
+            };
         }
 
         public static Specification<Person> nameEquals(String name) {


### PR DESCRIPTION
This adds fix or workaround for this [issue](https://github.com/micronaut-projects/micronaut-data/issues/2764) 
I am not sure paging count query was meant to be used this way, but user expected it and might not hurt if they need kind of this workaround.