### PR TITLE
fix: Defer R2DBC Transactional callbacks using flatMap

### DIFF
--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
@@ -250,8 +250,9 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     protected <R> Flux<R> executeCallbackFlux(@NonNull ReactiveTransactionStatus<C> status,
                                               @NonNull TransactionalCallback<C, R> handler) {
         try {
-            return Flux.from(handler.doInTransaction(status))
-                .contextWrite(context -> addTxStatus(context, status));
+            return Flux.just( status )
+            	.flatMap( handler::doInTransaction )
+            	.contextWrite(context -> addTxStatus(context, status));
         } catch (Exception e) {
             return Flux.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
         }
@@ -269,8 +270,9 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     protected <R> Mono<R> executeCallbackMono(@NonNull ReactiveTransactionStatus<C> status,
                                               @NonNull Function<ReactiveTransactionStatus<C>, Mono<R>> handler) {
         try {
-            return handler.apply(status)
-                .contextWrite(context -> addTxStatus(context, status));
+        	return Mono.just( status )
+				.flatMap(handler::apply)
+				.contextWrite(context -> addTxStatus(context, status));
         } catch (Exception e) {
             return Mono.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
         }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
@@ -250,9 +250,9 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     protected <R> Flux<R> executeCallbackFlux(@NonNull ReactiveTransactionStatus<C> status,
                                               @NonNull TransactionalCallback<C, R> handler) {
         try {
-            return Flux.just( status )
-            	.flatMap( handler::doInTransaction )
-            	.contextWrite(context -> addTxStatus(context, status));
+            return Flux.just(status)
+                .flatMap(handler::doInTransaction)
+                .contextWrite(context -> addTxStatus(context, status));
         } catch (Exception e) {
             return Flux.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
         }
@@ -270,9 +270,9 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     protected <R> Mono<R> executeCallbackMono(@NonNull ReactiveTransactionStatus<C> status,
                                               @NonNull Function<ReactiveTransactionStatus<C>, Mono<R>> handler) {
         try {
-        	return Mono.just( status )
-				.flatMap(handler::apply)
-				.contextWrite(context -> addTxStatus(context, status));
+            return Mono.just(status)
+                .flatMap(handler::apply)
+                .contextWrite(context -> addTxStatus(context, status));
         } catch (Exception e) {
             return Mono.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
         }


### PR DESCRIPTION
Ensures the TransactionStatus is propagated to the handler

fixes #2835