### PR TITLE
CursoredPage not supported with findAll and PredicateSpecification

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CursoredPaginationSpec.groovy
@@ -43,8 +43,4 @@ class H2CursoredPaginationSpec extends AbstractCursoredPageSpec {
         return br
     }
 
-    @Override
-    void init() {
-        pr.deleteAll()
-    }
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mysql/MysqlCursoredPaginationSpec.groovy
@@ -16,16 +16,11 @@
 package io.micronaut.data.jdbc.mysql
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class MysqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements MySQLTestPropertyProvider {
-
-    @Shared @AutoCleanup ApplicationContext context
 
     @Memoized
     @Override
@@ -37,11 +32,6 @@ class MysqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements My
     @Override
     BookRepository getBookRepository() {
         return context.getBean(MySqlBookRepository)
-    }
-
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
     }
 
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXECursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXECursoredPaginationSpec.groovy
@@ -16,16 +16,11 @@
 package io.micronaut.data.jdbc.oraclexe
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements OracleTestPropertyProvider {
-
-    @Shared @AutoCleanup ApplicationContext context
 
     @Override
     @Memoized
@@ -37,11 +32,6 @@ class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements
     @Memoized
     BookRepository getBookRepository() {
         return context.getBean(OracleXEBookRepository)
-    }
-
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
     }
 
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -16,17 +16,11 @@
 package io.micronaut.data.jdbc.postgres
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Ignore
-import spock.lang.Shared
 
-@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
 class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
-    @Shared @AutoCleanup ApplicationContext context
 
     @Memoized
     @Override
@@ -40,8 +34,4 @@ class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements
         return context.getBean(PostgresBookRepository)
     }
 
-    @Override
-    void init() {
-        context = ApplicationContext.run(getProperties())
-    }
 }

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerCursoredPaginationSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerCursoredPaginationSpec.groovy
@@ -15,16 +15,11 @@
  */
 package io.micronaut.data.jdbc.sqlserver
 
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class SqlServerCursoredPaginationSpec extends AbstractCursoredPageSpec implements MSSQLTestPropertyProvider {
-
-    @Shared @AutoCleanup ApplicationContext context
 
     @Override
     PersonRepository getPersonRepository() {
@@ -36,8 +31,4 @@ class SqlServerCursoredPaginationSpec extends AbstractCursoredPageSpec implement
         return context.getBean(MSBookRepository)
     }
 
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
-    }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2CursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/h2/H2CursoredPaginationSpec.groovy
@@ -16,18 +16,10 @@
 package io.micronaut.data.r2dbc.h2
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.*
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import io.micronaut.data.tck.tests.AbstractRepositorySpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class H2CursoredPaginationSpec extends AbstractCursoredPageSpec implements H2TestPropertyProvider {
-
-    @Shared
-    @AutoCleanup
-    ApplicationContext context
 
     @Memoized
     @Override
@@ -39,10 +31,5 @@ class H2CursoredPaginationSpec extends AbstractCursoredPageSpec implements H2Tes
     @Override
     BookRepository getBookRepository() {
         return context.getBean(H2BookRepository)
-    }
-
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
     }
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlCursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mysql/MySqlCursoredPaginationSpec.groovy
@@ -16,16 +16,11 @@
 package io.micronaut.data.r2dbc.mysql
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class MySqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements MySqlTestPropertyProvider {
-
-    @Shared @AutoCleanup ApplicationContext context
 
     @Memoized
     @Override
@@ -37,11 +32,6 @@ class MySqlCursoredPaginationSpec extends AbstractCursoredPageSpec implements My
     @Override
     BookRepository getBookRepository() {
         return context.getBean(MySqlBookRepository)
-    }
-
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
     }
 
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXECursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXECursoredPaginationSpec.groovy
@@ -16,16 +16,11 @@
 package io.micronaut.data.r2dbc.oraclexe
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 
 class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements OracleXETestPropertyProvider {
-
-    @Shared @AutoCleanup ApplicationContext context
 
     @Override
     @Memoized
@@ -37,11 +32,6 @@ class OracleXECursoredPaginationSpec extends AbstractCursoredPageSpec implements
     @Memoized
     BookRepository getBookRepository() {
         return context.getBean(OracleXEBookRepository)
-    }
-
-    @Override
-    void init() {
-        context = ApplicationContext.run(properties)
     }
 
 }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresCursoredPaginationSpec.groovy
@@ -16,17 +16,11 @@
 package io.micronaut.data.r2dbc.postgres
 
 import groovy.transform.Memoized
-import io.micronaut.context.ApplicationContext
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
 import io.micronaut.data.tck.tests.AbstractCursoredPageSpec
-import spock.lang.AutoCleanup
-import spock.lang.Ignore
-import spock.lang.Shared
 
-//@Ignore("Causes error: 'FATAL: sorry, too many clients already'")
 class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements PostgresTestPropertyProvider {
-    @Shared @AutoCleanup ApplicationContext context
 
     @Memoized
     @Override
@@ -40,8 +34,4 @@ class PostgresCursoredPaginationSpec extends AbstractCursoredPageSpec implements
         return context.getBean(PostgresBookRepository)
     }
 
-    @Override
-    void init() {
-        context = ApplicationContext.run(getProperties())
-    }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -87,6 +87,8 @@ import static io.micronaut.data.model.runtime.StoredQuery.OperationType;
 @Internal
 public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQueryInterceptor<T, R> {
 
+    protected static final String PREPARED_QUERY_KEY = "PREPARED_QUERY";
+
     protected final CriteriaRepositoryOperations criteriaRepositoryOperations;
     private final Map<RepositoryMethodKey, QueryBuilder> sqlQueryBuilderForRepositories = new ConcurrentHashMap<>();
     private final Map<RepositoryMethodKey, Set<JoinPath>> methodsJoinPaths = new ConcurrentHashMap<>();
@@ -150,7 +152,9 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
             }
             return criteriaRepositoryOperations.findAll(query);
         }
-        return operations.findAll(preparedQueryForCriteria(methodKey, context, type, methodJoinPaths));
+        PreparedQuery<?, ?> preparedQuery = preparedQueryForCriteria(methodKey, context, type, methodJoinPaths);
+        context.setAttribute(PREPARED_QUERY_KEY, preparedQuery);
+        return operations.findAll(preparedQuery);
     }
 
     @NonNull

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/FindPageSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/FindPageSpecificationInterceptor.java
@@ -19,9 +19,12 @@ import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.intercept.RepositoryMethodKey;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
+import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 
 import java.util.List;
 
@@ -68,7 +71,18 @@ public class FindPageSpecificationInterceptor extends AbstractSpecificationInter
             count = count(methodKey, context);
         }
 
-        Page page = Page.of(resultList, getPageable(context), count);
+        Page page;
+        if (pageable.getMode() == Pageable.Mode.OFFSET) {
+            page = Page.of(resultList, pageable, count);
+        } else {
+            PreparedQuery preparedQuery = (PreparedQuery) context.getAttribute(PREPARED_QUERY_KEY).orElse(null);
+            if (preparedQuery instanceof DefaultSqlPreparedQuery<?, ?> sqlPreparedQuery) {
+                List<Pageable.Cursor> cursors = sqlPreparedQuery.createCursors(resultList, pageable);
+                page = CursoredPage.of(resultList, pageable, cursors, count);
+            } else {
+                throw new UnsupportedOperationException("Only offset pageable mode is supported by this query implementation");
+            }
+        }
         Class<Object> rt = context.getReturnType().getType();
         if (rt.isInstance(page)) {
             return page;

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
@@ -22,6 +22,7 @@ import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.query.JoinPath;
+import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
 import io.micronaut.data.operations.reactive.ReactiveCapableRepository;
 import io.micronaut.data.operations.reactive.ReactiveCriteriaCapableRepository;
@@ -84,7 +85,9 @@ public abstract class AbstractReactiveSpecificationInterceptor<T, R> extends Abs
             }
             return reactiveCriteriaOperations.findAll(criteriaQuery);
         }
-        return reactiveOperations.findAll(preparedQueryForCriteria(methodKey, context, type, methodJoinPaths));
+        PreparedQuery<?, ?> preparedQuery = preparedQueryForCriteria(methodKey, context, type, methodJoinPaths);
+        context.setAttribute(PREPARED_QUERY_KEY, preparedQuery);
+        return (Publisher<Object>) reactiveOperations.findAll(preparedQuery);
     }
 
     @NonNull

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/FindPageReactiveSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/FindPageReactiveSpecificationInterceptor.java
@@ -19,12 +19,17 @@ import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.data.intercept.RepositoryMethodKey;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
+import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 /**
  * Runtime implementation of {@code Publisher<Page> find(Specification, Pageable)}.
@@ -61,12 +66,26 @@ public class FindPageReactiveSpecificationInterceptor extends AbstractReactiveSp
                 .collectList()
                 .flatMap(
                     list -> pageable.requestTotal()
-                        ? Mono.from(countReactive(methodKey, context)).map(count -> Page.of(list, getPageable(context), count))
-                        : Mono.just(Page.of(list, getPageable(context), null))
+                        ? Mono.from(countReactive(methodKey, context)).map(count -> getPage(list, pageable, count, context))
+                        : Mono.just(getPage(list, pageable, null, context))
                 );
         }
         return Publishers.convertPublisher(conversionService, result, context.getReturnType().getType());
-
     }
 
+    private Page getPage(List<Object> list, Pageable pageable, Long count, MethodInvocationContext<Object, Object> context) {
+        Page page;
+        if (pageable.getMode() == Pageable.Mode.OFFSET) {
+            page = Page.of(list, pageable, count);
+        } else {
+            PreparedQuery preparedQuery = (PreparedQuery) context.getAttribute(PREPARED_QUERY_KEY).orElse(null);
+            if (preparedQuery instanceof DefaultSqlPreparedQuery<?, ?> sqlPreparedQuery) {
+                List<Pageable.Cursor> cursors = sqlPreparedQuery.createCursors(list, pageable);
+                page = CursoredPage.of(list, pageable, cursors, count);
+            } else {
+                throw new UnsupportedOperationException("Only offset pageable mode is supported by this query implementation");
+            }
+        }
+        return page;
+    }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultFindPageReactiveInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/reactive/DefaultFindPageReactiveInterceptor.java
@@ -20,11 +20,16 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.intercept.RepositoryMethodKey;
 import io.micronaut.data.intercept.reactive.FindPageReactiveInterceptor;
+import io.micronaut.data.model.CursoredPage;
 import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.runtime.PreparedQuery;
 import io.micronaut.data.operations.RepositoryOperations;
+import io.micronaut.data.runtime.operations.internal.sql.DefaultSqlPreparedQuery;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+
+import java.util.List;
 
 /**
  * Default implementation of {@link FindPageReactiveInterceptor}.
@@ -52,8 +57,19 @@ public class DefaultFindPageReactiveInterceptor extends AbstractPublisherInterce
             return Flux.from(reactiveOperations.findOne(countQuery))
                 .flatMap(total -> {
                     Flux<Object> resultList = Flux.from(reactiveOperations.findAll(preparedQuery));
-                    return resultList.collectList().map(list ->
-                        Page.of(list, preparedQuery.getPageable(), total.longValue())
+                    return resultList.collectList().map(list -> {
+                            Pageable pageable = preparedQuery.getPageable();
+                            Page page;
+                            if (pageable.getMode() == Pageable.Mode.OFFSET) {
+                                page = Page.of(list, pageable, total.longValue());
+                            } else if (preparedQuery instanceof DefaultSqlPreparedQuery<?, ?> sqlPreparedQuery) {
+                                List<Pageable.Cursor> cursors = sqlPreparedQuery.createCursors(list, pageable);
+                                page = CursoredPage.of(list, pageable, cursors, total.longValue());
+                            } else {
+                                throw new UnsupportedOperationException("Only offset pageable mode is supported by this query implementation");
+                            }
+                            return page;
+                        }
                     );
                 });
         }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -253,6 +253,39 @@ abstract class AbstractCursoredPageSpec extends Specification {
         page.content.name.every{ it.startsWith("A") }
     }
 
+    void "test pageable findAll using PredicateSpecification"() {
+        when:"findAll using PredicateSpecification and CursoredPage"
+        def pageable = CursoredPageable.from(10, null)
+        def page = personRepository.findAll(PersonRepository.Specifications.nameLike("A%"), pageable)
+
+        then:"The page is correct"
+        page.offset == 0
+        page.pageNumber == 0
+        page.totalSize == 30
+        page.content.name.every{ it.startsWith("A") }
+        var firstContent = page.content
+
+        when:"The next page is retrieved"
+        page = personRepository.findAll(PersonRepository.Specifications.nameLike("A%"), page.nextPageable())
+
+        then:"it is correct"
+        page.offset == 10
+        page.pageNumber == 1
+        page.content.id != firstContent.id
+        page.content.name.every{ it.startsWith("A") }
+
+        when:"The previous page is selected"
+        pageable = page.previousPageable()
+        page = personRepository.findAll(PersonRepository.Specifications.nameLike("A%"), pageable)
+
+        then:"it is correct"
+        page.offset == 0
+        page.pageNumber == 0
+        page.content.size() == 10
+        page.content.id == firstContent.id
+        page.content.name.every{ it.startsWith("A") }
+    }
+
     void "test find with left join"() {
         given:
         def books = bookRepository.saveAll([

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.tck.tests
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.data.model.CursoredPageable
 import io.micronaut.data.model.Page
 import io.micronaut.data.model.Pageable
@@ -23,20 +24,23 @@ import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.entities.Person
 import io.micronaut.data.tck.repositories.BookRepository
 import io.micronaut.data.tck.repositories.PersonRepository
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 import java.util.function.Function
 
 abstract class AbstractCursoredPageSpec extends Specification {
 
+    @AutoCleanup
+    @Shared
+    ApplicationContext context = ApplicationContext.run(properties)
+
     abstract PersonRepository getPersonRepository()
 
     abstract BookRepository getBookRepository()
 
-    abstract void init()
-
     def setup() {
-        init()
 
         // Create a repository that will look something like this:
         // id | name     | age

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -256,8 +256,8 @@ abstract class AbstractCursoredPageSpec extends Specification {
 
         where:
         resultFunction << [
-                            (cursoredPageableOther) -> personRepository.findByNameLike("A%", cursoredPageableOther),
-                            (cursoredPageable) -> personRepository.findAll(PersonRepository.Specifications.nameLike("A%"), cursoredPageable),
+                            (cursoredPageable) -> personRepository.findByNameLike("A%", (Pageable) cursoredPageable),
+                            (cursoredPageable) -> personRepository.findAll(PersonRepository.Specifications.nameLike("A%"), (Pageable) cursoredPageable),
                           ]
     }
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractReactiveRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractReactiveRepositorySpec.groovy
@@ -682,7 +682,7 @@ abstract class AbstractReactiveRepositorySpec extends Specification {
         personRepository.saveAll(people).collectList().block()
     }
 
-    void "test pageable list"() {
+    void "test pageable list"(Pageable pageable) {
         given:
             setupPersonsForPageableTest()
         when: "All the people are count"
@@ -692,7 +692,6 @@ abstract class AbstractReactiveRepositorySpec extends Specification {
             count == 1300
 
         when: "10 people are paged"
-            def pageable = Pageable.from(0, 10, Sort.of(Sort.Order.asc("id")))
             Page<Person> page = personRepository.findAll(pageable).block()
 
         then: "The data is correct"
@@ -725,39 +724,8 @@ abstract class AbstractReactiveRepositorySpec extends Specification {
             page.content[0].name.startsWith("A")
             page.content.size() == 10
 
-        when: "10 people are paged using CursoredPage"
-        pageable = CursoredPageable.from(10, null)
-        page = personRepository.findAll(pageable).block()
-
-        then: "The data is correct"
-        page.content.size() == 10
-        page.content.every() { it instanceof Person }
-        page.content[0].name.startsWith("A")
-        page.content[1].name.startsWith("B")
-        page.totalSize == 1300
-        page.totalPages == 130
-        page.nextPageable().offset == 10
-        page.nextPageable().size == 10
-
-        when: "The next page is selected"
-        pageable = page.nextPageable()
-        page = personRepository.findAll(pageable).block()
-
-        then: "it is correct"
-        page.offset == 10
-        page.pageNumber == 1
-        page.content[0].name.startsWith("K")
-        page.content.size() == 10
-
-        when: "The previous page is selected"
-        pageable = page.previousPageable()
-        page = personRepository.findAll(pageable).block()
-
-        then: "it is correct"
-        page.offset == 0
-        page.pageNumber == 0
-        page.content[0].name.startsWith("A")
-        page.content.size() == 10
+        where:
+        pageable << [Pageable.from(0, 10, Sort.of(Sort.Order.asc("id"))), CursoredPageable.from(10, null)]
     }
 
     void "test pageable sort"() {

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonReactiveRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonReactiveRepository.java
@@ -21,6 +21,7 @@ import io.micronaut.data.annotation.ParameterExpression;
 import io.micronaut.data.annotation.Query;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
+import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
 import io.micronaut.data.repository.jpa.reactive.ReactorJpaSpecificationExecutor;
 import io.micronaut.data.repository.reactive.ReactorPageableRepository;
 import io.micronaut.data.tck.entities.Person;
@@ -90,4 +91,10 @@ public interface PersonReactiveRepository extends ReactorPageableRepository<Pers
     @Query("DELETE FROM person WHERE name = :xyz")
     Mono<Long> deleteCustomSingleNoEntity(String xyz);
 
+    class Specifications {
+
+        public static PredicateSpecification<Person> nameLike(String name) {
+            return (root, criteriaBuilder) -> criteriaBuilder.like(root.get("name"), name);
+        }
+    }
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonReactiveRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonReactiveRepository.java
@@ -91,7 +91,10 @@ public interface PersonReactiveRepository extends ReactorPageableRepository<Pers
     @Query("DELETE FROM person WHERE name = :xyz")
     Mono<Long> deleteCustomSingleNoEntity(String xyz);
 
-    class Specifications {
+    final class Specifications {
+
+        private Specifications() {
+        }
 
         public static PredicateSpecification<Person> nameLike(String name) {
             return (root, criteriaBuilder) -> criteriaBuilder.like(root.get("name"), name);

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
@@ -183,6 +183,10 @@ public interface PersonRepository extends CrudRepository<Person, Long>, Pageable
             return (root, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);
         }
 
+        public static PredicateSpecification<Person> nameLike(String name) {
+            return (root, criteriaBuilder) -> criteriaBuilder.like(root.get("name"), name);
+        }
+
         public static PredicateSpecification<Person> nameEqualsCaseInsensitive(String name) {
             return (root, criteriaBuilder) -> criteriaBuilder.equal(criteriaBuilder.lower(root.get("name")), name.toLowerCase());
         }

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/PersonRepository.java
@@ -177,7 +177,10 @@ public interface PersonRepository extends CrudRepository<Person, Long>, Pageable
 
     CursoredPage<Person> retrieve(@NonNull Pageable pageable);
 
-    class Specifications {
+    final class Specifications {
+
+        private Specifications() {
+        }
 
         public static PredicateSpecification<Person> nameEquals(String name) {
             return (root, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);


### PR DESCRIPTION
Added support for reactive as well.
Targeting 4.8.x since not sure when 4.9.x will be released.