### PR TITLE
Do not exit with an error if repository has a default implementation

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -297,19 +297,25 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
                     processMethodInfo(methodMatchContext, methodInfo);
                     return;
                 }
-                if (matchContext.isPossiblyFailing()) {
-                    matchContext.logPossibleFailures();
-                } else {
-                    String messageStart = matchContext.getUnableToImplementMessage();
-                    context.fail(messageStart + "No possible implementations found.", element);
+                if (!element.isDefault()) {
+                    if (matchContext.isPossiblyFailing()) {
+                        matchContext.logPossibleFailures();
+                    } else {
+                        String messageStart = matchContext.getUnableToImplementMessage();
+                        context.fail(messageStart + "No possible implementations found.", element);
+                    }
+                    this.failing = true;
                 }
-                this.failing = true;
             } catch (MatchFailedException e) {
-                context.fail(matchContext.getUnableToImplementMessage() + e.getMessage(), e.getElement() == null ? element : e.getElement());
-                this.failing = true;
+                if (!element.isDefault()) {
+                    context.fail(matchContext.getUnableToImplementMessage() + e.getMessage(), e.getElement() == null ? element : e.getElement());
+                    this.failing = true;
+                }
             } catch (Exception e) {
-                matchContext.fail(e.getMessage());
-                this.failing = true;
+                if (!element.isDefault()) {
+                    matchContext.fail(e.getMessage());
+                    this.failing = true;
+                }
             }
         }
     }
@@ -399,6 +405,9 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
         ClassElement runtimeInterceptor = methodInfo.getRuntimeInterceptor();
         if (runtimeInterceptor == null) {
+            if (element.isDefault()) {
+                return;
+            }
             throw new MatchFailedException("Unable to implement Repository method: " + currentRepository.getSimpleName() + "." + element.getName() + "(..). No possible runtime implementations found.", element);
         }
 

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/CrudRepositorySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/CrudRepositorySpec.groovy
@@ -80,8 +80,8 @@ import java.util.List;
 @io.micronaut.context.annotation.Executable
 interface MyInterface extends CrudRepository<Person, Long> {
 
-    List<Person> list(String name);   
-    
+    List<Person> list(String name);
+
     int count(String name);
 }
 """)
@@ -196,6 +196,33 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteIds.synthesize(DataMethod).idType() == Long
         deleteIds.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
+    }
+
+    void "test allow not implementing a default method"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyInterface' + BeanDefinitionVisitor.PROXY_SUFFIX, """
+package test;
+
+import io.micronaut.data.model.entities.Person;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.annotation.Repository;
+import java.util.List;
+
+@Repository
+@io.micronaut.context.annotation.Executable
+interface MyInterface extends CrudRepository<Person, Long> {
+
+    default List<Person> findPeopleByName(String firstName, String surname) {
+        return list(firstName + " " + surname);
+    }
+
+    List<Person> list(String name);
+
+}
+""")
+
+        expect:
+        def list = beanDefinition.getRequiredMethod("list", String.class)
     }
 
 


### PR DESCRIPTION
This is useful if a repository wants to implement and customize another interface, e.g.:

```java
interface MyRepo extends RequiredRepo, CrudRepository<MyObject, String> {

    @Override
    default getByName(String name) {
        return getById(name);
    }

    // This is to be implemented by micronaut-data instead of the above method
    getById(String id);

}
```