### PR TITLE
Test cases for broken mapped entities

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2MappedEntitySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2MappedEntitySpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2
+
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+@H2DBProperties
+class H2MappedEntitySpec extends Specification {
+    @Inject
+    H2DoubleImplement1Repository di1
+    @Inject
+    H2DoubleImplement2Repository di2
+    @Inject
+    H2DoubleImplement3Repository di3
+
+    void "test mapped entities with multiple interfaces"() {
+        when: "First implementation"
+        def results1 = di1.get()
+
+        then: "The result is correct"
+        results1 != null
+
+        when: "Second implementation"
+        def results2 = di2.get()
+
+        then: "The result is correct"
+        results2 != null
+
+        when: "Second implementation"
+        def results3 = di3.get()
+
+        then: "The result is correct"
+        results3 != null
+    }
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement1Repository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement1Repository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.CarRepository;
+import io.micronaut.data.tck.repositories.DoubleImplement1Repository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2DoubleImplement1Repository extends DoubleImplement1Repository {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement2Repository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement2Repository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.DoubleImplement2Repository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2DoubleImplement2Repository extends DoubleImplement2Repository {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement3Repository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2DoubleImplement3Repository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.DoubleImplement3Repository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2DoubleImplement3Repository extends DoubleImplement3Repository {
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement1.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement1.java
@@ -1,0 +1,24 @@
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class DoubleImplement1 implements DoubleImplementB1 {
+    int a;
+    int b;
+
+    public DoubleImplement1(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public int getA() {
+        return this.a;
+    }
+
+    @Override
+    public int getB() {
+        return this.b;
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement2.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement2.java
@@ -1,0 +1,24 @@
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class DoubleImplement2 implements DoubleImplementB2 {
+    int a;
+    int b;
+
+    public DoubleImplement2(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public int getA() {
+        return this.a;
+    }
+
+    @Override
+    public int getB() {
+        return this.b;
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement3.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplement3.java
@@ -1,0 +1,24 @@
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class DoubleImplement3 implements DoubleImplementA, DoubleImplementB3 {
+    int a;
+    int b;
+
+    public DoubleImplement3(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public int getA() {
+        return this.a;
+    }
+
+    @Override
+    public int getB() {
+        return this.b;
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementA.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementA.java
@@ -1,0 +1,5 @@
+package io.micronaut.data.tck.entities;
+
+interface DoubleImplementA {
+    int getA();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB1.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB1.java
@@ -1,0 +1,5 @@
+package io.micronaut.data.tck.entities;
+
+interface DoubleImplementB1 extends DoubleImplementA {
+    int getB();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB2.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB2.java
@@ -1,0 +1,6 @@
+package io.micronaut.data.tck.entities;
+
+interface DoubleImplementB2 extends DoubleImplementA {
+    int getA();
+    int getB();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB3.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/DoubleImplementB3.java
@@ -1,0 +1,6 @@
+package io.micronaut.data.tck.entities;
+
+interface DoubleImplementB3 {
+    int getA();
+    int getB();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement1Repository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement1Repository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.tck.entities.DoubleImplement1;
+
+public interface DoubleImplement1Repository {
+    @Query("select 2 as a, 3 as b")
+    DoubleImplement1 get();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement2Repository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement2Repository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.tck.entities.DoubleImplement2;
+
+public interface DoubleImplement2Repository {
+    @Query("select 2 as a, 3 as b")
+    DoubleImplement2 get();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement3Repository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/DoubleImplement3Repository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.repositories;
+
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.tck.entities.DoubleImplement3;
+
+public interface DoubleImplement3Repository {
+    @Query("select 2 as a, 3 as b")
+    DoubleImplement3 get();
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-micronaut = "4.4.7"
-micronaut-platform = "4.3.7"
+micronaut = "4.4.9"
+micronaut-platform = "4.4.2"
 micronaut-docs = "2.0.0"
 micronaut-gradle-plugin = "4.4.0"
 micronaut-testresources = "2.5.2"


### PR DESCRIPTION
Invalid bytecode generated for classes with interfaces leads to `Caused by: java.lang.VerifyError: Bad type on operand stack`

See https://github.com/micronaut-projects/micronaut-core/issues/10588