### PR TITLE
Introducing the Observer pattern to SQL execution

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
@@ -113,7 +113,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
     private final Map<QueryKey, SqlStoredQuery> entityInserts = new ConcurrentHashMap<>(10);
     private final Map<QueryKey, SqlStoredQuery> entityUpdates = new ConcurrentHashMap<>(10);
     private final Map<Association, String> associationInserts = new ConcurrentHashMap<>(10);
-    private final List<SqlExecutionObserver> listeners;
+    protected final List<SqlExecutionObserver> observers;
 
     /**
      * Default constructor.
@@ -142,7 +142,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
         AttributeConverterRegistry attributeConverterRegistry,
         JsonMapper jsonMapper,
         SqlJsonColumnMapperProvider<RS> sqlJsonColumnMapperProvider,
-            List<SqlExecutionObserver> listeners) {
+            List<SqlExecutionObserver> observers) {
         super(dateTimeProvider, runtimeEntityRegistry, conversionService, attributeConverterRegistry);
         this.dataSourceName = dataSourceName;
         this.columnNameResultSetReader = columnNameResultSetReader;
@@ -150,7 +150,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
         this.preparedStatementWriter = preparedStatementWriter;
         this.jsonMapper = jsonMapper;
         this.sqlJsonColumnMapperProvider = sqlJsonColumnMapperProvider;
-        this.listeners = listeners;
+        this.observers = observers;
         Collection<BeanDefinition<Object>> beanDefinitions = beanContext
             .getBeanDefinitions(Object.class, Qualifiers.byStereotype(Repository.class));
         for (BeanDefinition<Object> beanDefinition : beanDefinitions) {
@@ -200,7 +200,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
         }
 
         String query = sqlPreparedQuery.getQuery();
-        listeners.forEach(listener -> listener.query(query));
+        observers.forEach(listener -> listener.query(query));
         final PS ps;
         try {
             ps = statementFunction.create(query);
@@ -248,7 +248,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
 
         dataType = dialect.getDataType(dataType);
 
-        for (SqlExecutionObserver listener : listeners) {
+        for (SqlExecutionObserver listener : observers) {
             listener.parameter(index, value, dataType);
         }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/LoggingSqlExecutionObserver.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/LoggingSqlExecutionObserver.java
@@ -38,4 +38,11 @@ public class LoggingSqlExecutionObserver implements SqlExecutionObserver {
             QUERY_LOG.trace("Binding parameter at position {} to value {} with data type: {}", index, value, dataType);
         }
     }
+
+    @Override
+    public void updatedRecords(Number result) {
+        if (QUERY_LOG.isTraceEnabled()) {
+            QUERY_LOG.trace("Update operation updated {} records", result);
+        }
+    }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/LoggingSqlExecutionObserver.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/LoggingSqlExecutionObserver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.operations.internal.sql;
+
+import io.micronaut.data.model.DataType;
+import io.micronaut.data.runtime.config.DataSettings;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+
+@Singleton
+public class LoggingSqlExecutionObserver implements SqlExecutionObserver {
+
+    protected static final Logger QUERY_LOG = DataSettings.QUERY_LOG;
+
+    @Override
+    public void query(String query) {
+        if (QUERY_LOG.isDebugEnabled()) {
+            QUERY_LOG.debug("Executing Query: {}", query);
+        }
+    }
+
+    @Override
+    public void parameter(int index, Object value, DataType dataType) {
+        if (QUERY_LOG.isTraceEnabled()) {
+            QUERY_LOG.trace("Binding parameter at position {} to value {} with data type: {}", index, value, dataType);
+        }
+    }
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/SqlExecutionObserver.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/SqlExecutionObserver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.operations.internal.sql;
+
+import io.micronaut.data.model.DataType;
+
+public interface SqlExecutionObserver {
+
+    void query(String query);
+
+    void parameter(int index, Object value, DataType datatype);
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/SqlExecutionObserver.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/SqlExecutionObserver.java
@@ -22,4 +22,6 @@ public interface SqlExecutionObserver {
     void query(String query);
 
     void parameter(int index, Object value, DataType datatype);
+
+    void updatedRecords(Number result);
 }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/TestSqlExecutionObserver.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/TestSqlExecutionObserver.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.data.tck
+
+import io.micronaut.data.model.DataType
+import io.micronaut.data.runtime.operations.internal.sql.SqlExecutionObserver
+import jakarta.inject.Singleton
+
+@Singleton
+class TestSqlExecutionObserver implements SqlExecutionObserver {
+    public List<Invocation> invocations = new ArrayList<>()
+
+    @Override
+    void query(String query) {
+        invocations.add(new Invocation(query))
+    }
+
+    @Override
+    void parameter(int index, Object value, DataType datatype) {
+        invocations.last().parameters[index] = value
+    }
+
+    @Override
+    void updatedRecords(Number result) {
+        invocations.last().affected = result
+    }
+
+    void clear() {
+        invocations.clear()
+    }
+
+    class Invocation {
+        String query
+        Map<Integer, Object> parameters = [:]
+        Number affected
+
+        Invocation(String query) {
+            this.query = query
+        }
+    }
+}

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -23,55 +23,17 @@ import io.micronaut.data.model.CursoredPageable
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaBuilder
-import io.micronaut.data.repository.jpa.criteria.CriteriaQueryBuilder
-import io.micronaut.data.repository.jpa.criteria.DeleteSpecification
-import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
-import io.micronaut.data.repository.jpa.criteria.QuerySpecification
-import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
-import io.micronaut.data.tck.entities.Author
-import io.micronaut.data.tck.entities.AuthorBooksDto
-import io.micronaut.data.tck.entities.AuthorDtoWithBookDtos
-import io.micronaut.data.tck.entities.BasicTypes
-import io.micronaut.data.tck.entities.Book
-import io.micronaut.data.tck.entities.BookDto
-import io.micronaut.data.tck.entities.Car
-import io.micronaut.data.tck.entities.Chapter
-import io.micronaut.data.tck.entities.City
-import io.micronaut.data.tck.entities.Company
-import io.micronaut.data.tck.entities.Country
-import io.micronaut.data.tck.entities.CountryRegion
-import io.micronaut.data.tck.entities.CountryRegionCity
-import io.micronaut.data.tck.entities.EntityIdClass
-import io.micronaut.data.tck.entities.EntityWithIdClass
-import io.micronaut.data.tck.entities.EntityWithIdClass2
-import io.micronaut.data.tck.entities.Face
-import io.micronaut.data.tck.entities.Food
-import io.micronaut.data.tck.entities.Genre
-import io.micronaut.data.tck.entities.Meal
-import io.micronaut.data.tck.entities.Nose
-import io.micronaut.data.tck.entities.Page
-import io.micronaut.data.tck.entities.Person
-import io.micronaut.data.tck.entities.Student
-import io.micronaut.data.tck.entities.TimezoneBasicTypes
+import io.micronaut.data.repository.jpa.criteria.*
+import io.micronaut.data.tck.TestSqlExecutionObserver
+import io.micronaut.data.tck.entities.*
 import io.micronaut.data.tck.jdbc.entities.Role
 import io.micronaut.data.tck.jdbc.entities.UserRole
 import io.micronaut.data.tck.repositories.*
 import io.micronaut.transaction.SynchronousTransactionManager
 import io.micronaut.transaction.TransactionCallback
 import io.micronaut.transaction.TransactionStatus
-import jakarta.persistence.criteria.CriteriaBuilder
-import jakarta.persistence.criteria.CriteriaQuery
-import jakarta.persistence.criteria.CriteriaUpdate
-import jakarta.persistence.criteria.Path
-import jakarta.persistence.criteria.Predicate
-import jakarta.persistence.criteria.Root
-import spock.lang.AutoCleanup
-import spock.lang.IgnoreIf
-import spock.lang.Issue
-import spock.lang.PendingFeature
-import spock.lang.Shared
-import spock.lang.Specification
-import spock.lang.Unroll
+import jakarta.persistence.criteria.*
+import spock.lang.*
 
 import java.sql.Connection
 import java.time.LocalDate
@@ -79,15 +41,8 @@ import java.time.ZoneId
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-import static io.micronaut.data.tck.repositories.BookSpecifications.hasChapter
-import static io.micronaut.data.tck.repositories.BookSpecifications.titleContains
-import static io.micronaut.data.tck.repositories.BookSpecifications.titleEquals
-import static io.micronaut.data.tck.repositories.BookSpecifications.titleEqualsWithJoin
-import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.distinct
-import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.idsIn
-import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.nameEquals
-import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.setIncome
-import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.setName
+import static io.micronaut.data.tck.repositories.BookSpecifications.*
+import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.*
 
 abstract class AbstractRepositorySpec extends Specification {
 
@@ -124,6 +79,9 @@ abstract class AbstractRepositorySpec extends Specification {
 
     @Shared
     Optional<SynchronousTransactionManager<Connection>> transactionManager = context.findBean(SynchronousTransactionManager)
+
+    @Shared
+    TestSqlExecutionObserver observer = context.getBean(TestSqlExecutionObserver)
 
     ApplicationContext getApplicationContext() {
         return context
@@ -2863,6 +2821,99 @@ abstract class AbstractRepositorySpec extends Specification {
 
          cleanup:
          entityWithIdClass2Repository.deleteAll()
+    }
+
+    void "observer receives inserts"() {
+        given:
+        observer.clear()
+
+        when:
+        bookRepository.save(new Book(title: "Anonymous", totalPages: 400))
+
+        then:
+        observer.invocations.size() == 1
+        observer.invocations.get(0).query =~ /(?i)insert\s+into\s+.*/
+        observer.invocations.get(0).parameters[3] == "Anonymous"
+        observer.invocations.get(0).parameters[4] == 400
+
+        cleanup:
+        cleanupData()
+    }
+
+    void "observer receives query"() {
+        given:
+        observer.clear()
+
+        when:
+        bookRepository.findById(1)
+
+        then:
+        observer.invocations.size() == 1
+        observer.invocations.get(0).query =~ /(?i)select\s+.*\s+from\s+.book.\s+.*/
+        observer.invocations.get(0).parameters == [1: 1]
+
+
+        cleanup:
+        cleanupData()
+    }
+
+    void "observer receives update"() {
+        given:
+        setupBooks()
+        def book = bookRepository.findAllByTitleStartingWith("Along Came a Spider").first()
+        def author = authorRepository.searchByName("Stephen King")
+        observer.clear()
+
+        when:
+        bookRepository.updateAuthor(book.id, author)
+
+        then:
+        observer.invocations.size() == 1
+        observer.invocations[0].query =~ /(?i)update\s+.book.\s+.*/
+        observer.invocations[0].parameters[1] == author.id
+        observer.invocations[0].parameters[3] == book.id
+        observer.invocations[0].affected == 1
+
+        cleanup:
+        cleanupData()
+    }
+
+    void "observer receives delete"() {
+        given:
+        setupBooks()
+        def book = bookRepository.findAllByTitleStartingWith("Along Came a Spider").first()
+        observer.clear()
+
+        when:
+        bookRepository.delete(book)
+
+        then:
+        observer.invocations.size() == 1
+        observer.invocations[0].query =~ /(?i)delete\s+from\s+.book.\s+.*/
+        observer.invocations[0].parameters == [1: book.id]
+
+        cleanup:
+        cleanupData()
+    }
+
+    void "observer receives @Query"(){
+      given:
+      saveSampleBooks()
+      observer.clear()
+
+      when:
+      def book = bookDtoRepository.findByTitleWithQuery("The Stand")
+
+      then:
+      book.isPresent()
+      book.get().title == "The Stand"
+
+      observer.invocations.size() == 1
+      observer.invocations[0].query =~ /select \* from book b where b.title = .*/
+      observer.invocations[0].parameters == [1: "The Stand"]
+
+      cleanup:
+      cleanupData()
     }
 
     void "test criteria functions"() {


### PR DESCRIPTION
Externalising the QUERY_LOG as an observer so the same mechanism can be used for adding the query information to Spans (tracing)