### PR TITLE
doc. add link to GitHub repository

### DIFF
--- a/src/main/docs/guide/repository.adoc
+++ b/src/main/docs/guide/repository.adoc
@@ -1,0 +1,3 @@
+You can find the source code of this project in this repository:
+
+https://github.com/{githubSlug}[https://github.com/{githubSlug}]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,5 +1,6 @@
 introduction:
   title: Introduction
+  repository: Repository  
   whatsNew: What's New?
   breaks: Breaking Changes
   releaseHistory: Release History


### PR DESCRIPTION
This PR adds a link to the GitHub Repository. We do this "almost" every Micronaut Module. 