### PR TITLE
Initial addition of cursored pagination for SQL

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -9,4 +9,6 @@
               <!-- files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/> -->
 
     <suppress checks="MissingJavadocType" files=".*doc-examples.*" />
+    <suppress checks="FileLength" files=".*AbstractSqlLikeQueryBuilder.*" />
+
 </suppressions>

--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder.java
@@ -26,6 +26,7 @@ import io.micronaut.data.annotation.repeatable.WhereSpecifications;
 import io.micronaut.data.model.Association;
 import io.micronaut.data.model.Embedded;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.PersistentPropertyPath;
@@ -329,6 +330,9 @@ public final class CosmosSqlQueryBuilder extends SqlQueryBuilder {
     @NonNull
     @Override
     public QueryResult buildPagination(@NonNull Pageable pageable) {
+        if (pageable.getMode() != Mode.OFFSET) {
+            throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by cosmos operations");
+        }
         int size = pageable.getSize();
         if (size > 0) {
             StringBuilder builder = new StringBuilder(" ");

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
@@ -29,6 +29,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.QueryHint;
 import io.micronaut.data.jpa.annotation.EntityGraph;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.query.builder.jpa.JpaQueryBuilder;
 import io.micronaut.data.model.runtime.PagedQuery;
@@ -335,6 +336,9 @@ public abstract class AbstractHibernateOperations<S, Q, P extends Q> implements 
         String queryStr = preparedQuery.getQuery();
         Pageable pageable = preparedQuery.getPageable();
         if (pageable != Pageable.UNPAGED) {
+            if (pageable.getMode() != Mode.OFFSET) {
+                throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by hibernate operations");
+            }
             Sort sort = pageable.getSort();
             if (sort.isSorted()) {
                 queryStr += QUERY_BUILDER.buildOrderBy(queryStr, getEntity(preparedQuery.getRootEntity()), AnnotationMetadata.EMPTY_METADATA, sort,
@@ -598,6 +602,9 @@ public abstract class AbstractHibernateOperations<S, Q, P extends Q> implements 
         if (pageable == Pageable.UNPAGED) {
             // no pagination
             return;
+        }
+        if (pageable.getMode() != Mode.OFFSET) {
+            throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by hibernate operations");
         }
 
         int max = pageable.getSize();

--- a/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/repository/jpa/intercept/ReactiveFindPageSpecificationInterceptor.java
+++ b/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/repository/jpa/intercept/ReactiveFindPageSpecificationInterceptor.java
@@ -84,7 +84,7 @@ public class ReactiveFindPageSpecificationInterceptor extends AbstractSpecificat
         return operations.withSession(session -> {
             if (pageable.isUnpaged()) {
                 return Mono.fromCompletionStage(() -> session.createQuery(query).getResultList())
-                    .map(resultList -> Page.of(resultList, pageable, resultList.size()));
+                    .map(resultList -> Page.of(resultList, pageable, (long) resultList.size()));
             }
             return Mono.fromCompletionStage(() -> {
                 Stage.SelectionQuery<Object> q = session.createQuery(query);
@@ -92,6 +92,10 @@ public class ReactiveFindPageSpecificationInterceptor extends AbstractSpecificat
                 q.setMaxResults(pageable.getSize());
                 return q.getResultList();
             }).flatMap(results -> {
+                if (!pageable.requestTotal()) {
+                    return Mono.just(Page.of(results, pageable, null));
+                }
+
                 final CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
                 final Root<Object> countRoot = countQuery.from(rootEntity);
                 final Predicate countPredicate = specification != null ? specification.toPredicate(countRoot, countQuery, criteriaBuilder) : null;

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -726,7 +726,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
 
     @Override
     public <R> Page<R> findPage(@NonNull PagedQuery<R> query) {
-        throw new UnsupportedOperationException("The findPage method without an explicit query is not supported. Use findPage(PreparedQuery) instead");
+        throw new UnsupportedOperationException("The findPage method without an explicit query is not supported. Use findAll(PreparedQuery) instead");
     }
 
     @Override

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CursoredPaginationSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2
+
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Shared
+
+@MicronautTest
+@H2DBProperties
+class H2CursoredPaginationSpec extends AbstractCursoredPageSpec {
+    @Inject
+    @Shared
+    H2PersonRepository pr
+
+    @Inject
+    @Shared
+    H2BookRepository br
+
+    @Override
+    PersonRepository getPersonRepository() {
+        return pr
+    }
+
+    @Override
+    BookRepository getBookRepository() {
+        return br
+    }
+
+    @Override
+    void init() {
+        pr.deleteAll()
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlCursoredPaginationSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.mysql
 
 import groovy.transform.Memoized
 import io.micronaut.context.ApplicationContext
@@ -21,27 +21,27 @@ import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Shared
 
-@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
-class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
+class MysqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements MySQLTestPropertyProvider {
+
     @Shared @AutoCleanup ApplicationContext context
 
     @Memoized
     @Override
     PersonRepository getPersonRepository() {
-        return context.getBean(PostgresPersonRepository)
+        return context.getBean(MySqlPersonRepository)
     }
 
     @Memoized
     @Override
     BookRepository getBookRepository() {
-        return context.getBean(PostgresBookRepository)
+        return context.getBean(MySqlBookRepository)
     }
 
     @Override
     void init() {
-        context = ApplicationContext.run(getProperties())
+        context = ApplicationContext.run(properties)
     }
+
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXECursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXECursoredPaginationSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.oraclexe
+
+import groovy.transform.Memoized
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements OracleTestPropertyProvider {
+
+    @Shared @AutoCleanup ApplicationContext context
+
+    @Override
+    @Memoized
+    PersonRepository getPersonRepository() {
+        return context.getBean(OracleXEPersonRepository)
+    }
+
+    @Override
+    @Memoized
+    BookRepository getBookRepository() {
+        return context.getBean(OracleXEBookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(properties)
+    }
+
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXEPaginationSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.data.jdbc.postgres
+package io.micronaut.data.jdbc.oraclexe
 
 import groovy.transform.Memoized
 import io.micronaut.context.ApplicationContext
@@ -21,27 +21,27 @@ import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Shared
 
-@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
-class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
+class OracleXEPaginationSpec extends AbstractCursoredPageSpec implements OracleTestPropertyProvider {
+
     @Shared @AutoCleanup ApplicationContext context
 
-    @Memoized
     @Override
+    @Memoized
     PersonRepository getPersonRepository() {
-        return context.getBean(PostgresPersonRepository)
+        return context.getBean(OracleXEPersonRepository)
     }
 
-    @Memoized
     @Override
+    @Memoized
     BookRepository getBookRepository() {
-        return context.getBean(PostgresBookRepository)
+        return context.getBean(OracleXEBookRepository)
     }
 
     @Override
     void init() {
-        context = ApplicationContext.run(getProperties())
+        context = ApplicationContext.run(properties)
     }
+
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -20,8 +20,10 @@ import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 
+@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
 class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
     @Shared @AutoCleanup ApplicationContext context
 

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.postgres
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
+    @Shared @AutoCleanup ApplicationContext context
+
+    @Override
+    PersonRepository getPersonRepository() {
+        return context.getBean(PostgresPersonRepository)
+    }
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(PostgresBookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(getProperties())
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerCursoredPaginationSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.sqlserver
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class SqlServerCursoredPaginationSpec extends AbstractCursoredPageSpec implements MSSQLTestPropertyProvider {
+
+    @Shared @AutoCleanup ApplicationContext context
+
+    @Override
+    PersonRepository getPersonRepository() {
+        return context.getBean(MSSQLPersonRepository)
+    }
+
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MSBookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(properties)
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerPaginationSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.jdbc.sqlserver
 
+import groovy.transform.Memoized
 import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
@@ -26,11 +27,13 @@ class SqlServerPaginationSpec extends AbstractPageSpec implements MSSQLTestPrope
 
     @Shared @AutoCleanup ApplicationContext context
 
+    @Memoized
     @Override
     PersonRepository getPersonRepository() {
         return context.getBean(MSSQLPersonRepository)
     }
 
+    @Memoized
     @Override
     BookRepository getBookRepository() {
         return context.getBean(MSBookRepository)

--- a/data-model/src/main/java/io/micronaut/data/annotation/RepositoryConfiguration.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/RepositoryConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.annotation;
 
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Slice;
@@ -59,7 +60,8 @@ public @interface RepositoryConfiguration {
             @TypeRole(role = TypeRole.PAGEABLE, type = Pageable.class),
             @TypeRole(role = TypeRole.SORT, type = Sort.class),
             @TypeRole(role = TypeRole.SLICE, type = Slice.class),
-            @TypeRole(role = TypeRole.PAGE, type = Page.class)
+            @TypeRole(role = TypeRole.PAGE, type = Page.class),
+            @TypeRole(role = TypeRole.CURSORED_PAGE, type = CursoredPage.class)
     };
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/annotation/TypeRole.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/TypeRole.java
@@ -76,6 +76,11 @@ public @interface TypeRole {
     String PAGE = "page";
 
     /**
+     * The parameter that is used to represent a {@link io.micronaut.data.model.CursoredPage}.
+     */
+    String CURSORED_PAGE = "cursoredPage";
+
+    /**
      * The name of the role.
      * @return The role name
      */

--- a/data-model/src/main/java/io/micronaut/data/intercept/FindCursoredPageInterceptor.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/FindCursoredPageInterceptor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.intercept;
+
+/**
+ * An interceptor that handles a return type of {@link io.micronaut.data.model.CursoredPage}.
+ *
+ * @author Andriy Dmytruk
+ * @param <T> The declaring type
+ * @param <R> The return type
+ * @since 4.8.0
+ */
+public interface FindCursoredPageInterceptor<T, R> extends DataInterceptor<T, R> {
+}

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
@@ -20,41 +20,42 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.micronaut.context.annotation.DefaultImplementation;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.data.model.Pageable.Cursor;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Inspired by the Spring Data's {@code Page} and GORM's {@code PagedResultList}, this models a type that supports
- * pagination operations.
+ * Inspired by the Jakarta's {@code CursoredPage}, this models a type that supports
+ * pagination operations with cursors.
  *
- * <p>A Page is a result set associated with a particular {@link Pageable} that includes a calculation of the total
- * size of page of records.</p>
+ * <p>A CursoredPage is a result set associated with a particular {@link Pageable} that includes
+ * a calculation of the total size of page of records.</p>
  *
  * @param <T> The generic type
- * @author graemerocher
- * @since 1.0.0
+ * @author Andriy Dmytruk
+ * @since 4.8.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@TypeHint(Page.class)
-@JsonDeserialize(as = DefaultPage.class)
+@TypeHint(CursoredPage.class)
+@JsonDeserialize(as = DefaultCursoredPage.class)
 @Serdeable
-@DefaultImplementation(DefaultPage.class)
-public interface Page<T> extends Slice<T> {
+@DefaultImplementation(DefaultCursoredPage.class)
+public interface CursoredPage<T> extends Page<T> {
 
-    Page<?> EMPTY = new DefaultPage<>(Collections.emptyList(), Pageable.unpaged(), null);
+    CursoredPage<?> EMPTY = new DefaultCursoredPage<>(Collections.emptyList(), Pageable.unpaged(), Collections.emptyList(), null);
 
     /**
-     * @return Whether this {@link Page} contains the total count of the records
+     * @return Whether this {@link CursoredPage} contains the total count of the records
      * @since 4.8.0
      */
     boolean hasTotalSize();
@@ -82,10 +83,38 @@ public interface Page<T> extends Slice<T> {
 
     @Override
     default boolean hasNext() {
-        return hasTotalSize()
-            ? getOffset() + getSize() < getTotalSize()
-            : getContent().size() == getSize();
+        Pageable pageable = getPageable();
+        if (pageable.getMode() == Mode.CURSOR_NEXT) {
+            return getContent().size() == pageable.getSize();
+        } else {
+            return true;
+        }
     }
+
+    @Override
+    default boolean hasPrevious() {
+        Pageable pageable = getPageable();
+        if (pageable.getMode() == Mode.CURSOR_PREVIOUS) {
+            return getContent().size() == pageable.getSize();
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    default CursoredPageable nextPageable() {
+        Pageable pageable = getPageable();
+        Cursor cursor = getCursor(getCursors().size() - 1).orElse(pageable.cursor().orElse(null));
+        return Pageable.afterCursor(cursor, pageable.getNumber() + 1, pageable.getSize(), pageable.getSort());
+    }
+
+    @Override
+    default CursoredPageable previousPageable() {
+        Pageable pageable = getPageable();
+        Cursor cursor = getCursor(0).orElse(pageable.cursor().orElse(null));
+        return Pageable.beforeCursor(cursor, Math.max(0, pageable.getNumber() - 1), pageable.getSize(), pageable.getSort());
+    }
+
 
     /**
      * Maps the content with the given function.
@@ -95,32 +124,13 @@ public interface Page<T> extends Slice<T> {
      * @return A new slice with the mapped content
      */
     @Override
-    default @NonNull <T2> Page<T2> map(Function<T, T2> function) {
+    default @NonNull <T2> CursoredPage<T2> map(Function<T, T2> function) {
         List<T2> content = getContent().stream().map(function).collect(Collectors.toList());
-        return new DefaultPage<>(content, getPageable(), getTotalSize());
+        return new DefaultCursoredPage<>(content, getPageable(), getCursors(), getTotalSize());
     }
 
     /**
-     * Creates a page from the given content, pageable and totalSize.
-     *
-     * @param content The content
-     * @param pageable The pageable
-     * @param totalSize The total size
-     * @param <T> The generic type
-     * @return The slice
-     */
-    @ReflectiveAccess
-    static @NonNull <T> Page<T> of(
-            @JsonProperty("content") @NonNull List<T> content,
-            @JsonProperty("pageable") @NonNull Pageable pageable,
-            @JsonProperty("totalSize") @Nullable Long totalSize
-    ) {
-        return new DefaultPage<>(content, pageable, totalSize);
-    }
-
-    /**
-     * Creates a page from the given content, pageable, cursors and totalSize.
-     * This method is for JSON deserialization. Please use {@link CursoredPage#of} instead.
+     * Creates a cursored page from the given content, pageable, cursors and totalSize.
      *
      * @param content The content
      * @param pageable The pageable
@@ -130,19 +140,34 @@ public interface Page<T> extends Slice<T> {
      * @return The slice
      */
     @JsonCreator
-    @Internal
     @ReflectiveAccess
-    static @NonNull <T> Page<T> ofCursors(
+    static @NonNull <T> CursoredPage<T> of(
         @JsonProperty("content") @NonNull List<T> content,
         @JsonProperty("pageable") @NonNull Pageable pageable,
         @JsonProperty("cursors") @Nullable List<Cursor> cursors,
         @JsonProperty("totalSize") @Nullable Long totalSize
     ) {
-        if (cursors == null) {
-            return new DefaultPage<>(content, pageable, totalSize);
-        }
         return new DefaultCursoredPage<>(content, pageable, cursors, totalSize);
     }
+
+    /**
+     * Get cursor at the given position or empty if no such cursor exists.
+     * There must be a cursor for each of the data entities in the same order.
+     * To start pagination after or before a cursor create a pageable from it using the
+     * same sorting as before.
+     *
+     * @param i The index of cursor to retrieve.
+     * @return The cursor at the provided index.
+     */
+    Optional<Cursor> getCursor(int i);
+
+    /**
+     * Get all the cursors.
+     *
+     * @see #getCursor(int) getCursor(i) for more details.
+     * @return All the cursors
+     */
+    List<Cursor> getCursors();
 
     /**
      * Creates an empty page object.
@@ -150,7 +175,8 @@ public interface Page<T> extends Slice<T> {
      * @return The slice
      */
     @SuppressWarnings("unchecked")
-    static @NonNull <T2> Page<T2> empty() {
-        return (Page<T2>) EMPTY;
+    static @NonNull <T2> CursoredPage<T2> empty() {
+        return (CursoredPage<T2>) EMPTY;
     }
+
 }

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -40,7 +40,7 @@ public interface CursoredPageable extends Pageable {
      * Constant for no pagination.
      */
     CursoredPageable UNPAGED = new DefaultCursoredPageable(
-        0, null, null, false, -1, null
+        0, null, null, false, -1, Sort.UNSORTED
     );
 
     /**
@@ -114,6 +114,9 @@ public interface CursoredPageable extends Pageable {
         @JsonProperty("size") int size,
         @JsonProperty("sort") @Nullable Sort sort
     ) {
+        if (sort == null) {
+            sort = UNSORTED;
+        }
         return new DefaultCursoredPageable(0, null, null, false, size, sort);
     }
 
@@ -137,6 +140,9 @@ public interface CursoredPageable extends Pageable {
         @JsonProperty("size") int size,
         @JsonProperty("sort") @Nullable Sort sort
     ) {
+        if (sort == null) {
+            sort = UNSORTED;
+        }
         return new DefaultCursoredPageable(page, startCursor, endCursor, isBackward, size, sort);
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -75,6 +75,20 @@ public interface CursoredPageable extends Pageable {
     }
 
     /**
+     * @return Whether there is a next page
+     */
+    default boolean hasNext() {
+        return false;
+    }
+
+    /**
+     * @return Whether there is a previous page.
+     */
+    default boolean hasPrevious() {
+        return false;
+    }
+
+    /**
      * Creates a new {@link CursoredPageable} with the given sort.
      *
      * @param sort The sort

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+
+/**
+ * Models pageable data that uses a cursor.
+ *
+ * @author Andriy Dmytruk
+ * @since 4.6.1
+ */
+@Serdeable
+@Introspected
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface CursoredPageable extends Pageable {
+
+    /**
+     * Constant for no pagination.
+     */
+    CursoredPageable UNPAGED = new DefaultCursoredPageable(
+        0, null, null, false, -1, null
+    );
+
+    /**
+     * @return The cursor values corresponding to the beginning of queried data.
+     * This cursor is used for forward pagination.
+     */
+    @Nullable
+    List<Object> getStartCursor();
+
+    /**
+     * @return The cursor values corresponding to the end of queried data.
+     * This cursor is used for backward pagination.
+     */
+    @Nullable
+    List<Object> getEndCursor();
+
+    /**
+     * Whether the pageable is traversing backwards.
+     *
+     * @return Whether cursor is going in reverse direction.
+     */
+    boolean isBackward();
+
+    @Override
+    default @NonNull CursoredPageable next() {
+        throw new IllegalStateException("To get the next CursoredPageable, you must retrieve this one from a page");
+    }
+
+    @Override
+    default @NonNull CursoredPageable previous() {
+        throw new IllegalStateException("To get the next CursoredPageable, you must retrieve this one from a page");
+    }
+
+    /**
+     * Creates a new {@link CursoredPageable} with the given sort.
+     *
+     * @param sort The sort
+     * @return The pageable
+     */
+    static @NonNull CursoredPageable from(Sort sort) {
+        if (sort == null) {
+            return UNPAGED;
+        }
+        return new DefaultCursoredPageable(
+            0, null, null, false, -1, sort
+        );
+    }
+
+    /**
+     * Creates a new {@link CursoredPageable} with the given sort and page size.
+     *
+     * @param size The page size
+     * @param sort The sort
+     * @return The pageable
+     */
+    static @NonNull CursoredPageable from(
+        @JsonProperty("size") int size,
+        @JsonProperty("sort") @Nullable Sort sort
+    ) {
+        return new DefaultCursoredPageable(0, null, null, false, size, sort);
+    }
+
+    /**
+     * Creates a new {@link CursoredPageable} with the given cursor.
+     *
+     * @param page The page
+     * @param startCursor The cursor pointing to the beginning of the traversed data.
+     * @param endCursor The cursor pointing to the end the traversed data.
+     * @param isBackward Whether the cursor is for backward traversing
+     * @param size The page size
+     * @param sort The sort
+     * @return The pageable
+     */
+    @JsonCreator
+    static @NonNull CursoredPageable from(
+        @JsonProperty("number") int page,
+        @JsonProperty("startCursor") @Nullable List<Object> startCursor,
+        @JsonProperty("endCursor") @Nullable List<Object> endCursor,
+        @JsonProperty(value = "isBackward", defaultValue = "false") boolean isBackward,
+        @JsonProperty("size") int size,
+        @JsonProperty("sort") @Nullable Sort sort
+    ) {
+        return new DefaultCursoredPageable(page, startCursor, endCursor, isBackward, size, sort);
+    }
+
+    /**
+     * @return A new instance without paging data.
+     */
+    static @NonNull CursoredPageable unpaged() {
+        return UNPAGED;
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -39,7 +39,7 @@ public interface CursoredPageable extends Pageable {
      * Constant for no pagination.
      */
     CursoredPageable UNPAGED = new DefaultCursoredPageable(
-        -1, null, null, Mode.CURSOR_NEXT, 0, Sort.UNSORTED, true
+        -1, null, Mode.CURSOR_NEXT, 0, Sort.UNSORTED, true
     );
 
     /**
@@ -54,16 +54,6 @@ public interface CursoredPageable extends Pageable {
         return isBackward() ? Mode.CURSOR_PREVIOUS : Mode.CURSOR_NEXT;
     }
 
-    @Override
-    default @NonNull CursoredPageable next() {
-        throw new IllegalStateException("Cannot retrieve next page, as a currentCursor for that is not present");
-    }
-
-    @Override
-    default @NonNull CursoredPageable previous() {
-        throw new IllegalStateException("Cannot retrieve previous page, as a currentCursor for that is not present");
-    }
-
     /**
      * Creates a new {@link CursoredPageable} with the given sort.
      *
@@ -75,7 +65,7 @@ public interface CursoredPageable extends Pageable {
             return UNPAGED;
         }
         return new DefaultCursoredPageable(
-            -1, null, null, Mode.CURSOR_NEXT, 0, sort, true
+            -1, null, Mode.CURSOR_NEXT, 0, sort, true
         );
     }
 
@@ -93,7 +83,7 @@ public interface CursoredPageable extends Pageable {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, null, null, Mode.CURSOR_NEXT, 0, sort, true);
+        return new DefaultCursoredPageable(size, null, Mode.CURSOR_NEXT, 0, sort, true);
     }
 
     /**
@@ -101,7 +91,6 @@ public interface CursoredPageable extends Pageable {
      *
      * @param page The page
      * @param cursor The current currentCursor that will be used for querying data.
-     * @param nextCursor The currentCursor that could be used for querying the next page of data.
      * @param mode The pagination mode. Must be either forward or backward currentCursor pagination.
      * @param size The page size
      * @param sort The sort
@@ -111,9 +100,8 @@ public interface CursoredPageable extends Pageable {
     @Internal
     @JsonCreator
     static @NonNull CursoredPageable from(
-        @JsonProperty("page") int page,
+        @JsonProperty("number") int page,
         @Nullable Cursor cursor,
-        @Nullable Cursor nextCursor,
         Pageable.Mode mode,
         int size,
         @Nullable Sort sort,
@@ -122,7 +110,7 @@ public interface CursoredPageable extends Pageable {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, cursor, nextCursor, mode, page, sort, requestTotal);
+        return new DefaultCursoredPageable(size, cursor, mode, page, sort, requestTotal);
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -29,7 +29,7 @@ import java.util.List;
  * Models pageable data that uses a cursor.
  *
  * @author Andriy Dmytruk
- * @since 4.6.1
+ * @since 4.8.0
  */
 @Serdeable
 @Introspected

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -41,7 +41,7 @@ public interface CursoredPageable extends Pageable {
      * Constant for no pagination.
      */
     CursoredPageable UNPAGED = new DefaultCursoredPageable(
-        -1, null, null, false, 0, Sort.UNSORTED
+        -1, null, null, false, 0, Sort.UNSORTED, true
     );
 
     /**
@@ -110,7 +110,7 @@ public interface CursoredPageable extends Pageable {
             return UNPAGED;
         }
         return new DefaultCursoredPageable(
-            -1, null, null, false, 0, sort
+            -1, null, null, false, 0, sort, true
         );
     }
 
@@ -128,7 +128,7 @@ public interface CursoredPageable extends Pageable {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, null, null, false, 0, sort);
+        return new DefaultCursoredPageable(size, null, null, false, 0, sort, true);
     }
 
     /**
@@ -154,7 +154,7 @@ public interface CursoredPageable extends Pageable {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, startCursor, endCursor, isBackward, page, sort);
+        return new DefaultCursoredPageable(size, startCursor, endCursor, isBackward, page, sort, true);
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPageable.java
@@ -25,7 +25,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.serde.annotation.Serdeable;
 
 /**
- * Models pageable data that uses a currentCursor.
+ * Models a pageable request that uses a cursor.
  *
  * @author Andriy Dmytruk
  * @since 4.8.0
@@ -34,13 +34,6 @@ import io.micronaut.serde.annotation.Serdeable;
 @Introspected
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface CursoredPageable extends Pageable {
-
-    /**
-     * Constant for no pagination.
-     */
-    CursoredPageable UNPAGED = new DefaultCursoredPageable(
-        -1, null, Mode.CURSOR_NEXT, 0, Sort.UNSORTED, true
-    );
 
     /**
      * Whether the pageable is traversing backwards.
@@ -62,7 +55,7 @@ public interface CursoredPageable extends Pageable {
      */
     static @NonNull CursoredPageable from(Sort sort) {
         if (sort == null) {
-            return UNPAGED;
+            sort = Sort.UNSORTED;
         }
         return new DefaultCursoredPageable(
             -1, null, Mode.CURSOR_NEXT, 0, sort, true
@@ -111,13 +104,6 @@ public interface CursoredPageable extends Pageable {
             sort = UNSORTED;
         }
         return new DefaultCursoredPageable(size, cursor, mode, page, sort, requestTotal);
-    }
-
-    /**
-     * @return A new instance without paging data.
-     */
-    static @NonNull CursoredPageable unpaged() {
-        return UNPAGED;
     }
 
 }

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.data.model.Pageable.Cursor;
-import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.List;
@@ -35,7 +34,7 @@ import java.util.Optional;
  * @param <T> The generic type
  */
 @Serdeable
-class DefaultCursoredPage<T> extends DefaultPage<T> {
+class DefaultCursoredPage<T> extends DefaultPage<T> implements CursoredPage<T> {
 
     private final List<Cursor> cursors;
 
@@ -78,41 +77,12 @@ class DefaultCursoredPage<T> extends DefaultPage<T> {
 
     @Override
     public Optional<Cursor> getCursor(int i) {
-        return i >= cursors.size() ? Optional.empty() : Optional.of(cursors.get(i));
+        return i >= cursors.size() || i < 0 ? Optional.empty() : Optional.of(cursors.get(i));
     }
 
     @Override
-    public boolean hasNext() {
-        Pageable pageable = getPageable();
-        if (pageable.getMode() == Mode.CURSOR_NEXT) {
-            return cursors.size() == pageable.getSize();
-        } else {
-            return true;
-        }
-    }
-
-    @Override
-    public boolean hasPrevious() {
-        Pageable pageable = getPageable();
-        if (pageable.getMode() == Mode.CURSOR_PREVIOUS) {
-            return cursors.size() == pageable.getSize();
-        } else {
-            return true;
-        }
-    }
-
-    @Override
-    public Pageable nextPageable() {
-        Pageable pageable = getPageable();
-        Cursor cursor = cursors.isEmpty() ? pageable.cursor().orElse(null) : cursors.get(cursors.size() - 1);
-        return Pageable.afterCursor(cursor, pageable.getNumber() + 1, pageable.getSize(), pageable.getSort());
-    }
-
-    @Override
-    public Pageable previousPageable() {
-        Pageable pageable = getPageable();
-        Cursor cursor = cursors.isEmpty() ? pageable.cursor().orElse(null) : cursors.get(0);
-        return Pageable.beforeCursor(cursor, Math.max(0, pageable.getNumber() - 1), pageable.getSize(), pageable.getSort());
+    public List<Cursor> getCursors() {
+        return cursors;
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.data.model.Pageable.Cursor;
+import io.micronaut.data.model.Pageable.Mode;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link Page} to return when {@link CursoredPageable} is requested.
+ *
+ * @author Andriy Dmytruk
+ * @since 4.8.0
+ * @param <T> The generic type
+ */
+@Serdeable
+class DefaultCursoredPage<T> extends DefaultPage<T> {
+
+    private final List<Cursor> cursors;
+
+    /**
+     * Default constructor.
+     * @param content The content
+     * @param pageable The pageable
+     * @param totalSize The total size
+     */
+    @JsonCreator
+    @Creator
+    @ReflectiveAccess
+    DefaultCursoredPage(
+            @JsonProperty("content")
+            List<T> content,
+            @JsonProperty("pageable")
+            Pageable pageable,
+            @JsonProperty("cursors")
+            List<Cursor> cursors,
+            @JsonProperty("totalSize")
+            Long totalSize
+    ) {
+        super(content, pageable, totalSize);
+        if (content.size() != cursors.size()) {
+            throw new IllegalArgumentException("The number of cursors must match the number of content items for a page");
+        }
+        this.cursors = cursors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultCursoredPage<?> that)) {
+            return false;
+        }
+        return Objects.equals(cursors, that.cursors) && super.equals(o);
+    }
+
+    @Override
+    public Optional<Cursor> getCursor(int i) {
+        return Optional.of(cursors.get(i));
+    }
+
+    @Override
+    public boolean hasNext() {
+        Pageable pageable = getPageable();
+        if (pageable.getMode() == Mode.CURSOR_NEXT) {
+            return cursors.size() == pageable.getSize();
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        Pageable pageable = getPageable();
+        if (pageable.getMode() == Mode.CURSOR_PREVIOUS) {
+            return cursors.size() == pageable.getSize();
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public Pageable nextPageable() {
+        Pageable pageable = getPageable();
+        Cursor cursor = cursors.isEmpty() ? pageable.cursor().orElse(null) : cursors.get(cursors.size() - 1);
+        return Pageable.afterCursor(cursor, pageable.getNumber() + 1, pageable.getSize(), pageable.getSort());
+    }
+
+    @Override
+    public Pageable previousPageable() {
+        Pageable pageable = getPageable();
+        Cursor cursor = cursors.isEmpty() ? pageable.cursor().orElse(null) : cursors.get(0);
+        return Pageable.beforeCursor(cursor, Math.max(0, pageable.getNumber() - 1), pageable.getSize(), pageable.getSort());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cursors, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultPage{" +
+                "totalSize=" + getTotalSize() +
+                ",content=" + getContent() +
+                ",pageable=" + getPageable() +
+                ",cursors=" + cursors +
+                '}';
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPage.java
@@ -78,7 +78,7 @@ class DefaultCursoredPage<T> extends DefaultPage<T> {
 
     @Override
     public Optional<Cursor> getCursor(int i) {
-        return Optional.of(cursors.get(i));
+        return i >= cursors.size() ? Optional.empty() : Optional.of(cursors.get(i));
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -33,9 +32,9 @@ import java.util.Objects;
 record DefaultCursoredPageable(
     int size,
     @Nullable
-    List<Object> startCursor,
+    Cursor startCursor,
     @Nullable
-    List<Object> endCursor,
+    Cursor endCursor,
     boolean isBackward,
     int page,
     Sort sort
@@ -80,12 +79,12 @@ record DefaultCursoredPageable(
     }
 
     @Override
-    public List<Object> getStartCursor() {
+    public Cursor getStartCursor() {
         return startCursor;
     }
 
     @Override
-    public List<Object> getEndCursor() {
+    public Cursor getEndCursor() {
         return endCursor;
     }
 
@@ -98,11 +97,11 @@ record DefaultCursoredPageable(
     public CursoredPageable next() {
         if (endCursor != null) {
             return new DefaultCursoredPageable(
-                    page + 1,
+                    getSize(),
                     endCursor,
                     null,
                     false,
-                    getSize(),
+                    page + 1,
                     getSort()
             );
         }
@@ -113,11 +112,11 @@ record DefaultCursoredPageable(
     public CursoredPageable previous() {
         if (startCursor != null) {
             return new DefaultCursoredPageable(
-                    Math.max(page - 1, 0),
+                    getSize(),
                     null,
                     startCursor,
                     true,
-                    getSize(),
+                    Math.max(page - 1, 0),
                     getSort()
             );
         }

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -27,17 +27,19 @@ import java.util.Objects;
  * The default cursored pageable implementation.
  *
  * @author Andriy Dmytruk
- * @since 4.6.1
+ * @since 4.8.0
  */
 @Introspected
-final class DefaultCursoredPageable implements CursoredPageable {
-
-    private final int max;
-    private final int number;
-    private final List<Object> startCursor;
-    private final List<Object> endCursor;
-    private final boolean isBackward;
-    private final Sort sort;
+record DefaultCursoredPageable(
+    int size,
+    @Nullable
+    List<Object> startCursor,
+    @Nullable
+    List<Object> endCursor,
+    boolean isBackward,
+    int page,
+    Sort sort
+) implements CursoredPageable {
 
     /**
      * Default constructor.
@@ -52,29 +54,23 @@ final class DefaultCursoredPageable implements CursoredPageable {
      * @param sort The sorting
      */
     @Creator
-    DefaultCursoredPageable(int page, @Nullable List<Object> startCursor, @Nullable List<Object> endCursor, boolean isBackward, int size, @Nullable Sort sort) {
+    DefaultCursoredPageable {
         if (page < 0) {
             throw new IllegalArgumentException("Page index cannot be negative");
         }
         if (size == 0) {
             throw new IllegalArgumentException("Size cannot be 0");
         }
-        this.max = size;
-        this.number = page;
-        this.startCursor = startCursor;
-        this.endCursor = endCursor;
-        this.isBackward = isBackward;
-        this.sort = sort == null ? Sort.unsorted() : sort;
     }
 
     @Override
     public int getSize() {
-        return max;
+        return size;
     }
 
     @Override
     public int getNumber() {
-        return number;
+        return page;
     }
 
     @NonNull
@@ -102,7 +98,7 @@ final class DefaultCursoredPageable implements CursoredPageable {
     public CursoredPageable next() {
         if (endCursor != null) {
             return new DefaultCursoredPageable(
-                    number + 1,
+                    page + 1,
                     endCursor,
                     null,
                     false,
@@ -117,7 +113,7 @@ final class DefaultCursoredPageable implements CursoredPageable {
     public CursoredPageable previous() {
         if (startCursor != null) {
             return new DefaultCursoredPageable(
-                    Math.max(number - 1, 0),
+                    Math.max(page - 1, 0),
                     null,
                     startCursor,
                     true,
@@ -146,21 +142,22 @@ final class DefaultCursoredPageable implements CursoredPageable {
         if (!(o instanceof DefaultCursoredPageable that)) {
             return false;
         }
-        return max == that.max &&
-                Objects.equals(startCursor, that.startCursor) &&
-                Objects.equals(sort, that.sort);
+        return size == that.size
+            && Objects.equals(startCursor, that.startCursor)
+            && Objects.equals(endCursor, that.endCursor)
+            && Objects.equals(sort, that.sort);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(max, startCursor, sort);
+        return Objects.hash(size, startCursor, endCursor, sort);
     }
 
     @Override
     public String toString() {
         return "DefaultCursoredPageable{" +
-                "max=" + max +
-                ", number=" + number +
+                "size=" + size +
+                ", number=" + page +
                 ", startCursor=" + startCursor +
                 ", endCursor=" + endCursor +
                 ", sort=" + sort +

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -129,6 +129,16 @@ final class DefaultCursoredPageable implements CursoredPageable {
     }
 
     @Override
+    public boolean hasNext() {
+        return endCursor != null;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return startCursor != null;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model;
+
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The default cursored pageable implementation.
+ *
+ * @author Andriy Dmytruk
+ * @since 4.6.1
+ */
+@Introspected
+final class DefaultCursoredPageable implements CursoredPageable {
+
+    private final int max;
+    private final int number;
+    private final List<Object> startCursor;
+    private final List<Object> endCursor;
+    private final boolean isBackward;
+    private final Sort sort;
+
+    /**
+     * Default constructor.
+     *
+     * @param page The page.
+     * @param startCursor The cursor that is pointing to the start of the data.
+     *                    This cursor will be used for forward pagination.
+     * @param endCursor The cursor that is pointing to the end of the data.
+     *                  This cursor will be used for backward pagination
+     * @param isBackward Whether user requested for backward pagination.
+     * @param size The size of a page
+     * @param sort The sorting
+     */
+    @Creator
+    DefaultCursoredPageable(int page, @Nullable List<Object> startCursor, @Nullable List<Object> endCursor, boolean isBackward, int size, @Nullable Sort sort) {
+        if (page < 0) {
+            throw new IllegalArgumentException("Page index cannot be negative");
+        }
+        if (size == 0) {
+            throw new IllegalArgumentException("Size cannot be 0");
+        }
+        this.max = size;
+        this.number = page;
+        this.startCursor = startCursor;
+        this.endCursor = endCursor;
+        this.isBackward = isBackward;
+        this.sort = sort == null ? Sort.unsorted() : sort;
+    }
+
+    @Override
+    public int getSize() {
+        return max;
+    }
+
+    @Override
+    public int getNumber() {
+        return number;
+    }
+
+    @NonNull
+    @Override
+    public Sort getSort() {
+        return sort;
+    }
+
+    @Override
+    public List<Object> getStartCursor() {
+        return startCursor;
+    }
+
+    @Override
+    public List<Object> getEndCursor() {
+        return endCursor;
+    }
+
+    @Override
+    public boolean isBackward() {
+        return isBackward;
+    }
+
+    @Override
+    public CursoredPageable next() {
+        if (endCursor != null) {
+            return new DefaultCursoredPageable(
+                    number + 1,
+                    endCursor,
+                    null,
+                    false,
+                    getSize(),
+                    getSort()
+            );
+        }
+        return CursoredPageable.super.next();
+    }
+
+    @Override
+    public CursoredPageable previous() {
+        if (startCursor != null) {
+            return new DefaultCursoredPageable(
+                    Math.max(number - 1, 0),
+                    null,
+                    startCursor,
+                    true,
+                    getSize(),
+                    getSort()
+            );
+        }
+        return CursoredPageable.super.previous();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultCursoredPageable that)) {
+            return false;
+        }
+        return max == that.max &&
+                Objects.equals(startCursor, that.startCursor) &&
+                Objects.equals(sort, that.sort);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(max, startCursor, sort);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultCursoredPageable{" +
+                "max=" + max +
+                ", number=" + number +
+                ", startCursor=" + startCursor +
+                ", endCursor=" + endCursor +
+                ", sort=" + sort +
+                '}';
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -37,7 +37,8 @@ record DefaultCursoredPageable(
     Cursor endCursor,
     boolean isBackward,
     int page,
-    Sort sort
+    Sort sort,
+    boolean requestTotal
 ) implements CursoredPageable {
 
     /**
@@ -97,12 +98,13 @@ record DefaultCursoredPageable(
     public CursoredPageable next() {
         if (endCursor != null) {
             return new DefaultCursoredPageable(
-                    getSize(),
+                    size,
                     endCursor,
                     null,
                     false,
                     page + 1,
-                    getSort()
+                    sort,
+                    requestTotal
             );
         }
         return CursoredPageable.super.next();
@@ -112,15 +114,32 @@ record DefaultCursoredPageable(
     public CursoredPageable previous() {
         if (startCursor != null) {
             return new DefaultCursoredPageable(
-                    getSize(),
+                    size,
                     null,
                     startCursor,
                     true,
                     Math.max(page - 1, 0),
-                    getSort()
+                    sort,
+                    requestTotal
             );
         }
         return CursoredPageable.super.previous();
+    }
+
+    @Override
+    public Pageable withTotal() {
+        if (requestTotal) {
+            return this;
+        }
+        return new DefaultCursoredPageable(size, startCursor, endCursor, isBackward, page, sort, true);
+    }
+
+    @Override
+    public Pageable withoutTotal() {
+        if (!requestTotal) {
+            return this;
+        }
+        return new DefaultCursoredPageable(size, startCursor, endCursor, isBackward, page, sort, true);
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -117,12 +117,12 @@ record DefaultCursoredPageable(
 
     @Override
     public CursoredPageable previous() {
-        Cursor requiredCursor = mode == Mode.CURSOR_NEXT ? nextCursor : currentCursor;
+        Cursor requiredCursor = mode == Mode.CURSOR_PREVIOUS ? nextCursor : currentCursor;
         if (requiredCursor != null) {
             return new DefaultCursoredPageable(
                     size,
-                    null,
                     requiredCursor,
+                    null,
                     Mode.CURSOR_PREVIOUS,
                     Math.max(page - 1, 0),
                     sort,

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultCursoredPageable.java
@@ -25,6 +25,16 @@ import java.util.Objects;
 /**
  * The default cursored pageable implementation.
  *
+ * @param page The page.
+ * @param startCursor The cursor that is pointing to the start of the data.
+ *                    This cursor will be used for forward pagination.
+ * @param endCursor The cursor that is pointing to the end of the data.
+ *                  This cursor will be used for backward pagination
+ * @param isBackward Whether user requested for backward pagination.
+ * @param size The size of a page
+ * @param sort The sorting
+ * @param requestTotal Whether to request the total count
+ *
  * @author Andriy Dmytruk
  * @since 4.8.0
  */
@@ -43,15 +53,6 @@ record DefaultCursoredPageable(
 
     /**
      * Default constructor.
-     *
-     * @param page The page.
-     * @param startCursor The cursor that is pointing to the start of the data.
-     *                    This cursor will be used for forward pagination.
-     * @param endCursor The cursor that is pointing to the end of the data.
-     *                  This cursor will be used for backward pagination
-     * @param isBackward Whether user requested for backward pagination.
-     * @param size The size of a page
-     * @param sort The sorting
      */
     @Creator
     DefaultCursoredPageable {

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
@@ -56,7 +56,6 @@ class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
         this.totalSize = totalSize;
     }
 
-
     @Override
     public boolean hasTotalSize() {
         return totalSize != null;

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 @Serdeable
 class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
 
-    private final long totalSize;
+    private final Long totalSize;
 
     /**
      * Default constructor.
@@ -51,14 +51,24 @@ class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
             @JsonProperty("pageable")
             Pageable pageable,
             @JsonProperty("totalSize")
-            long totalSize) {
+            Long totalSize) {
         super(content, pageable);
         this.totalSize = totalSize;
+    }
+
+
+    @Override
+    public boolean hasTotalSize() {
+        return totalSize != null;
     }
 
     @Override
     @ReflectiveAccess
     public long getTotalSize() {
+        if (totalSize == null) {
+            throw new IllegalStateException("Page does not contain total count. " +
+                "It is likely that the Pageable needs to be modified to request this information.");
+        }
         return totalSize;
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
@@ -45,7 +45,7 @@ final class DefaultPageable implements Pageable {
      * @param sort The sort
      */
     @Creator
-    DefaultPageable(int page, int size, @Nullable Sort sort, Boolean requestTotal) {
+    DefaultPageable(int page, int size, @Nullable Sort sort, @Nullable Boolean requestTotal) {
         if (page < 0) {
             throw new IllegalArgumentException("Page index cannot be negative");
         }
@@ -55,7 +55,7 @@ final class DefaultPageable implements Pageable {
         this.max = size;
         this.number = page;
         this.sort = sort == null ? Sort.unsorted() : sort;
-        this.requestTotal = requestTotal == null ? true : requestTotal;
+        this.requestTotal = requestTotal == null || requestTotal;
     }
 
     @Override
@@ -66,11 +66,6 @@ final class DefaultPageable implements Pageable {
     @Override
     public int getNumber() {
         return number;
-    }
-
-    @Override
-    public Mode getMode() {
-        return Mode.OFFSET;
     }
 
     @Override
@@ -127,7 +122,7 @@ final class DefaultPageable implements Pageable {
     public String toString() {
         return "DefaultPageable{" +
                 "max=" + max +
-                ", number=" + number +
+                ", page=" + number +
                 ", sort=" + sort +
                 '}';
     }

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 @Introspected
 final class DefaultPageable implements Pageable {
 
+    private final boolean requestTotal;
     private final int max;
     private final int number;
     private final Sort sort;
@@ -44,7 +45,7 @@ final class DefaultPageable implements Pageable {
      * @param sort The sort
      */
     @Creator
-    DefaultPageable(int page, int size, @Nullable Sort sort) {
+    DefaultPageable(int page, int size, @Nullable Sort sort, Boolean requestTotal) {
         if (page < 0) {
             throw new IllegalArgumentException("Page index cannot be negative");
         }
@@ -54,6 +55,7 @@ final class DefaultPageable implements Pageable {
         this.max = size;
         this.number = page;
         this.sort = sort == null ? Sort.unsorted() : sort;
+        this.requestTotal = requestTotal == null ? true : requestTotal;
     }
 
     @Override
@@ -76,10 +78,31 @@ final class DefaultPageable implements Pageable {
         return Optional.empty();
     }
 
+    @Override
+    public boolean requestTotal() {
+        return requestTotal;
+    }
+
     @NonNull
     @Override
     public Sort getSort() {
         return sort;
+    }
+
+    @Override
+    public Pageable withTotal() {
+        if (this.requestTotal) {
+            return this;
+        }
+        return new DefaultPageable(number, max, sort, true);
+    }
+
+    @Override
+    public Pageable withoutTotal() {
+        if (!this.requestTotal) {
+            return this;
+        }
+        return new DefaultPageable(number, max, sort, false);
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Introspected;
 
 import io.micronaut.core.annotation.NonNull;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * The default pageable implementation.
@@ -63,6 +64,16 @@ final class DefaultPageable implements Pageable {
     @Override
     public int getNumber() {
         return number;
+    }
+
+    @Override
+    public Mode getMode() {
+        return Mode.OFFSET;
+    }
+
+    @Override
+    public Optional<Cursor> cursor() {
+        return Optional.empty();
     }
 
     @NonNull

--- a/data-model/src/main/java/io/micronaut/data/model/DefaultSort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultSort.java
@@ -97,6 +97,11 @@ final class DefaultSort implements Sort {
     }
 
     @Override
+    public String toString() {
+        return "DefaultSort{orderBy=" + orderBy + '}';
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.serde.annotation.Serdeable;
@@ -48,14 +49,28 @@ import java.util.stream.Collectors;
 @DefaultImplementation(DefaultPage.class)
 public interface Page<T> extends Slice<T> {
 
-    Page<?> EMPTY = new DefaultPage<>(Collections.emptyList(), Pageable.unpaged(), 0);
+    Page<?> EMPTY = new DefaultPage<>(Collections.emptyList(), Pageable.unpaged(), null);
 
     /**
+     * @return Whether this {@link Page} contains the total count of the records
+     * @since 4.8.0
+     */
+    boolean hasTotalSize();
+
+    /**
+     * Get the total count of all the records that can be given by this query.
+     * The method may produce a {@link IllegalStateException} if the {@link Pageable} request
+     * did not ask for total size.
+     *
      * @return The total size of the all records.
      */
     long getTotalSize();
 
     /**
+     * Get the total count of pages that can be given by this query.
+     * The method may produce a {@link IllegalStateException} if the {@link Pageable} request
+     * did not ask for total size.
+     *
      * @return The total number of pages
      */
     default int getTotalPages() {
@@ -115,7 +130,7 @@ public interface Page<T> extends Slice<T> {
     static @NonNull <T> Page<T> of(
             @JsonProperty("content") @NonNull List<T> content,
             @JsonProperty("pageable") @NonNull Pageable pageable,
-            @JsonProperty("totalSize") long totalSize) {
+            @JsonProperty("totalSize") @Nullable Long totalSize) {
         return new DefaultPage<>(content, pageable, totalSize);
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.annotation.TypeHint;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.Collections;
@@ -36,7 +37,7 @@ import java.util.stream.Collectors;
  * pagination operations.
  *
  * <p>A Page is a result set associated with a particular {@link Pageable} that includes a calculation of the total
- * size of number of records.</p>
+ * size of page of records.</p>
  *
  * @param <T> The generic type
  * @author graemerocher
@@ -71,7 +72,7 @@ public interface Page<T> extends Slice<T> {
      * The method may produce a {@link IllegalStateException} if the {@link Pageable} request
      * did not ask for total size.
      *
-     * @return The total number of pages
+     * @return The total page of pages
      */
     default int getTotalPages() {
         int size = getSize();
@@ -85,12 +86,12 @@ public interface Page<T> extends Slice<T> {
      * @return Whether there exist a next page.
      */
     default boolean hasNext() {
-        if (getPageable() instanceof CursoredPageable cursoredPageable) {
-            return cursoredPageable.hasNext();
+        if (getPageable().getMode() == Mode.OFFSET) {
+            return hasTotalSize()
+                ? getOffset() + getSize() < getTotalSize()
+                : getContent().size() == getSize();
         }
-        return hasTotalSize()
-            ? getOffset() + getSize() < getTotalSize()
-            : getContent().size() == getSize();
+        return getPageable().hasNext();
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -64,6 +64,32 @@ public interface Page<T> extends Slice<T> {
     }
 
     /**
+     * Determines whether there is a next page.
+     *
+     * @since 4.8.0
+     * @return Whether there exist a next page.
+     */
+    default boolean hasNext() {
+        if (getPageable() instanceof CursoredPageable cursoredPageable) {
+            return cursoredPageable.hasNext();
+        }
+        return getOffset() + getSize() < getTotalSize();
+    }
+
+    /**
+     * Determines whether there is a previous page.
+     *
+     * @since 4.8.0
+     * @return Whether there exist a previous page.
+     */
+    default boolean hasPrevious() {
+        if (getPageable() instanceof CursoredPageable cursoredPageable) {
+            return cursoredPageable.hasPrevious();
+        }
+        return getOffset() > 0;
+    }
+
+    /**
      * Maps the content with the given function.
      *
      * @param function The function to apply to each element in the content.

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -88,7 +88,9 @@ public interface Page<T> extends Slice<T> {
         if (getPageable() instanceof CursoredPageable cursoredPageable) {
             return cursoredPageable.hasNext();
         }
-        return getOffset() + getSize() < getTotalSize();
+        return hasTotalSize()
+            ? getOffset() + getSize() < getTotalSize()
+            : getContent().size() == getSize();
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -101,10 +101,10 @@ public interface Page<T> extends Slice<T> {
      * @return Whether there exist a previous page.
      */
     default boolean hasPrevious() {
-        if (getPageable() instanceof CursoredPageable cursoredPageable) {
-            return cursoredPageable.hasPrevious();
+        if (getPageable().getMode() == Mode.OFFSET) {
+            return getOffset() > 0;
         }
-        return getOffset() > 0;
+        return getPageable().hasPrevious();
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -43,27 +43,7 @@ public interface Pageable extends Sort {
     /**
      * Constant for no pagination.
      */
-    Pageable UNPAGED = new Pageable() {
-        @Override
-        public int getNumber() {
-            return 0;
-        }
-
-        @Override
-        public Mode getMode() {
-            return Mode.OFFSET;
-        }
-
-        @Override
-        public Optional<Cursor> cursor() {
-            return Optional.empty();
-        }
-
-        @Override
-        public int getSize() {
-            return -1;
-        }
-    };
+    Pageable UNPAGED = new DefaultPageable(0, -1, Sort.UNSORTED, true);
 
     /**
      * @return The page number.
@@ -88,6 +68,16 @@ public interface Pageable extends Sort {
      * @return The cursor
      */
     Optional<Cursor> cursor();
+
+    /**
+     * Whether the returned page should contain information about total items that
+     * can be produced by this query. If the value is false, {@link Page#getTotalSize()} and
+     * {@link Page#getTotalPages()} methods will fail. By default, pageable will have this value
+     * set to true.
+     *
+     * @return Whether total size information is required.
+     */
+    boolean requestTotal();
 
     /**
      * Offset in the requested collection. Defaults to zero.
@@ -189,12 +179,26 @@ public interface Pageable extends Sort {
     }
 
     /**
+     * Specify that the {@link Page} response should have information about total size.
+     * @see #requestTotal() requestTotal() for more details.
+     * @return A pageable instance that will request the total size.
+     */
+    Pageable withTotal();
+
+    /**
+     * Specify that the {@link Page} response should not have information about total size.
+     * @see #requestTotal() requestTotal() for more details.
+     * @return A pageable instance that won't request the total size.
+     */
+    Pageable withoutTotal();
+
+    /**
      * Creates a new {@link Pageable} at the given offset with a default size of 10.
      * @param page The page
      * @return The pageable
      */
     static @NonNull Pageable from(int page) {
-        return new DefaultPageable(page, 10, null);
+        return new DefaultPageable(page, 10, null, true);
     }
 
     /**
@@ -204,7 +208,7 @@ public interface Pageable extends Sort {
      * @return The pageable
      */
     static @NonNull Pageable from(int page, int size) {
-        return new DefaultPageable(page, size, null);
+        return new DefaultPageable(page, size, null, true);
     }
 
     /**
@@ -219,7 +223,7 @@ public interface Pageable extends Sort {
             @JsonProperty("number") int page,
             @JsonProperty("size") int size,
             @JsonProperty("sort") @Nullable Sort sort) {
-        return new DefaultPageable(page, size, sort);
+        return new DefaultPageable(page, size, sort, true);
     }
 
     /**
@@ -231,7 +235,7 @@ public interface Pageable extends Sort {
         if (sort == null) {
             return UNPAGED;
         } else {
-            return new DefaultPageable(0, -1, sort);
+            return new DefaultPageable(0, -1, sort, true);
         }
     }
 
@@ -255,7 +259,7 @@ public interface Pageable extends Sort {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, cursor, null, false, page, sort);
+        return new DefaultCursoredPageable(size, cursor, null, false, page, sort, true);
     }
 
     /**
@@ -271,7 +275,7 @@ public interface Pageable extends Sort {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, null, cursor, true, page, sort);
+        return new DefaultCursoredPageable(size, null, cursor, true, page, sort, true);
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -282,7 +282,8 @@ public interface Pageable extends Sort {
      * @param page The page
      * @param size The size
      * @param mode The pagination mode
-     * @param cursor The currentCursor
+     * @param cursor The current cursor
+     * @param nextCursor The next cursor
      * @param sort The sort
      * @param requestTotal Whether to query total count
      * @return The pageable

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -314,7 +314,7 @@ public interface Pageable extends Sort {
      * @param sort The sorting
      * @return The pageable
      */
-    static @NonNull Pageable afterCursor(@NonNull Cursor cursor, int page, int size, @Nullable Sort sort) {
+    static @NonNull CursoredPageable afterCursor(@NonNull Cursor cursor, int page, int size, @Nullable Sort sort) {
         if (sort == null) {
             sort = UNSORTED;
         }
@@ -331,7 +331,7 @@ public interface Pageable extends Sort {
      * @param sort The sorting
      * @return The pageable
      */
-    static @NonNull Pageable beforeCursor(@NonNull Cursor cursor, int page, int size, @Nullable Sort sort) {
+    static @NonNull CursoredPageable beforeCursor(@NonNull Cursor cursor, int page, int size, @Nullable Sort sort) {
         if (sort == null) {
             sort = UNSORTED;
         }

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -92,28 +92,6 @@ public interface Pageable extends Sort {
     }
 
     /**
-     * Return whether there is a next page as best this pageable could determine.
-     * Use {@link Page} for more reliable results.
-     *
-     * @since 4.8.0
-     * @return Whether there is a next page
-     */
-    default boolean hasNext() {
-        return false;
-    }
-
-    /**
-     * Return whether there is a previous page as best this pageable could determine.
-     * Use {@link Page} for more reliable results.
-     *
-     * @since 4.8.0
-     * @return Whether there is a previous page.
-     */
-    default boolean hasPrevious() {
-        return false;
-    }
-
-    /**
      * Offset in the requested collection. Defaults to zero.
      * @return offset in the requested collection
      */
@@ -283,7 +261,6 @@ public interface Pageable extends Sort {
      * @param size The size
      * @param mode The pagination mode
      * @param cursor The current cursor
-     * @param nextCursor The next cursor
      * @param sort The sort
      * @param requestTotal Whether to query total count
      * @return The pageable
@@ -295,7 +272,6 @@ public interface Pageable extends Sort {
             @JsonProperty("size") int size,
             @JsonProperty("mode") @Nullable Mode mode,
             @JsonProperty("cursor") @Nullable Cursor cursor,
-            @JsonProperty("nextCursor") @Nullable Cursor nextCursor,
             @JsonProperty("sort") @Nullable Sort sort,
             @JsonProperty(value = "requestTotal", defaultValue = "true") boolean requestTotal
     ) {
@@ -303,8 +279,7 @@ public interface Pageable extends Sort {
             return new DefaultPageable(page, size, sort, requestTotal);
         } else {
             return new DefaultCursoredPageable(
-                size, cursor, nextCursor, mode, page,
-                sort == null ? UNSORTED : sort, requestTotal
+                size, cursor, mode, page, sort == null ? UNSORTED : sort, requestTotal
             );
         }
     }
@@ -343,7 +318,7 @@ public interface Pageable extends Sort {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, cursor, null, Mode.CURSOR_NEXT, page, sort, true);
+        return new DefaultCursoredPageable(size, cursor, Mode.CURSOR_NEXT, page, sort, true);
     }
 
     /**
@@ -360,7 +335,7 @@ public interface Pageable extends Sort {
         if (sort == null) {
             sort = UNSORTED;
         }
-        return new DefaultCursoredPageable(size, cursor, null, Mode.CURSOR_PREVIOUS, page, sort, true);
+        return new DefaultCursoredPageable(size, cursor, Mode.CURSOR_PREVIOUS, page, sort, true);
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Slice.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Slice.java
@@ -57,13 +57,38 @@ public interface Slice<T> extends Iterable<T> {
     @NonNull Pageable getPageable();
 
     /**
-     * @return The page page
+     * @return The page number
      */
     default int getPageNumber() {
         return getPageable().getNumber();
     }
 
     /**
+     * Determine whether there is a next page.
+     *
+     * @since 4.8.0
+     * @return Whether there exist a next page.
+     */
+    default boolean hasNext() {
+        return getContent().size() == getSize();
+    }
+
+    /**
+     * Determine whether there is a previous page.
+     *
+     * @since 4.8.0
+     * @return Whether there exist a previous page.
+     */
+    default boolean hasPrevious() {
+        return getOffset() > 0;
+    }
+
+    /**
+     * Create a pageable for querying the next page of data.
+     * <p>A pageable may be created even if the end of data was reached to accommodate for
+     * cases when new data might be added to the repository. Use {@link #hasNext()} to
+     * verify if you have reached the end.</p>
+     *
      * @return The next pageable
      */
     default @NonNull Pageable nextPageable() {
@@ -71,7 +96,12 @@ public interface Slice<T> extends Iterable<T> {
     }
 
     /**
-     * @return The previous pageable.
+     * Create a pageable for querying the previous page of data.
+     * <p>A pageable may be created even if the end of data was reached to accommodate for
+     * cases when new data might be added to the repository. Use {@link #hasPrevious()} to
+     * verify if you have reached the end.</p>
+     *
+     * @return The previous pageable
      */
     default @NonNull Pageable previousPageable() {
         return getPageable().previous();

--- a/data-model/src/main/java/io/micronaut/data/model/Slice.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Slice.java
@@ -57,7 +57,7 @@ public interface Slice<T> extends Iterable<T> {
     @NonNull Pageable getPageable();
 
     /**
-     * @return The page number
+     * @return The page page
      */
     default int getPageNumber() {
         return getPageable().getNumber();
@@ -107,7 +107,7 @@ public interface Slice<T> extends Iterable<T> {
     }
 
     /**
-     * @return The number of elements
+     * @return The page of elements
      */
     default int getNumberOfElements() {
         return getContent().size();

--- a/data-model/src/main/java/io/micronaut/data/model/Sort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Sort.java
@@ -179,6 +179,19 @@ public interface Sort {
         }
 
         /**
+         * Create an order that is reversed to current.
+         *
+         * @return A new instance of order that is reversed.
+         */
+        public Order reverse() {
+            return new Order(
+                property,
+                direction == Direction.ASC ? Direction.DESC : Direction.ASC,
+                ignoreCase
+            );
+        }
+
+        /**
          * Creates a new order for the given property in descending order.
          *
          * @param property The property

--- a/data-model/src/main/java/io/micronaut/data/model/Sort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Sort.java
@@ -235,6 +235,14 @@ public interface Sort {
         }
 
         @Override
+        public String toString() {
+            return "SORT{" + property
+                + (direction == Direction.ASC ? ", ASC" : ", DESC")
+                + (ignoreCase ? ", ignoreCase" : "")
+                + ")";
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -1999,6 +1999,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
      * For example, property name might be encoded as {@code `person_.name`} using
      * its path and table's alias.
      *
+     * @param propertyName The name of the property
      * @param query The query
      * @param entity The root entity
      * @param annotationMetadata The annotation metadata

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/AbstractSqlLikeQueryBuilder.java
@@ -1969,8 +1969,6 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
         StringBuilder buff = new StringBuilder(ORDER_BY_CLAUSE);
         Iterator<Sort.Order> i = orders.iterator();
 
-        String jsonEntityColumn = getJsonEntityColumn(annotationMetadata);
-
         while (i.hasNext()) {
             Sort.Order order = i.next();
             String property = order.getProperty();
@@ -1978,59 +1976,9 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             if (ignoreCase) {
                 buff.append("LOWER(");
             }
-            if (nativeQuery) {
-                buff.append(property);
-            } else {
-                PersistentPropertyPath path = entity.getPropertyPath(property);
-                if (path == null) {
-                    throw new IllegalArgumentException("Cannot sort on non-existent property path: " + property);
-                }
-                List<Association> associations = new ArrayList<>(path.getAssociations());
-                int assocCount = associations.size();
-                // If last association is embedded, it does not need to be joined to the alias since it will be in the destination table
-                // JPA/Hibernate is special case and in that case we leave association for specific handling below
-                if (assocCount > 0 && computePropertyPaths() && associations.get(assocCount - 1) instanceof Embedded) {
-                    associations.remove(assocCount - 1);
-                }
-                if (associations.isEmpty()) {
-                    buff.append(getAliasName(entity));
-                } else {
-                    StringJoiner joiner = new StringJoiner(".");
-                    for (Association association : associations) {
-                        joiner.add(association.getName());
-                    }
-                    String joinAlias = getAliasName(new JoinPath(joiner.toString(), associations.toArray(new Association[0]), Join.Type.DEFAULT, null));
-                    if (!computePropertyPaths()) {
-                        if (!query.contains(" " + joinAlias + " ") && !query.endsWith(" " + joinAlias)) {
-                            // Special hack case for JPA, Hibernate can join the relation with cross join automatically when referenced by the property path
-                            // This probably should be removed in the future major version
-                            buff.append(getAliasName(entity)).append(DOT);
-                            StringJoiner pathJoiner = new StringJoiner(".");
-                            for (Association association : associations) {
-                                pathJoiner.add(association.getName());
-                            }
-                            buff.append(pathJoiner);
-                        } else {
-                            buff.append(joinAlias);
-                        }
-                    } else {
-                        buff.append(joinAlias);
-                    }
-                }
-                buff.append(DOT);
-
-                if (jsonEntityColumn != null) {
-                    buff.append(jsonEntityColumn).append(DOT);
-                }
-
-                if (!computePropertyPaths() || jsonEntityColumn != null) {
-                    buff.append(path.getProperty().getName());
-                } else {
-                    buff.append(getColumnName(path.getProperty()));
-                }
-                if (ignoreCase) {
-                    buff.append(")");
-                }
+            buff.append(buildPropertyByName(property, query, entity, annotationMetadata, nativeQuery));
+            if (ignoreCase) {
+                buff.append(")");
             }
             buff.append(SPACE).append(order.getDirection());
             if (i.hasNext()) {
@@ -2044,6 +1992,80 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             Collections.emptyList(),
             Collections.emptyMap()
         );
+    }
+
+    /**
+     * Encode the given property retrieval into a query instance.
+     * For example, property name might be encoded as {@code `person_.name`} using
+     * its path and table's alias.
+     *
+     * @param query The query
+     * @param entity The root entity
+     * @param annotationMetadata The annotation metadata
+     * @param nativeQuery Whether the query is native query, in which case the property name will be supplied by the user and not verified
+     * @return The encoded query
+     */
+    public String buildPropertyByName(
+            @NonNull String propertyName, @NonNull String query,
+            @NonNull PersistentEntity entity, @NonNull AnnotationMetadata annotationMetadata,
+            boolean nativeQuery
+    ) {
+        if (nativeQuery) {
+            return propertyName;
+        }
+
+        PersistentPropertyPath path = entity.getPropertyPath(propertyName);
+        if (path == null) {
+            throw new IllegalArgumentException("Cannot sort on non-existent property path: " + propertyName);
+        }
+        List<Association> associations = new ArrayList<>(path.getAssociations());
+        int assocCount = associations.size();
+        // If last association is embedded, it does not need to be joined to the alias since it will be in the destination table
+        // JPA/Hibernate is special case and in that case we leave association for specific handling below
+        if (assocCount > 0 && computePropertyPaths() && associations.get(assocCount - 1) instanceof Embedded) {
+            associations.remove(assocCount - 1);
+        }
+
+        StringBuilder buff = new StringBuilder();
+        if (associations.isEmpty()) {
+            buff.append(getAliasName(entity));
+        } else {
+            StringJoiner joiner = new StringJoiner(".");
+            for (Association association : associations) {
+                joiner.add(association.getName());
+            }
+            String joinAlias = getAliasName(new JoinPath(joiner.toString(), associations.toArray(new Association[0]), Join.Type.DEFAULT, null));
+            if (!computePropertyPaths()) {
+                if (!query.contains(" " + joinAlias + " ") && !query.endsWith(" " + joinAlias)) {
+                    // Special hack case for JPA, Hibernate can join the relation with cross join automatically when referenced by the property path
+                    // This probably should be removed in the future major version
+                    buff.append(getAliasName(entity)).append(DOT);
+                    StringJoiner pathJoiner = new StringJoiner(".");
+                    for (Association association : associations) {
+                        pathJoiner.add(association.getName());
+                    }
+                    buff.append(pathJoiner);
+                } else {
+                    buff.append(joinAlias);
+                }
+            } else {
+                buff.append(joinAlias);
+            }
+        }
+        buff.append(DOT);
+
+        String jsonEntityColumn = getJsonEntityColumn(annotationMetadata);
+        if (jsonEntityColumn != null) {
+            buff.append(jsonEntityColumn).append(DOT);
+        }
+
+        if (!computePropertyPaths() || jsonEntityColumn != null) {
+            buff.append(path.getProperty().getName());
+        } else {
+            buff.append(getColumnName(path.getProperty()));
+        }
+
+        return buff.toString();
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -39,7 +39,6 @@ import io.micronaut.data.annotation.sql.JoinColumns;
 import io.micronaut.data.annotation.sql.SqlMembers;
 import io.micronaut.data.exceptions.MappingException;
 import io.micronaut.data.model.Association;
-import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Embedded;
 import io.micronaut.data.model.JsonDataType;

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -44,6 +44,7 @@ import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Embedded;
 import io.micronaut.data.model.JsonDataType;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.PersistentPropertyPath;
@@ -1214,7 +1215,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
         int size = pageable.getSize();
         if (size > 0) {
             StringBuilder builder = new StringBuilder(" ");
-            long from = pageable instanceof CursoredPageable ? 0 : pageable.getOffset();
+            long from = pageable.getMode() == Mode.OFFSET ? pageable.getOffset() : 0;
             switch (dialect) {
                 case H2:
                 case MYSQL:

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -39,6 +39,7 @@ import io.micronaut.data.annotation.sql.JoinColumns;
 import io.micronaut.data.annotation.sql.SqlMembers;
 import io.micronaut.data.exceptions.MappingException;
 import io.micronaut.data.model.Association;
+import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Embedded;
 import io.micronaut.data.model.JsonDataType;
@@ -1213,7 +1214,7 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder implements Quer
         int size = pageable.getSize();
         if (size > 0) {
             StringBuilder builder = new StringBuilder(" ");
-            long from = pageable.getOffset();
+            long from = pageable instanceof CursoredPageable ? 0 : pageable.getOffset();
             switch (dialect) {
                 case H2:
                 case MYSQL:

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/PagedQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/PagedQuery.java
@@ -53,4 +53,5 @@ public interface PagedQuery<E> extends Named, AnnotationMetadataProvider {
     default Map<String, Object> getQueryHints() {
         return Collections.emptyMap();
     }
+
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/QueryParameterBinding.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/QueryParameterBinding.java
@@ -150,7 +150,7 @@ public interface QueryParameterBinding {
 
     /**
      * @return Is expression value
-     * @see 4.5.0
+     * @since 4.5.0
      */
     default boolean isExpression() {
         return false;

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -122,9 +122,38 @@ class PageSpec extends Specification {
         def json = serdeMapper.writeValueAsString(pageable)
 
         then:
-        json == '{"size":3,"number":0,"sort":{}}'
+        json == '{"size":3,"number":0,"mode":"OFFSET","sort":{}}'
         def deserializedPageable = serdeMapper.readValue(json, Pageable)
         deserializedPageable == pageable
+    }
+
+    void "test serialization and deserialization of a cursored pageable - serde"() {
+        def pageable = Pageable.afterCursor(
+                Pageable.Cursor.of("value1", 2),
+                0, 3, Sort.UNSORTED
+        )
+
+        when:
+        def json = serdeMapper.writeValueAsString(pageable)
+
+        then:
+        json == '{"size":3,"cursor":{"elements":["value1",2]},"mode":"CURSOR_NEXT","number":0,"sort":{},"requestTotal":true}'
+        def deserializedPageable = serdeMapper.readValue(json, Pageable)
+        deserializedPageable == pageable
+        def deserializedPageable2 = serdeMapper.readValue(json, CursoredPageable)
+        deserializedPageable2 == pageable
+    }
+
+    void "test sort serialization"() {
+        def sort = Sort.of(Sort.Order.asc("property"))
+
+        when:
+        def json = serdeMapper.writeValueAsString(sort)
+
+        then:
+        json == '{"orderBy":[{"ignoreCase":false,"direction":"ASC","property":"property","ascending":true}]}'
+        def deserializedSort = serdeMapper.readValue(json, Sort)
+        deserializedSort == sort
     }
 
     @EqualsAndHashCode

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -122,7 +122,7 @@ class PageSpec extends Specification {
         def json = serdeMapper.writeValueAsString(pageable)
 
         then:
-        json == '{"size":3,"number":0,"mode":"OFFSET","sort":{}}'
+        json == '{"size":3,"number":0,"sort":{},"mode":"OFFSET"}'
         def deserializedPageable = serdeMapper.readValue(json, Pageable)
         deserializedPageable == pageable
     }

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -125,6 +125,13 @@ class PageSpec extends Specification {
         json == '{"size":3,"number":0,"sort":{},"mode":"OFFSET"}'
         def deserializedPageable = serdeMapper.readValue(json, Pageable)
         deserializedPageable == pageable
+
+        when:
+        def json2 = '{"size":3,"number":0,"sort":{}}'
+        def deserializedPageable2 = serdeMapper.readValue(json2, Pageable)
+
+        then:
+        deserializedPageable2 == pageable
     }
 
     void "test serialization and deserialization of a cursored pageable - serde"() {

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoPreparedQuery.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoPreparedQuery.java
@@ -18,6 +18,7 @@ package io.micronaut.data.mongodb.operations;
 import com.mongodb.client.model.Sorts;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.model.runtime.RuntimePersistentEntity;
@@ -81,6 +82,9 @@ final class DefaultMongoPreparedQuery<E, R> extends DefaultBindableParametersPre
         MongoFind find = mongoStoredQuery.getFind(defaultPreparedQuery.getContext());
         Pageable pageable = defaultPreparedQuery.getPageable();
         if (pageable != Pageable.UNPAGED) {
+            if (pageable.getMode() != Mode.OFFSET) {
+                throw new UnsupportedOperationException("Mode " + pageable.getMode() + " is not supported by the MongoDB implementation");
+            }
             MongoFindOptions findOptions = find.getOptions();
             MongoFindOptions options = findOptions == null ? new MongoFindOptions() : new MongoFindOptions(findOptions);
             options.limit(pageable.getSize()).skip((int) pageable.getOffset());
@@ -113,6 +117,9 @@ final class DefaultMongoPreparedQuery<E, R> extends DefaultBindableParametersPre
     private int applyPageable(Pageable pageable, List<Bson> pipeline) {
         int limit = 0;
         if (pageable != Pageable.UNPAGED) {
+            if (pageable.getMode() != Mode.OFFSET) {
+                throw new UnsupportedOperationException("Mode " + pageable.getMode() + " is not supported by the MongoDB implementation");
+            }
             int skip = (int) pageable.getOffset();
             limit = pageable.getSize();
             Sort pageableSort = pageable.getSort();

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/DefaultMongoRepositoryOperations.java
@@ -46,6 +46,7 @@ import io.micronaut.data.connection.ConnectionDefinition;
 import io.micronaut.data.exceptions.DataAccessException;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.runtime.AttributeConverterRegistry;
@@ -316,6 +317,9 @@ final class DefaultMongoRepositoryOperations extends AbstractMongoRepositoryOper
                                                  MongoPreparedQuery<T, R> preparedQuery,
                                                  boolean stream) {
         Pageable pageable = preparedQuery.getPageable();
+        if (pageable.getMode() != Mode.OFFSET) {
+            throw new UnsupportedOperationException("Mode " + pageable.getMode() + " is not supported by the MongoDB implementation");
+        }
         int limit = pageable == Pageable.UNPAGED ? -1 : pageable.getSize();
         Class<T> type = preparedQuery.getRootEntity();
         Class<R> resultType = preparedQuery.getResultType();
@@ -334,6 +338,9 @@ final class DefaultMongoRepositoryOperations extends AbstractMongoRepositoryOper
                                                MongoPreparedQuery<T, R> preparedQuery,
                                                boolean stream) {
         Pageable pageable = preparedQuery.getPageable();
+        if (pageable.getMode() != Mode.OFFSET) {
+            throw new UnsupportedOperationException("Mode " + pageable.getMode() + " is not supported by the MongoDB implementation");
+        }
         int limit = pageable == Pageable.UNPAGED ? -1 : pageable.getSize();
         Class<T> type = preparedQuery.getRootEntity();
         Class<R> resultType = preparedQuery.getResultType();

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -38,6 +38,7 @@ import io.micronaut.data.annotation.TypeRole;
 import io.micronaut.data.annotation.sql.Procedure;
 import io.micronaut.data.intercept.annotation.DataMethod;
 import io.micronaut.data.intercept.annotation.DataMethodQueryParameter;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.JsonDataType;
 import io.micronaut.data.model.Page;
@@ -121,6 +122,7 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
     public RepositoryTypeElementVisitor() {
         typeRoles.put(Pageable.class.getName(), TypeRole.PAGEABLE);
         typeRoles.put(Sort.class.getName(), TypeRole.SORT);
+        typeRoles.put(CursoredPage.class.getName(), TypeRole.CURSORED_PAGE);
         typeRoles.put(Page.class.getName(), TypeRole.PAGE);
         typeRoles.put(Slice.class.getName(), TypeRole.SLICE);
     }
@@ -347,7 +349,10 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
                         .orElse(null)));
 
                 ClassElement genericReturnType = methodMatchContext.getReturnType();
-                if (methodMatchContext.isTypeInRole(genericReturnType, TypeRole.PAGE) || element.isPresent(Query.class, "countQuery")) {
+                if (methodMatchContext.isTypeInRole(genericReturnType, TypeRole.PAGE)
+                        || methodMatchContext.isTypeInRole(genericReturnType, TypeRole.CURSORED_PAGE)
+                        || element.isPresent(Query.class, "countQuery")
+                ) {
                     QueryResult countQueryResult = methodInfo.getCountQueryResult();
                     if (countQueryResult == null) {
                         throw new MatchFailedException("Query returns a Page and does not specify a 'countQuery' member.", element);

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/FindersUtils.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/FindersUtils.java
@@ -32,6 +32,7 @@ import io.micronaut.data.intercept.DeleteReturningOneInterceptor;
 import io.micronaut.data.intercept.ExistsByInterceptor;
 import io.micronaut.data.intercept.FindAllInterceptor;
 import io.micronaut.data.intercept.FindByIdInterceptor;
+import io.micronaut.data.intercept.FindCursoredPageInterceptor;
 import io.micronaut.data.intercept.FindOneInterceptor;
 import io.micronaut.data.intercept.FindOptionalInterceptor;
 import io.micronaut.data.intercept.FindPageInterceptor;
@@ -361,7 +362,9 @@ public interface FindersUtils {
                 return new FindersUtils.InterceptorMatch(findInterceptorDef.returnType(), findInterceptorDef.interceptor(), false);
             }
         }
-        if (isPage(matchContext, returnType)) {
+        if (isCursoredPage(matchContext, returnType)) {
+            return typeAndInterceptorEntry(matchContext, firstTypeArgument, FindCursoredPageInterceptor.class);
+        } else if (isPage(matchContext, returnType)) {
             return typeAndInterceptorEntry(matchContext, firstTypeArgument, FindPageInterceptor.class);
         } else if (isSlice(matchContext, returnType)) {
             return typeAndInterceptorEntry(matchContext, firstTypeArgument, FindSliceInterceptor.class);
@@ -572,6 +575,14 @@ public interface FindersUtils {
         return isContainer(type, Publisher.class)
             || TypeUtils.isReactiveType(type)
             && (type.getTypeArguments().isEmpty() || isContainer(type, type.getName())); // Validate container argument
+    }
+
+    static boolean isCursoredPage(MethodMatchContext methodMatchContext, ClassElement typeArgument) {
+        boolean matches = methodMatchContext.isTypeInRole(typeArgument, TypeRole.CURSORED_PAGE);
+        if (matches && !methodMatchContext.hasParameterInRole(TypeRole.PAGEABLE)) {
+            methodMatchContext.fail("Method must accept an argument that is a Pageable");
+        }
+        return matches;
     }
 
     static boolean isPage(MethodMatchContext methodMatchContext, ClassElement typeArgument) {

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
@@ -192,7 +192,9 @@ public class QueryCriteriaMethodMatch extends AbstractCriteriaMethodMatch {
             genericReturnType = genericReturnType.getFirstTypeArgument().orElse(matchContext.getRootEntity().getType());
         }
         QueryResult countQueryResult = null;
-        if (matchContext.isTypeInRole(genericReturnType, TypeRole.PAGE)) {
+        if (matchContext.isTypeInRole(genericReturnType, TypeRole.PAGE)
+            || matchContext.isTypeInRole(genericReturnType, TypeRole.CURSORED_PAGE)
+        ) {
 //                SourcePersistentEntityCriteriaQuery<Object> count = cb.createQuery();
 //                count.select(cb.count(query.getRoots().iterator().next()));
 //                CommonAbstractCriteria countQueryCriteria = defineQuery(matchContext, matchContext.getRootEntity(), cb);

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2CursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2CursoredPaginationSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.h2
+
+import groovy.transform.Memoized
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.*
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import io.micronaut.data.tck.tests.AbstractRepositorySpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class H2CursoredPaginationSpec extends AbstractCursoredPageSpec implements H2TestPropertyProvider {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context
+
+    @Memoized
+    @Override
+    PersonRepository getPersonRepository() {
+        return context.getBean(H2PersonRepository)
+    }
+
+    @Memoized
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(H2BookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(properties)
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlCursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlCursoredPaginationSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mysql
+
+import groovy.transform.Memoized
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class MySqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements MySqlTestPropertyProvider {
+
+    @Shared @AutoCleanup ApplicationContext context
+
+    @Memoized
+    @Override
+    PersonRepository getPersonRepository() {
+        return context.getBean(MySqlPersonRepository)
+    }
+
+    @Memoized
+    @Override
+    BookRepository getBookRepository() {
+        return context.getBean(MySqlBookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(properties)
+    }
+
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXECursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXECursoredPaginationSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.oraclexe
+
+import groovy.transform.Memoized
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.tck.repositories.BookRepository
+import io.micronaut.data.tck.repositories.PersonRepository
+import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements OracleXETestPropertyProvider {
+
+    @Shared @AutoCleanup ApplicationContext context
+
+    @Override
+    @Memoized
+    PersonRepository getPersonRepository() {
+        return context.getBean(OracleXEPersonRepository)
+    }
+
+    @Override
+    @Memoized
+    BookRepository getBookRepository() {
+        return context.getBean(OracleXEBookRepository)
+    }
+
+    @Override
+    void init() {
+        context = ApplicationContext.run(properties)
+    }
+
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Ignore
 import spock.lang.Shared
 
-@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
+//@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
 class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
     @Shared @AutoCleanup ApplicationContext context
 

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.data.jdbc.oraclexe
+package io.micronaut.data.r2dbc.postgres
 
 import groovy.transform.Memoized
 import io.micronaut.context.ApplicationContext
@@ -21,27 +21,27 @@ import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 
-class OracleXEPaginationSpec extends AbstractCursoredPageSpec implements OracleTestPropertyProvider {
-
+@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
+class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
     @Shared @AutoCleanup ApplicationContext context
 
-    @Override
     @Memoized
+    @Override
     PersonRepository getPersonRepository() {
-        return context.getBean(OracleXEPersonRepository)
+        return context.getBean(PostgresPersonRepository)
     }
 
-    @Override
     @Memoized
+    @Override
     BookRepository getBookRepository() {
-        return context.getBean(OracleXEBookRepository)
+        return context.getBean(PostgresBookRepository)
     }
 
     @Override
     void init() {
-        context = ApplicationContext.run(properties)
+        context = ApplicationContext.run(getProperties())
     }
-
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultAbstractFindPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultAbstractFindPageInterceptor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.intercept;
+
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.intercept.RepositoryMethodKey;
+import io.micronaut.data.model.CursoredPage;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Cursor;
+import io.micronaut.data.model.Pageable.Mode;
+import io.micronaut.data.model.runtime.PreparedQuery;
+import io.micronaut.data.operations.RepositoryOperations;
+import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
+
+import java.util.List;
+
+/**
+ * An abstract base implementation of query interceptor for page interceptors
+ * implementing {@link io.micronaut.data.intercept.FindPageInterceptor} or
+ * {@link io.micronaut.data.intercept.FindCursoredPageInterceptor}.
+ *
+ * @param <T> The declaring type
+ * @param <R> The paged type.
+ * @author graemerocher
+ * @since 4.8.0
+ */
+public abstract class DefaultAbstractFindPageInterceptor<T, R> extends AbstractQueryInterceptor<T, R> {
+
+    /**
+     * Default constructor.
+     * @param datastore The operations
+     */
+    protected DefaultAbstractFindPageInterceptor(@NonNull RepositoryOperations datastore) {
+        super(datastore);
+    }
+
+    @Override
+    public R intercept(RepositoryMethodKey methodKey, MethodInvocationContext<T, R> context) {
+        Class<R> returnType = context.getReturnType().getType();
+        if (context.hasAnnotation(Query.class)) {
+            PreparedQuery<?, ?> preparedQuery = prepareQuery(methodKey, context);
+
+            Iterable<?> iterable = operations.findAll(preparedQuery);
+            List<R> results = (List<R>) CollectionUtils.iterableToList(iterable);
+            Pageable pageable = getPageable(context);
+            Long totalCount = null;
+            if (pageable.requestTotal()) {
+                PreparedQuery<?, Number> countQuery = prepareCountQuery(methodKey, context);
+                Number n = operations.findOne(countQuery);
+                totalCount = n != null ? n.longValue() : null;
+            }
+
+            Page<R> page;
+            if (pageable.getMode() == Mode.OFFSET) {
+                page = Page.of(results, pageable, totalCount);
+            } else if (preparedQuery instanceof DefaultSqlPreparedQuery<?, ?> sqlPreparedQuery) {
+                List<Cursor> cursors = sqlPreparedQuery.createCursors((List<Object>) results, pageable);
+                page = CursoredPage.of(results, pageable, cursors, totalCount);
+            } else {
+                throw new UnsupportedOperationException("Only offset pageable mode is supported by this query implementation");
+            }
+            if (returnType.isInstance(page)) {
+                return (R) page;
+            } else {
+                return operations.getConversionService().convert(page, returnType)
+                        .orElseThrow(() -> new IllegalStateException("Unsupported page interface type " + returnType));
+            }
+        } else {
+
+            Page page = operations.findPage(getPagedQuery(context));
+            if (returnType.isInstance(page)) {
+                return (R) page;
+            } else {
+                return operations.getConversionService().convert(page, returnType)
+                        .orElseThrow(() -> new IllegalStateException("Unsupported page interface type " + returnType));
+            }
+        }
+    }
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindCursoredPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindCursoredPageInterceptor.java
@@ -31,7 +31,7 @@ import io.micronaut.data.operations.RepositoryOperations;
  * @author Andriy Dmytruk
  * @since 4.8.0
  */
-public class DefaultFindCursoredPageInterceptor<T, R> extends DefaultFindPageInterceptor<T, R> implements FindCursoredPageInterceptor<T, R> {
+public class DefaultFindCursoredPageInterceptor<T, R> extends DefaultAbstractFindPageInterceptor<T, R> implements FindCursoredPageInterceptor<T, R> {
 
     /**
      * Default constructor.

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindCursoredPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindCursoredPageInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.intercept;
+
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.intercept.FindCursoredPageInterceptor;
+import io.micronaut.data.model.CursoredPageable;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
+import io.micronaut.data.operations.RepositoryOperations;
+
+/**
+ * Default implementation of {@link FindCursoredPageInterceptor}.
+ *
+ * @param <T> The declaring type
+ * @param <R> The paged type.
+ * @author Andriy Dmytruk
+ * @since 4.8.0
+ */
+public class DefaultFindCursoredPageInterceptor<T, R> extends DefaultFindPageInterceptor<T, R> implements FindCursoredPageInterceptor<T, R> {
+
+    /**
+     * Default constructor.
+     *
+     * @param datastore The operations
+     */
+    protected DefaultFindCursoredPageInterceptor(@NonNull RepositoryOperations datastore) {
+        super(datastore);
+    }
+
+    @Override
+    protected Pageable getPageable(MethodInvocationContext<?, ?> context) {
+        Pageable pageable = super.getPageable(context);
+        if (pageable.getMode() == Mode.OFFSET) {
+            if (pageable.getNumber() == 0) {
+                pageable = CursoredPageable.from(pageable.getSize(), pageable.getSort());
+            } else {
+                throw new IllegalArgumentException("Pageable with offset mode provided, but method must return a cursored page");
+            }
+        }
+        return pageable;
+    }
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
@@ -21,10 +21,14 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.FindPageInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
+import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
+import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -56,7 +60,13 @@ public class DefaultFindPageInterceptor<T, R> extends AbstractQueryInterceptor<T
             List<R> resultList = (List<R>) CollectionUtils.iterableToList(iterable);
             Number n = operations.findOne(countQuery);
             Long result = n != null ? n.longValue() : 0;
-            Page<R> page = Page.of(resultList, getPageable(context), result);
+
+            Pageable pageable = getPageable(context);
+            if (preparedQuery instanceof DefaultSqlPreparedQuery sqlPreparedQuery) {
+                pageable = sqlPreparedQuery.updatePageable(resultList, pageable, result);
+            }
+
+            Page<R> page = Page.of(resultList, pageable, result);
             if (returnType.isInstance(page)) {
                 return (R) page;
             } else {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
@@ -21,6 +21,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.FindPageInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Pageable.Cursor;
@@ -70,9 +71,9 @@ public class DefaultFindPageInterceptor<T, R> extends AbstractQueryInterceptor<T
                 page = Page.of(results, pageable, totalCount);
             } else if (preparedQuery instanceof DefaultSqlPreparedQuery<?, ?> sqlPreparedQuery) {
                 List<Cursor> cursors = sqlPreparedQuery.createCursors((List<Object>) results, pageable);
-                page = Page.ofCursors(results, pageable, cursors, totalCount);
+                page = CursoredPage.of(results, pageable, cursors, totalCount);
             } else {
-                throw new UnsupportedOperationException("Only offest pageable mode is supported by this query implementation");
+                throw new UnsupportedOperationException("Only offset pageable mode is supported by this query implementation");
             }
             if (returnType.isInstance(page)) {
                 return (R) page;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindPageInterceptor.java
@@ -21,14 +21,12 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.FindPageInterceptor;
 import io.micronaut.data.intercept.RepositoryMethodKey;
-import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 
-import java.util.Collections;
 import java.util.List;
 
 /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindSliceInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DefaultFindSliceInterceptor.java
@@ -27,7 +27,6 @@ import io.micronaut.data.model.Slice;
 import io.micronaut.data.model.runtime.PagedQuery;
 import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
-import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 
 import java.util.List;
 
@@ -57,9 +56,6 @@ public class DefaultFindSliceInterceptor<T, R> extends AbstractQueryInterceptor<
             Pageable pageable = preparedQuery.getPageable();
             Iterable<R> iterable = (Iterable<R>) operations.findAll(preparedQuery);
             List<R> results = CollectionUtils.iterableToList(iterable);
-            if (preparedQuery instanceof DefaultSqlPreparedQuery sqlPreparedQuery) {
-                pageable = sqlPreparedQuery.updatePageable(results, pageable);
-            }
             Slice<R> slice = Slice.of(results, pageable);
             return convertOrFail(context, slice);
         } else {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -167,7 +167,7 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
         Set<JoinPath> methodJoinPaths = getMethodJoinPaths(methodKey, context);
         Long count;
         if (criteriaRepositoryOperations != null) {
-            count =  criteriaRepositoryOperations.findOne(buildCountQuery(context));
+            count = criteriaRepositoryOperations.findOne(buildCountQuery(context));
         } else {
             count = operations.findOne(preparedQueryForCriteria(methodKey, context, Type.COUNT, methodJoinPaths));
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -64,7 +64,6 @@ import jakarta.persistence.criteria.Root;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -27,6 +27,7 @@ import io.micronaut.data.annotation.RepositoryConfiguration;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.model.AssociationUtils;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityFrom;
 import io.micronaut.data.model.jpa.criteria.impl.QueryResultPersistentEntityCriteriaQuery;
@@ -141,6 +142,9 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
             CriteriaQuery<Object> query = buildQuery(context, type, methodJoinPaths);
             Pageable pageable = getPageable(context);
             if (pageable != null) {
+                if (pageable.getMode() != Mode.OFFSET) {
+                    throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported with specifications");
+                }
                 return criteriaRepositoryOperations.findAll(query, (int) pageable.getOffset(), pageable.getSize());
             }
             return criteriaRepositoryOperations.findAll(query);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/FindPageSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/FindPageSpecificationInterceptor.java
@@ -56,14 +56,17 @@ public class FindPageSpecificationInterceptor extends AbstractSpecificationInter
             return Page.of(
                 resultList,
                 pageable,
-                resultList.size()
+                (long) resultList.size()
             );
         }
 
         Iterable<?> iterable = findAll(methodKey, context, Type.FIND_PAGE);
         List<Object> resultList = (List<Object>) CollectionUtils.iterableToList(iterable);
 
-        Long count = count(methodKey, context);
+        Long count = null;
+        if (pageable.requestTotal()) {
+            count = count(methodKey, context);
+        }
 
         Page page = Page.of(resultList, getPageable(context), count);
         Class<Object> rt = context.getReturnType().getType();

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/FindPageAsyncSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/FindPageAsyncSpecificationInterceptor.java
@@ -25,7 +25,6 @@ import io.micronaut.data.operations.RepositoryOperations;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 /**
  * Runtime implementation of {@code CompletableFuture<Page> find(Specification, Pageable)}.

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/FindPageAsyncSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/async/FindPageAsyncSpecificationInterceptor.java
@@ -24,6 +24,8 @@ import io.micronaut.data.model.Pageable;
 import io.micronaut.data.operations.RepositoryOperations;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Runtime implementation of {@code CompletableFuture<Page> find(Specification, Pageable)}.
@@ -57,11 +59,14 @@ public class FindPageAsyncSpecificationInterceptor extends AbstractAsyncSpecific
         if (pageable.isUnpaged()) {
             return findAllAsync(methodKey, context, Type.FIND_PAGE).thenApply(iterable -> {
                 List<?> resultList = CollectionUtils.iterableToList(iterable);
-                return Page.of(resultList, pageable, resultList.size());
+                return Page.of(resultList, pageable, (long) resultList.size());
             });
         }
-        return findAllAsync(methodKey, context, Type.FIND_PAGE).thenCompose(iterable -> countAsync(methodKey, context)
-            .thenApply(count -> Page.of(CollectionUtils.iterableToList(iterable), pageable, count.longValue())));
+        return findAllAsync(methodKey, context, Type.FIND_PAGE).thenCompose(iterable ->
+            pageable.requestTotal()
+                ? countAsync(methodKey, context).thenApply(count -> Page.of(CollectionUtils.iterableToList(iterable), pageable, count.longValue()))
+                : CompletableFuture.completedFuture(Page.of(CollectionUtils.iterableToList(iterable), pageable, null))
+        );
 
     }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.data.exceptions.DataAccessException;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.query.JoinPath;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.operations.reactive.ReactiveCapableRepository;
@@ -76,6 +77,9 @@ public abstract class AbstractReactiveSpecificationInterceptor<T, R> extends Abs
             CriteriaQuery<Object> criteriaQuery = buildQuery(context, type, methodJoinPaths);
             Pageable pageable = getPageable(context);
             if (pageable != null) {
+                if (pageable.getMode() != Mode.OFFSET) {
+                    throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by hibernate operations");
+                }
                 return reactiveCriteriaOperations.findAll(criteriaQuery, (int) pageable.getOffset(), pageable.getSize());
             }
             return reactiveCriteriaOperations.findAll(criteriaQuery);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -46,6 +46,7 @@ import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -46,7 +46,6 @@ import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -309,10 +309,9 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
      *
      * @param results The scanning results
      * @param pageable The pageable sent by user
-     * @param totalSize The total count
      * @return The updated pageable
      */
-    public Pageable updatePageable(List<Object> results, Pageable pageable, long totalSize) {
+    public Pageable updatePageable(List<Object> results, Pageable pageable) {
         if (pageable instanceof CursoredPageable cursored) {
             if (cursored.isBackward()) {
                 Collections.reverse(results);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -22,6 +22,7 @@ import io.micronaut.data.exceptions.DataAccessException;
 import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Pageable.Cursor;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.Sort.Order;
@@ -245,7 +246,7 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
      * @return The additional query part
      */
     @NonNull
-    private String buildCursorPagination(@Nullable List<Object> cursor, @NonNull Sort sort) {
+    private String buildCursorPagination(@Nullable Pageable.Cursor cursor, @NonNull Sort sort) {
         List<Sort.Order> orders = sort.getOrderBy();
         cursorProperties = new ArrayList<>(orders.size());
         for (Order order: orders) {
@@ -317,21 +318,21 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
                 Collections.reverse(results);
             }
 
-            List<Object> startCursor = null;
-            List<Object> endCursor = null;
+            Cursor startCursor = null;
+            Cursor endCursor = null;
             if (!results.isEmpty()) {
                 if (!cursored.isBackward() || results.size() == cursored.getSize()) {
                     E firstValue = (E) results.get(0);
-                    startCursor = new ArrayList<>(cursorProperties.size());
+                    startCursor = Cursor.of(new ArrayList<>(cursorProperties.size()));
                     for (RuntimePersistentProperty<E> property : cursorProperties) {
-                        startCursor.add(property.getProperty().get(firstValue));
+                        startCursor.elements().add(property.getProperty().get(firstValue));
                     }
                 }
                 if (cursored.isBackward() || results.size() == cursored.getSize()) {
                     E lastValue = (E) results.get(results.size() - 1);
-                    endCursor = new ArrayList<>(cursorProperties.size());
+                    endCursor = Cursor.of(new ArrayList<>(cursorProperties.size()));
                     for (RuntimePersistentProperty<E> property : cursorProperties) {
-                        endCursor.add(property.getProperty().get(lastValue));
+                        endCursor.elements().add(property.getProperty().get(lastValue));
                     }
                 }
             } else {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -251,8 +251,9 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
         for (Order order: orders) {
             cursorProperties.add(getPersistentEntity().getPropertyByName(order.getProperty()));
         }
-        if (cursor == null)
+        if (cursor == null) {
             return "";
+        }
         if (orders.size() != cursor.size()) {
             throw new IllegalArgumentException("The cursor must match the sorting size");
         }
@@ -310,6 +311,7 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
      *
      * @param results The scanning results
      * @param pageable The pageable sent by user
+     * @param totalSize The total count
      * @return The updated pageable
      */
     public Pageable updatePageable(List<Object> results, Pageable pageable, long totalSize) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -261,6 +261,8 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
         } else {
             builder.append("WHERE (");
         }
+        String positionalParameter = getQueryBuilder().positionalParameterFormat();
+        int paramIndex = storedQuery.getQueryBindings().size() + 1;
         for (int i = 0; i < orders.size(); ++i) {
             builder.append("(");
             for (int j = 0; j <= i; ++j) {
@@ -272,7 +274,7 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
                     builder.append(i == j ? " < " : " = ");
                 }
                 cursorQueryBindings.add(cursorBindings.get(j));
-                builder.append("?");
+                builder.append(String.format(positionalParameter, paramIndex++));
                 if (i != j) {
                     builder.append(" AND ");
                 }
@@ -293,7 +295,9 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
      * @param results The scanning results
      * @param pageable The pageable sent by user
      * @return The updated pageable
+     * @since 4.8.0
      */
+    @Internal
     public List<Cursor> createCursors(List<Object> results, Pageable pageable) {
         if (pageable.getMode() != Mode.CURSOR_NEXT && pageable.getMode() != Mode.CURSOR_PREVIOUS) {
             return null;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -41,6 +41,7 @@ import io.micronaut.data.runtime.query.internal.DelegateStoredQuery;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -172,7 +173,13 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
                 // Create a sort for the cursored pagination. The sort must produce a unique
                 // sorting on the rows. Therefore, we make sure id is present in it.
                 List<Order> orders = new ArrayList<>(sort.getOrderBy());
-                for (PersistentProperty idProperty: persistentEntity.getIdentityProperties()) {
+                List<RuntimePersistentProperty<E>> idProperties;
+                if (persistentEntity.getIdentity() != null) {
+                    idProperties = List.of(persistentEntity.getIdentity());
+                } else {
+                    idProperties = Arrays.stream(persistentEntity.getCompositeIdentity()).toList();
+                }
+                for (PersistentProperty idProperty: idProperties) {
                     String name = idProperty.getName();
                     if (orders.stream().noneMatch(o -> o.getProperty().equals(name))) {
                         orders.add(Order.asc(name));

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -26,7 +26,6 @@ import io.micronaut.data.model.Pageable.Cursor;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.Sort.Order;
-import io.micronaut.data.model.Sort.Order.Direction;
 import io.micronaut.data.model.query.builder.AbstractSqlLikeQueryBuilder;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder;
@@ -42,7 +41,6 @@ import io.micronaut.data.runtime.query.internal.DelegateStoredQuery;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/data-spring/src/main/java/io/micronaut/data/spring/runtime/PageableDelegate.java
+++ b/data-spring/src/main/java/io/micronaut/data/spring/runtime/PageableDelegate.java
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Sort;
 
+import java.util.Optional;
+
 /**
  * Supports representing a Spring Pageable as a Micronaut {@link Pageable}.
  *
@@ -50,6 +52,21 @@ class PageableDelegate implements Pageable {
     }
 
     @Override
+    public Mode getMode() {
+        return Mode.OFFSET;
+    }
+
+    @Override
+    public Optional<Cursor> cursor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean requestTotal() {
+        return true;
+    }
+
+    @Override
     public long getOffset() {
         return target.getOffset();
     }
@@ -58,5 +75,15 @@ class PageableDelegate implements Pageable {
     @Override
     public Sort getSort() {
         return new SortDelegate(target.getSort());
+    }
+
+    @Override
+    public Pageable withTotal() {
+        return this;
+    }
+
+    @Override
+    public Pageable withoutTotal() {
+        throw new IllegalStateException("Disabling requesting total is not supported for current Pageable");
     }
 }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -110,7 +110,6 @@ abstract class AbstractCursoredPageSpec extends Specification {
 
     void "test pageable list with row removal"() {
         when: "10 people are paged"
-        CursoredPageable.from(10)
         def pageable = CursoredPageable.from(10, sorting)
         Page<Person> page = personRepository.findAll(pageable)
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -75,6 +75,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[1].name == name2
         page.totalSize == 780
         page.totalPages == 78
+        page.getCursor(0).isPresent()
+        page.getCursor(9).isPresent()
         page.hasNext()
 
         when: "The next page is selected"
@@ -145,6 +147,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name == elem1
         page.content.size() == 8
+        page.getCursor(7).isPresent()
+        page.getCursor(8).isEmpty()
         !page.hasPrevious()
         page.hasNext()
 
@@ -202,6 +206,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name == elem1
         page.content[1].name == elem2
+        page.getCursor(1).isPresent()
+        page.getCursor(2).isEmpty()
         page.content.size() == 2
         !page.hasPrevious()
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.data.tck.tests
 
 import io.micronaut.data.model.CursoredPageable
 import io.micronaut.data.model.Page
+import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.entities.Person
@@ -115,8 +116,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
 
     void "test pageable list with row removal"() {
         when: "10 people are paged"
-        def pageable = CursoredPageable.from(10, sorting)
-        Page<Person> page = personRepository.findAll(pageable)
+        def pageable = Pageable.from(0, 10, sorting) // The first pageable can be non-cursored
+        Page<Person> page = personRepository.retrieve(pageable) // The retrieve method explicitly returns CursoredPage
 
         then: "The data is correct"
         page.content.size() == 10
@@ -127,7 +128,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         when: "The next page is selected after deletion"
         personRepository.delete(page.content[1])
         personRepository.delete(page.content[9])
-        page = personRepository.findAll(page.nextPageable())
+        page = personRepository.retrieve(page.nextPageable())
 
         then: "it is correct"
         page.offset == 10
@@ -140,7 +141,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
-        page = personRepository.findAll(pageable)
+        page = personRepository.retrieve(pageable)
 
         then: "it is correct"
         page.offset == 0
@@ -163,7 +164,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
     void "test pageable list with row addition"() {
         when: "10 people are paged"
         def pageable = CursoredPageable.from(10, sorting)
-        Page<Person> page = personRepository.findAll(pageable)
+        Page<Person> page = personRepository.retrieve(pageable)
 
         then: "The data is correct"
         page.content.size() == 10
@@ -176,7 +177,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
                 new Person(name: "AAAAA00"), new Person(name: "AAAAA01"),
                 new Person(name: "ZZZZZ08"), new Person(name: "ZZZZZ07")
         ])
-        page = personRepository.findAll(page.nextPageable())
+        page = personRepository.retrieve(page.nextPageable())
 
         then: "it is correct"
         page.offset == 10
@@ -189,7 +190,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
-        page = personRepository.findAll(pageable)
+        page = personRepository.retrieve(pageable)
 
         then: "it is correct"
         page.offset == 0
@@ -199,7 +200,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.hasPrevious()
 
         when: "The second previous page is selected"
-        page = personRepository.findAll(page.previousPageable())
+        page = personRepository.retrieve(page.previousPageable())
 
         then:
         page.offset == 0

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -75,8 +75,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[1].name == name2
         page.totalSize == 780
         page.totalPages == 78
-        page.nextPageable().startCursor != null
-        page.previousPageable().endCursor != null
+        page.hasNext()
 
         when: "The next page is selected"
         page = personRepository.findAll(page.nextPageable())
@@ -87,6 +86,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[0].name == name10
         page.content[9].name == name19
         page.content.size() == 10
+        page.hasNext()
+        page.hasPrevious()
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
@@ -97,6 +98,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name == name1
         page.content.size() == 10
+        page.hasNext()
+        page.hasPrevious()
 
         where:
         sorting                                                      | name1     | name2     | name10    | name19
@@ -117,6 +120,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content.size() == 10
         page.content[0].name == elem1
         page.content[1].name == elem2
+        page.hasNext()
 
         when: "The next page is selected after deletion"
         personRepository.delete(page.content[1])
@@ -129,6 +133,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[0].name == elem10
         page.content[9].name == elem19
         page.content.size() == 10
+        page.hasNext()
+        page.hasPrevious()
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
@@ -139,6 +145,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name == elem1
         page.content.size() == 8
+        !page.hasPrevious()
+        page.hasNext()
 
         where:
         sorting                          | elem1     | elem2     | elem10    | elem19
@@ -157,6 +165,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content.size() == 10
         page.content[0].name == elem1
         page.content[1].name == elem2
+        page.hasNext()
 
         when: "The next page is selected after deletion"
         personRepository.saveAll([
@@ -171,6 +180,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[0].name == elem10
         page.content[9].name == elem19
         page.content.size() == 10
+        page.hasNext()
+        page.hasPrevious()
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
@@ -181,6 +192,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name == elem3
         page.content.size() == 10
+        page.hasPrevious()
 
         when: "The second previous page is selected"
         page = personRepository.findAll(page.previousPageable())
@@ -191,6 +203,7 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content[0].name == elem1
         page.content[1].name == elem2
         page.content.size() == 2
+        !page.hasPrevious()
 
         where:
         sorting                          | elem1     | elem2     | elem3     | elem10    | elem19

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractPageSpec.groovy
@@ -81,6 +81,8 @@ abstract class AbstractPageSpec extends Specification {
         page.totalPages == 130
         page.nextPageable().offset == 10
         page.nextPageable().size == 10
+        page.hasNext()
+        !page.hasPrevious()
 
         when: "The next page is selected"
         pageable = page.nextPageable()
@@ -91,6 +93,8 @@ abstract class AbstractPageSpec extends Specification {
         page.pageNumber == 1
         page.content[0].name.startsWith("K")
         page.content.size() == 10
+        page.hasNext()
+        page.hasPrevious()
 
         when: "The previous page is selected"
         pageable = page.previousPageable()
@@ -101,6 +105,8 @@ abstract class AbstractPageSpec extends Specification {
         page.pageNumber == 0
         page.content[0].name.startsWith("A")
         page.content.size() == 10
+        page.hasNext()
+        !page.hasPrevious()
     }
 
     void "test pageable sort"() {

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractPageSpec.groovy
@@ -82,6 +82,7 @@ abstract class AbstractPageSpec extends Specification {
         page.nextPageable().offset == 10
         page.nextPageable().size == 10
         page.hasNext()
+        page.hasTotalSize()
         !page.hasPrevious()
 
         when: "The next page is selected"
@@ -107,6 +108,29 @@ abstract class AbstractPageSpec extends Specification {
         page.content.size() == 10
         page.hasNext()
         !page.hasPrevious()
+    }
+
+    void "test pageable list without total count"() {
+        when: "10 people are paged"
+        def pageable = Pageable.from(0, 10).withoutTotal()
+        Page<Person> page = personRepository.findAll(pageable)
+
+        then: "The data is correct"
+        page.content.size() == 10
+        page.content.every() { it instanceof Person }
+        !page.hasTotalSize()
+
+        when:
+        page.getTotalPages()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        page.getTotalSize()
+
+        then:
+        thrown(IllegalStateException)
     }
 
     void "test pageable sort"() {

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
@@ -16,10 +16,12 @@
 package io.micronaut.data.tck.repositories;
 
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.ParameterExpression;
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Slice;
@@ -172,6 +174,8 @@ public interface PersonRepository extends CrudRepository<Person, Long>, Pageable
     List<Person> findDistinct();
 
     List<String> findDistinctName();
+
+    CursoredPage<Person> retrieve(@NonNull Pageable pageable);
 
     class Specifications {
 

--- a/doc-examples/jdbc-example-groovy/src/main/groovy/example/BookRepository.groovy
+++ b/doc-examples/jdbc-example-groovy/src/main/groovy/example/BookRepository.groovy
@@ -46,6 +46,14 @@ interface BookRepository extends CrudRepository<Book, Long> { // <2>
     Slice<Book> list(Pageable pageable);
     // end::pageable[]
 
+    // tag::cursored-pageable[]
+    CursoredPage<Book> find(CursoredPageable pageable) // <1>
+
+    CursoredPage<Book> findByPagesBetween(int minPageCount, int maxPageCount, Pageable pageable) // <2>
+
+    Page<Book> findByTitleStartingWith(String title, Pageable pageable) // <3>
+    // end::cursored-pageable[]
+
     // tag::simple-projection[]
     List<String> findTitleByPagesGreaterThan(int pageCount);
     // end::simple-projection[]

--- a/doc-examples/jdbc-example-groovy/src/test/groovy/example/BookRepositorySpec.groovy
+++ b/doc-examples/jdbc-example-groovy/src/test/groovy/example/BookRepositorySpec.groovy
@@ -1,5 +1,10 @@
 package example
 
+import io.micronaut.data.model.CursoredPage
+import io.micronaut.data.model.CursoredPageable
+import io.micronaut.data.model.Page
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Shared
 import spock.lang.Specification
@@ -51,6 +56,37 @@ class BookRepositorySpec extends Specification {
         // end::delete[]
         then:"It is gone"
         bookRepository.count() == 0
+    }
+
+    void "test cursored pageable"() {
+        given:
+        bookRepository.saveAll(Arrays.asList(
+                new Book("The Stand", 1000),
+                new Book("The Shining", 600),
+                new Book("The Power of the Dog", 500),
+                new Book("The Border", 700),
+                new Book("Along Came a Spider", 300),
+                new Book("Pet Cemetery", 400),
+                new Book("A Game of Thrones", 900),
+                new Book("A Clash of Kings", 1100)
+        ))
+
+        when:
+        // tag::cursored-pageable[]
+        CursoredPage<Book> page =  // <1>
+                bookRepository.find(CursoredPageable.from(5, Sort.of(Sort.Order.asc("title"))))
+        CursoredPage<Book> page2 = bookRepository.find(page.nextPageable()) // <2>
+        CursoredPage<Book> pageByPagesBetween = // <3>
+                bookRepository.findByPagesBetween(400, 700, Pageable.from(0, 3))
+        Page<Book> pageByTitleStarts = // <4>
+                bookRepository.findByTitleStartingWith("The", CursoredPageable.from( 3, Sort.unsorted()))
+        // end::cursored-pageable[]
+
+        then:
+        page.getNumberOfElements() == 5
+        page2.getNumberOfElements() == 3
+        pageByPagesBetween.getNumberOfElements() == 3
+        pageByTitleStarts.getNumberOfElements() == 3
     }
 
 

--- a/doc-examples/jdbc-example-java/src/main/java/example/BookRepository.java
+++ b/doc-examples/jdbc-example-java/src/main/java/example/BookRepository.java
@@ -46,6 +46,14 @@ interface BookRepository extends CrudRepository<Book, Long> { // <2>
     Slice<Book> list(Pageable pageable);
     // end::pageable[]
 
+    // tag::cursored-pageable[]
+    CursoredPage<Book> find(CursoredPageable pageable); // <1>
+
+    CursoredPage<Book> findByPagesBetween(int minPageCount, int maxPageCount, Pageable pageable); // <2>
+
+    Page<Book> findByTitleStartingWith(String title, Pageable pageable); // <3>
+    // end::cursored-pageable[]
+
     // tag::simple-projection[]
     List<String> findTitleByPagesGreaterThan(int pageCount);
     // end::simple-projection[]

--- a/doc-examples/jdbc-example-java/src/test/java/example/BookRepositorySpec.java
+++ b/doc-examples/jdbc-example-java/src/test/java/example/BookRepositorySpec.java
@@ -2,6 +2,8 @@ package example;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.data.annotation.Query;
+import io.micronaut.data.model.CursoredPage;
+import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Slice;
@@ -9,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.micronaut.data.model.Sort;
+import io.micronaut.data.model.Sort.Order;
 import jakarta.inject.Inject;
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -132,6 +136,47 @@ class BookRepositorySpec {
 
 		assertEquals(1, results.size());
 	}
+
+    @Test
+    void testCursoredPageable() {
+        bookRepository.saveAll(Arrays.asList(
+            new Book("The Stand", 1000),
+            new Book("The Shining", 600),
+            new Book("The Power of the Dog", 500),
+            new Book("The Border", 700),
+            new Book("Along Came a Spider", 300),
+            new Book("Pet Cemetery", 400),
+            new Book("A Game of Thrones", 900),
+            new Book("A Clash of Kings", 1100)
+        ));
+
+        // tag::cursored-pageable[]
+        CursoredPage<Book> page =  // <1>
+            bookRepository.find(CursoredPageable.from(5, Sort.of(Order.asc("title"))));
+        CursoredPage<Book> page2 = bookRepository.find(page.nextPageable()); // <2>
+        CursoredPage<Book> pageByPagesBetween = // <3>
+            bookRepository.findByPagesBetween(400, 700, Pageable.from(0, 3));
+        Page<Book> pageByTitleStarts = // <4>
+            bookRepository.findByTitleStartingWith("The", CursoredPageable.from( 3, Sort.unsorted()));
+        // end::cursored-pageable[]
+
+        assertEquals(
+            5,
+            page.getNumberOfElements()
+        );
+        assertEquals(
+            3,
+            page2.getNumberOfElements()
+        );
+        assertEquals(
+            3,
+            pageByPagesBetween.getNumberOfElements()
+        );
+        assertEquals(
+            3,
+            pageByTitleStarts.getNumberOfElements()
+        );
+    }
 
 	@Test
 	void testDto() {

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
@@ -8,9 +8,7 @@ import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.sql.Procedure
 import io.micronaut.data.jdbc.annotation.JdbcRepository
-import io.micronaut.data.model.Page
-import io.micronaut.data.model.Pageable
-import io.micronaut.data.model.Slice
+import io.micronaut.data.model.*
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.CrudRepository
 import jakarta.transaction.Transactional
@@ -49,6 +47,14 @@ interface BookRepository : CrudRepository<Book, Long> { // <2>
 
     fun list(pageable: Pageable): Slice<Book>
     // end::pageable[]
+
+    // tag::cursored-pageable[]
+    fun find(pageable: CursoredPageable): CursoredPage<Book> // <1>
+
+    fun findByPagesBetween(minPageCount: Int, maxPageCount: Int, pageable: Pageable): CursoredPage<Book> // <2>
+
+    fun findByTitleStartingWith(title: String, pageable: Pageable): Page<Book>  // <3>
+    // end::cursored-pageable[]
 
     // tag::simple-projection[]
     fun findTitleByPagesGreaterThan(pageCount: Int): List<String>

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/BookRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/BookRepositorySpec.kt
@@ -2,14 +2,15 @@ package example
 
 import io.micronaut.context.BeanContext
 import io.micronaut.data.annotation.Query
+import io.micronaut.data.model.CursoredPageable
 import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
-import jakarta.inject.Inject
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 
 @MicronautTest
 class BookRepositorySpec {
@@ -127,6 +128,49 @@ class BookRepositorySpec {
         val results = abstractBookRepository.findByTitle("The Shining")
 
         assertEquals(1, results.size)
+    }
+
+    @Test
+    fun testCursoredPageable() {
+        bookRepository.saveAll(
+            Arrays.asList(
+                Book(0, "The Stand", 1000),
+                Book(0, "The Shining", 600),
+                Book(0, "The Power of the Dog", 500),
+                Book(0, "The Border", 700),
+                Book(0, "Along Came a Spider", 300),
+                Book(0, "Pet Cemetery", 400),
+                Book(0, "A Game of Thrones", 900),
+                Book(0, "A Clash of Kings", 1100)
+            )
+        )
+
+        // tag::cursored-pageable[]
+        val page =  // <1>
+            bookRepository.find(CursoredPageable.from(5, Sort.of(Sort.Order.asc("title"))))
+        val page2 = bookRepository.find(page.nextPageable()) // <2>
+        val pageByPagesBetween =  // <3>
+            bookRepository.findByPagesBetween(400, 700, Pageable.from(0, 3))
+        val pageByTitleStarts =  // <4>
+            bookRepository.findByTitleStartingWith("The", CursoredPageable.from(3, Sort.unsorted()))
+        // end::cursored-pageable[]
+
+        assertEquals(
+            5,
+            page.numberOfElements
+        )
+        assertEquals(
+            3,
+            page2.numberOfElements
+        )
+        assertEquals(
+            3,
+            pageByPagesBetween.numberOfElements
+        )
+        assertEquals(
+            3,
+            pageByTitleStarts.numberOfElements
+        )
     }
 
     @Test

--- a/src/main/docs/guide/shared/querying/cursored-pagination.adoc
+++ b/src/main/docs/guide/shared/querying/cursored-pagination.adoc
@@ -1,0 +1,22 @@
+Micronaut Data includes the ability to specify cursored pagination with the api:data.model.CursoredPageable[] type.
+For cursored page methods return a api:data.model.CursoredPage[] type (inspired by https://jakarta.ee/specifications/data/1.0/apidocs/jakarta.data/jakarta/data/page/cursoredpage[CursoredPage] in Jakarta Data).
+
+WARNING: Cursored pagination is currently only supported with Micronaut Data JDBC and R2DBC.
+
+The following are some example signatures:
+
+snippet::example.BookRepository[project-base="doc-examples/jdbc-example", source="main", tags="cursored-pageable", indent="0"]
+
+<1> The signature defines a api:data.model.CursoredPageable[] parameter and api:data.model.CursoredPage[] return type.
+<2> The signature of method defines a api:data.model.CursoredPage[] return type, therefore method will throw an error if the request is not for the first page or is not cursored.
+<3> The method will return a api:data.model.CursoredPage[] only whenever a api:data.model.CursoredPageable[] is supplied.
+
+Therefore, you can use the repository methods to retrieve data with cursored pagination using the following queries:
+
+snippet::example.BookRepositorySpec[project-base="doc-examples/jdbc-example", tags="cursored-pageable", indent="0"]
+<1> Create a cursored pageable with a desired size and sorting and get a cursored page.
+<2> Get the next cursored pageable by calling `CursoredPage.getNextPageable()`.
+<3> Request first cursored page.
+<4> Supply a `CursoredPageable` to the repository method and a `CursoredPage` will be returned.
+
+NOTE: The cursor of pagination is based on the supplied sorting. If the supplied api:data.model.Sort[] in pageable does not produce a unique sorting, Micronaut Data internally will additionally sort by the identity column and extend the cursor with the column value to make sure pagination works correctly.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -15,6 +15,7 @@ shared:
     title: Writing Queries
     criteria: Query Criteria
     pagination: Pagination
+    cursored-pagination: Cursored Pagination
     ordering: Ordering
     projections: Query Projections
     dto: DTO Projections


### PR DESCRIPTION
This is an initial PR to check if this approach could be considered.

- Create the `CursoredPageable` type.
- Modify the `DefaultSqlPreparedQuery` to support cursored pageable for SQL. Since cursored pagination requires a new query part with parameters, the type was modified with additional query bindings.
- Modify `DefaultFindPageInterceptor` to return the correct pageable for further pagination in the cursored case.

Other interceptors will further need to be changed for this to work in all cases, like the `FindPageSpecificationInterceptor`. Additionally, the cursor could be encoded to base 64 instead of a JSON array. It seems like `Pageabe.hasNext()` method would also be beneficial. Should that be added to both offset and cursor pagination?