### PR TITLE
add explicit handling of JDBC type for  Oracle boolean type

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -199,7 +199,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
             dataSourceName,
             new ColumnNameResultSetReader(conversionService),
             new ColumnIndexResultSetReader(conversionService),
-            new JdbcQueryStatement(conversionService),
+            new JdbcQueryStatement(conversionService, jdbcConfiguration),
             dateTimeProvider,
             entityRegistry,
             beanContext,
@@ -565,7 +565,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
             preparedQuery.bindParameters(new JdbcParameterBinder(connection, callableStatement, preparedQuery));
             if (!preparedQuery.getResultArgument().isVoid()) {
                 DataType resultDataType = preparedQuery.getResultDataType();
-                int sqlType = JdbcQueryStatement.findSqlType(resultDataType);
+                int sqlType = JdbcQueryStatement.findSqlType(resultDataType, jdbcConfiguration.getDialect());
                 int outIndex = preparedQuery.getQueryBindings().size() + 1;
                 callableStatement.registerOutParameter(outIndex, sqlType);
             }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/BooleanTest.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/BooleanTest.java
@@ -1,0 +1,17 @@
+package io.micronaut.data.jdbc.oraclexe.bool;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import jakarta.persistence.Column;
+
+@MappedEntity
+public record BooleanTest(
+    @Id @GeneratedValue
+    Long id,
+    @Column(nullable = true)
+    @Nullable
+    Boolean canBeNull
+) {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/OracleBooleanTestRepository.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/OracleBooleanTestRepository.java
@@ -1,0 +1,9 @@
+package io.micronaut.data.jdbc.oraclexe.bool;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+public interface OracleBooleanTestRepository extends CrudRepository<BooleanTest, Long> {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/OracleXEBooleanTypeSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/bool/OracleXEBooleanTypeSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.data.jdbc.oraclexe.bool
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.jdbc.oraclexe.OracleTestPropertyProvider
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class OracleXEBooleanTypeSpec extends Specification implements OracleTestPropertyProvider {
+    @AutoCleanup
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(properties)
+
+    void "test persist oracle boolean type as null"() {
+        given:
+        def repository = applicationContext.getBean(OracleBooleanTestRepository)
+
+        when:
+        def result = repository.save(new BooleanTest(null, null))
+        result = repository.findById(result.id()).orElse(null)
+
+        then:
+        result != null
+        result.canBeNull() == null
+
+        when:
+        repository.update(new BooleanTest(result.id(), true))
+        result = repository.findById(result.id()).orElse(null)
+
+        then:
+        result != null
+        result.canBeNull()
+
+        when:
+        repository.update(new BooleanTest(result.id(), null))
+        result = repository.findById(result.id()).orElse(null)
+
+        then:
+        result != null
+        result.canBeNull() == null
+
+    }
+}


### PR DESCRIPTION
The JDBC driver for Oracle expects that you supply BIT as the time when using Boolean type on JDBC operations. This seems like a bug in the JDBC driver which I am unsure when will be fixed. In the meantime this is a workaround, which will have to be rolled back in the driver is ever fixed.

Fixes #1259