### PR TITLE
issues/3045: HQL where in with empty entity list throws NPE

### DIFF
--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/AbstractHibernateOperations.java
@@ -470,7 +470,7 @@ public abstract class AbstractHibernateOperations<S, Q, P extends Q> implements 
             @Override
             public void bindOne(QueryParameterBinding binding, Object value) {
                 String parameterName = Objects.requireNonNull(binding.getName(), "Parameter name cannot be null!");
-                if (storedQuery.isNative()) {
+                if (binding.getParameterIndex() != -1) {
                     int parameterIndex = binding.getParameterIndex();
                     Argument<?> argument = arguments[parameterIndex];
                     Class<?> argumentType = argument.getType();

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -152,8 +152,11 @@ final class HibernateJpaOperations extends AbstractHibernateOperations<Session, 
 
     @Override
     protected void setParameterList(CommonQueryContract query, String parameterName, Collection<Object> value) {
+        if (value == null) {
+            value = Collections.emptyList();
+        }
         // Passing collection as param like this as well, before Hibernate 6 there was other method to pass collection
-        query.setParameter(parameterName, value);
+        query.setParameterList(parameterName, value);
     }
 
     @Override
@@ -162,7 +165,7 @@ final class HibernateJpaOperations extends AbstractHibernateOperations<Session, 
             value = Collections.emptyList();
         }
         // Can we ignore type? Was needed before Hibernate 6
-        query.setParameter(parameterName, value);
+        query.setParameterList(parameterName, value);
     }
 
     @Override
@@ -177,7 +180,10 @@ final class HibernateJpaOperations extends AbstractHibernateOperations<Session, 
 
     @Override
     protected void setParameterList(CommonQueryContract query, int parameterIndex, Collection<Object> value) {
-        query.setParameter(parameterIndex, value);
+        if (value == null) {
+            value = Collections.emptyList();
+        }
+        query.setParameterList(parameterIndex, value);
     }
 
     @Override
@@ -186,7 +192,7 @@ final class HibernateJpaOperations extends AbstractHibernateOperations<Session, 
             value = Collections.emptyList();
         }
         // Can we ignore type? Was needed before Hibernate 6
-        query.setParameter(parameterIndex, parameterIndex);
+        query.setParameterList(parameterIndex, value);
     }
 
     @Override

--- a/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
+++ b/data-hibernate-jpa/src/test/groovy/io/micronaut/data/hibernate/AbstractHibernateQuerySpec.groovy
@@ -71,6 +71,30 @@ abstract class AbstractHibernateQuerySpec extends AbstractQuerySpec {
     @Inject
     RelPersonRepository relPersonRepo
 
+    void "test where in empty list of entities"() {
+        when:
+        def found = bookRepository.findByAuthors(List.of())
+        then:
+        found.empty
+        when:
+        def author = authorRepository.findByName("Stephen King")
+        found = bookRepository.findByAuthors(List.of(author))
+        then:
+        !found.empty
+    }
+
+    void "test where in empty list of basic type"() {
+        when:
+        def found = bookRepository.findByAuthorIds(List.of())
+        then:
+        found.empty
+        when:
+        def author = authorRepository.findByName("Stephen King")
+        found = bookRepository.findByAuthorIds(List.of(author.id))
+        then:
+        !found.empty
+    }
+
     void "test @where with nullable property values"() {
         when:
             userWithWhereRepository.update(new UserWithWhere(id: UUID.randomUUID(), email: null, deleted: null))

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookRepository.java
@@ -172,4 +172,10 @@ public abstract class BookRepository implements PageableRepository<Book, Long>, 
     abstract List<Book> findByTitleInAndTotalPagesGreaterThan(List<String> titles, int totalPages);
 
     abstract Long countByTitleInAndTotalPagesGreaterThan(List<String> titles, int totalPages);
+
+    @Query("SELECT b FROM Book b WHERE b.author in :authors")
+    public abstract List<Book> findByAuthors(List<Author> authors);
+
+    @Query("SELECT b FROM Book b WHERE b.author.id in :authorIds")
+    public abstract List<Book> findByAuthorIds(List<Long> authorIds);
 }


### PR DESCRIPTION
Important to note I couldn't run some of the test suites successfully on my M1, but those that did run passed locally.

* add test for the issue
* in HibernateJpaOperations, call setParameterList instead of setParameter where appropriate
* in AbstractHibernateOperations, evaluate any bindings that have an index, rather than just isNativeQuery bindings
* [use value in setParameterList instead of using parameterIndex as the value](https://github.com/micronaut-projects/micronaut-data/pull/3046/files#diff-8a07d811dde5fec39c77f6caa58650686ad9157064c10551c16ccd63041d4244L189)

Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>