### PR TITLE
Upgrade to Oracle Database Free

### DIFF
--- a/data-connection-jdbc/src/test/resources/application.yml
+++ b/data-connection-jdbc/src/test/resources/application.yml
@@ -9,7 +9,7 @@ test-resources:
       startup-timeout: 300s
     oracle:
       startup-timeout: 300s
-      image-name: gvenzl/oracle-xe:latest-faststart
+      image-name: gvenzl/oracle-free:latest-faststart
     postgres:
       startup-timeout: 300s
 


### PR DESCRIPTION
Hey all,

Thanks a lot for using my Oracle Database images.
I have noticed that you are still using the old Oracle Database XE version of my images.

Oracle has discontinued Oracle Database XE and instead offers Oracle Database Free as the successor, which was first released last year.

The database editions are compatible, hence nothing should break or change other than the connect string and the Docker image tag.

I have taken the liberty to provide the modifications based on what I could find in the repository.

Thanks,