### PR TITLE
Fix for cascade save operation with one-to-many relations

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CascadeSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CascadeSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.data.jdbc.h2
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Relation
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+@MicronautTest
+@H2DBProperties
+@Property(name = "datasources.default.packages", value = "io.micronaut.data.jdbc.h2")
+class H2CascadeSpec extends Specification {
+
+    @Inject
+    @Shared
+    CascadeEntityRepository repository
+
+    void "test cascade save"() {
+        when:
+        def entityA = new CascadeSubEntityA(null, 1, null)
+        def entityB = new CascadeSubEntityB(null, 2, null)
+        def entity = new CascadeEntity(null, List.of(entityA), List.of(entityB))
+        entity = repository.save(entity)
+        def opt = repository.findById(entity.id)
+        then:
+        opt.present
+        def loadedEntity = opt.get()
+        loadedEntity.subEntityAs.size() == 1
+        loadedEntity.subEntityBs.size() == 1
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CascadeSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2CascadeSpec.groovy
@@ -1,15 +1,6 @@
 package io.micronaut.data.jdbc.h2
 
 import io.micronaut.context.annotation.Property
-import io.micronaut.core.annotation.Nullable
-import io.micronaut.data.annotation.GeneratedValue
-import io.micronaut.data.annotation.Id
-import io.micronaut.data.annotation.Join
-import io.micronaut.data.annotation.MappedEntity
-import io.micronaut.data.annotation.Relation
-import io.micronaut.data.jdbc.annotation.JdbcRepository
-import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Shared
@@ -31,11 +22,11 @@ class H2CascadeSpec extends Specification {
         def entityB = new CascadeSubEntityB(null, 2, null)
         def entity = new CascadeEntity(null, List.of(entityA), List.of(entityB))
         entity = repository.save(entity)
-        def opt = repository.findById(entity.id)
+        def opt = repository.findById(entity.id())
         then:
         opt.present
         def loadedEntity = opt.get()
-        loadedEntity.subEntityAs.size() == 1
-        loadedEntity.subEntityBs.size() == 1
+        loadedEntity.subEntityAs().size() == 1
+        loadedEntity.subEntityBs().size() == 1
     }
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
@@ -12,7 +12,6 @@ public record CascadeEntity(
         @Id @GeneratedValue Long id,
         @Relation(value = Relation.Kind.ONE_TO_MANY, cascade = Relation.Cascade.ALL, mappedBy = "entity")
         List<CascadeSubEntityA> subEntityAs,
-        // a second relationship is needed to trigger the error
         @Relation(value = Relation.Kind.ONE_TO_MANY, cascade = Relation.Cascade.ALL, mappedBy = "entity")
         List<CascadeSubEntityB> subEntityBs
 ){};

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
@@ -14,4 +14,4 @@ public record CascadeEntity(
         List<CascadeSubEntityA> subEntityAs,
         @Relation(value = Relation.Kind.ONE_TO_MANY, cascade = Relation.Cascade.ALL, mappedBy = "entity")
         List<CascadeSubEntityB> subEntityBs
-){};
+){}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntity.java
@@ -1,0 +1,18 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Relation;
+
+import java.util.List;
+
+@MappedEntity
+public record CascadeEntity(
+        @Id @GeneratedValue Long id,
+        @Relation(value = Relation.Kind.ONE_TO_MANY, cascade = Relation.Cascade.ALL, mappedBy = "entity")
+        List<CascadeSubEntityA> subEntityAs,
+        // a second relationship is needed to trigger the error
+        @Relation(value = Relation.Kind.ONE_TO_MANY, cascade = Relation.Cascade.ALL, mappedBy = "entity")
+        List<CascadeSubEntityB> subEntityBs
+){};

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeEntityRepository.java
@@ -1,0 +1,11 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+@Join("subEntityAs")
+@Join("subEntityBs")
+interface CascadeEntityRepository extends CrudRepository<CascadeEntity, Long> {}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityA.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityA.java
@@ -1,0 +1,16 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Relation;
+
+@MappedEntity
+public record CascadeSubEntityA(
+        @Id @GeneratedValue Long id,
+        @Nullable Integer data,
+        @Relation(Relation.Kind.MANY_TO_ONE)
+        @Nullable
+        CascadeEntity entity
+){};

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityA.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityA.java
@@ -13,4 +13,4 @@ public record CascadeSubEntityA(
         @Relation(Relation.Kind.MANY_TO_ONE)
         @Nullable
         CascadeEntity entity
-){};
+){}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityB.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityB.java
@@ -1,0 +1,16 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Relation;
+
+@MappedEntity
+public record CascadeSubEntityB(
+        @Id @GeneratedValue Long id,
+        @Nullable Integer data,
+        @Relation(Relation.Kind.MANY_TO_ONE)
+        @Nullable
+        CascadeEntity entity
+){};

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityB.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/CascadeSubEntityB.java
@@ -13,4 +13,4 @@ public record CascadeSubEntityB(
         @Relation(Relation.Kind.MANY_TO_ONE)
         @Nullable
         CascadeEntity entity
-){};
+){}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -157,7 +158,7 @@ public abstract class AbstractSyncEntitiesOperations<Ctx extends OperationContex
 
     @Override
     public List<T> getEntities() {
-        return entities.stream().map(d -> d.entity).toList();
+        return entities.stream().map(d -> d.entity).collect(Collectors.toList());
     }
 
     @SuppressWarnings("VisibilityModifier")

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractSyncEntitiesOperations.java
@@ -157,6 +157,7 @@ public abstract class AbstractSyncEntitiesOperations<Ctx extends OperationContex
     }
 
     @Override
+    @SuppressWarnings({"java:S6204"})
     public List<T> getEntities() {
         return entities.stream().map(d -> d.entity).collect(Collectors.toList());
     }


### PR DESCRIPTION
Fix for #3024

It is targeting 4.8.x so we could release 4.8.x since I am not sure when 4.9.0 is going to be released.