### PR TITLE
Refactor limit, offset

### DIFF
--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder2.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder2.java
@@ -377,7 +377,7 @@ public final class CosmosSqlQueryBuilder2 extends SqlQueryBuilder2 {
 
     @NonNull
     @Override
-    public QueryResult buildPagination(@NonNull Pageable pageable) {
+    public String buildPagination(@NonNull Pageable pageable) {
         if (pageable.getMode() != Mode.OFFSET) {
             throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by cosmos operations");
         }
@@ -386,19 +386,9 @@ public final class CosmosSqlQueryBuilder2 extends SqlQueryBuilder2 {
             StringBuilder builder = new StringBuilder(" ");
             long from = pageable.getOffset();
             builder.append("OFFSET ").append(from).append(" LIMIT ").append(size).append(" ");
-            return QueryResult.of(
-                builder.toString(),
-                Collections.emptyList(),
-                Collections.emptyList(),
-                Collections.emptyMap()
-            );
+            return builder.toString();
         }
-        return QueryResult.of(
-            "",
-            Collections.emptyList(),
-            Collections.emptyList(),
-            Collections.emptyMap()
-        );
+        return "";
     }
 
 }

--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder.java
@@ -451,35 +451,7 @@ public final class MongoQueryBuilder implements QueryBuilder {
         } else {
             q = toJsonString(pipeline);
         }
-        return new QueryResult() {
-
-            @NonNull
-            @Override
-            public String getQuery() {
-                return q;
-            }
-
-            @Override
-            public int getMax() {
-                return query.getMax();
-            }
-
-            @Override
-            public long getOffset() {
-                return query.getOffset();
-            }
-
-            @Override
-            public List<String> getQueryParts() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public List<QueryParameterBinding> getParameterBindings() {
-                return queryState.getParameterBindings();
-            }
-
-        };
+        return QueryResult.of(q, queryState.getParameterBindings());
     }
 
     private void addLookups(Collection<JoinPath> joins, QueryState queryState) {
@@ -991,9 +963,7 @@ public final class MongoQueryBuilder implements QueryBuilder {
                 predicateQuery,
                 Collections.emptyList(),
                 queryState.getParameterBindings(),
-                queryState.getAdditionalRequiredParameters(),
-                query.getMax(),
-                query.getOffset()
+                queryState.getAdditionalRequiredParameters()
         );
     }
 

--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder2.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder2.java
@@ -186,35 +186,7 @@ public final class MongoQueryBuilder2 implements QueryBuilder2 {
         } else {
             q = toJsonString(pipeline);
         }
-        return new QueryResult() {
-
-            @NonNull
-            @Override
-            public String getQuery() {
-                return q;
-            }
-
-            @Override
-            public int getMax() {
-                return selectQueryDefinition.limit();
-            }
-
-            @Override
-            public long getOffset() {
-                return selectQueryDefinition.offset();
-            }
-
-            @Override
-            public List<String> getQueryParts() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public List<QueryParameterBinding> getParameterBindings() {
-                return queryState.getParameterBindings();
-            }
-
-        };
+        return QueryResult.of(q, queryState.getParameterBindings());
     }
 
     private void addLookups(Collection<JoinPath> joins, QueryState queryState) {
@@ -646,14 +618,12 @@ public final class MongoQueryBuilder2 implements QueryBuilder2 {
             predicateQuery,
             Collections.emptyList(),
             queryState.getParameterBindings(),
-            queryState.getAdditionalRequiredParameters(),
-            queryDefinition.limit(),
-            queryDefinition.offset()
+            queryState.getAdditionalRequiredParameters()
         );
     }
 
     @Override
-    public QueryResult buildPagination(Pageable pageable) {
+    public String buildPagination(Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 

--- a/data-document-processor/src/main/java/io/micronaut/data/document/processor/matchers/MongoRawQueryMethodMatcher.java
+++ b/data-document-processor/src/main/java/io/micronaut/data/document/processor/matchers/MongoRawQueryMethodMatcher.java
@@ -221,27 +221,7 @@ public class MongoRawQueryMethodMatcher implements MethodMatcher {
         }
         List<QueryParameterBinding> parameterBindings = new ArrayList<>(parameters.size());
         String filterQuery = processCustomQuery(matchContext, filterQueryString, parameters, entityParam, persistentEntity, parameterBindings);
-        return new QueryResult() {
-            @Override
-            public String getQuery() {
-                return filterQuery;
-            }
-
-            @Override
-            public List<String> getQueryParts() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public List<QueryParameterBinding> getParameterBindings() {
-                return parameterBindings;
-            }
-
-            @Override
-            public Map<String, String> getAdditionalRequiredParameters() {
-                return Collections.emptyMap();
-            }
-        };
+        return QueryResult.of(filterQuery, parameterBindings);
     }
 
     private QueryResult getUpdateQueryResult(MethodMatchContext matchContext,
@@ -278,10 +258,6 @@ public class MongoRawQueryMethodMatcher implements MethodMatcher {
                 return parameterBindings;
             }
 
-            @Override
-            public Map<String, String> getAdditionalRequiredParameters() {
-                return Collections.emptyMap();
-            }
         };
     }
 

--- a/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
+++ b/data-hibernate-jpa/src/main/java/io/micronaut/data/hibernate/operations/HibernateJpaOperations.java
@@ -654,10 +654,10 @@ final class HibernateJpaOperations extends AbstractHibernateOperations<Session, 
     public <T> List<T> findAll(CriteriaQuery<T> query, int offset, int limit) {
         return executeRead(session -> {
             Query<T> sessionQuery = session.createQuery(query);
-            if (offset != -1) {
+            if (offset > 0) {
                 sessionQuery = sessionQuery.setFirstResult(offset);
             }
-            if (limit != -1) {
+            if (limit > 0) {
                 sessionQuery = sessionQuery.setMaxResults(limit);
             }
             return sessionQuery.getResultList();

--- a/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactiveRepositoryOperations.java
+++ b/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactiveRepositoryOperations.java
@@ -440,10 +440,10 @@ final class DefaultHibernateReactiveRepositoryOperations extends AbstractHiberna
     public <T> Flux<T> findAll(CriteriaQuery<T> query, int offset, int limit) {
         return withSession(session -> helper.monoFromCompletionStage(() -> {
             Stage.SelectionQuery<T> sessionQuery = session.createQuery(query);
-            if (offset != -1) {
+            if (offset > 0) {
                 sessionQuery = sessionQuery.setFirstResult(offset);
             }
-            if (limit != -1) {
+            if (limit > 0) {
                 sessionQuery = sessionQuery.setMaxResults(limit);
             }
             return sessionQuery.getResultList();

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
@@ -126,13 +126,27 @@ public @interface DataMethod {
 
     /**
      * The parameter that holds the pageSize value.
+     * @deprecated Replaced with {@link #META_MEMBER_LIMIT}
      */
+    @Deprecated(forRemoval = true, since = "4.10")
     String META_MEMBER_PAGE_SIZE = "pageSize";
 
     /**
      * The parameter that holds the offset value.
+     * @deprecated Replaced with {@link #META_MEMBER_OFFSET}
      */
+    @Deprecated(forRemoval = true, since = "4.10")
     String META_MEMBER_PAGE_INDEX = "pageIndex";
+
+    /**
+     * The parameter that holds the offset value.
+     */
+    String META_MEMBER_OFFSET = "offset";
+
+    /**
+     * The parameter that holds the limit value.
+     */
+    String META_MEMBER_LIMIT = "limit";
 
     /**
      * The parameter that references the entity.
@@ -258,14 +272,18 @@ public @interface DataMethod {
     /**
      * An explicit pageSize (in absence of a pageable).
      * @return The pageSize
+     * @deprecated Not used
      */
+    @Deprecated(forRemoval = true, since = "4.10")
     int pageSize() default -1;
 
     /**
      * An explicit offset (in absence of a pageable).
      *
      * @return The offset
+     * @deprecated Not used
      */
+    @Deprecated(forRemoval = true, since = "4.10")
     long pageIndex() default 0;
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -184,6 +184,16 @@ public interface Pageable extends Sort {
 
     @NonNull
     @Override
+    default Pageable order(@NonNull List<Order> orders) {
+        Sort newSort = getSort();
+        for (Order order : orders) {
+            newSort = newSort.order(order);
+        }
+        return Pageable.from(getNumber(), getSize(), newSort);
+    }
+
+    @NonNull
+    @Override
     @JsonIgnore
     default List<Order> getOrderBy() {
         return getSort().getOrderBy();

--- a/data-model/src/main/java/io/micronaut/data/model/Sort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Sort.java
@@ -72,6 +72,21 @@ public interface Sort {
     @NonNull Sort order(@NonNull Sort.Order order);
 
     /**
+     * Adds an orders.
+     *
+     * @param orders The orders
+     * @return A new sort with the order applied
+     * @since 4.10
+     */
+    @NonNull
+    default Sort order(@NonNull List<Sort.Order> orders) {
+        for (Order order : orders) {
+            order(order);
+        }
+        return this;
+    }
+
+    /**
      * Orders by the specified property name and direction.
      *
      * @param propertyName The property name to order by

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityQuery.java
@@ -112,6 +112,10 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
         return queryBuilder.buildSelect(annotationMetadata, definition);
     }
 
+    protected boolean hasDynamicSort() {
+        return false;
+    }
+
     /**
      * @return Build {@link io.micronaut.data.model.query.builder.QueryBuilder2.SelectQueryDefinition}.
      */
@@ -125,7 +129,8 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
             distinct,
             orders == null ? List.of() : orders,
             max,
-            offset
+            offset,
+            hasDynamicSort()
         );
     }
 
@@ -140,7 +145,8 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
             distinct,
             List.of(),
             -1,
-            -1
+            -1,
+            false
         );
         return queryBuilder.buildSelect(annotationMetadata, definition);
     }
@@ -423,6 +429,7 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
         private final List<Order> order;
         private final int limit;
         private final int offset;
+        private final boolean hasDynamicSort;
 
         public SelectQueryDefinitionImpl(PersistentEntity persistentEntity,
                                          Predicate predicate,
@@ -432,7 +439,8 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
                                          boolean isDistinct,
                                          List<Order> order,
                                          int limit,
-                                         int offset) {
+                                         int offset,
+                                         boolean hasDynamicSort) {
             super(persistentEntity, predicate, joinPaths);
             this.selection = selection;
             this.isForUpdate = isForUpdate;
@@ -440,6 +448,12 @@ public abstract class AbstractPersistentEntityQuery<T, Self extends AbstractQuer
             this.order = order;
             this.limit = limit;
             this.offset = offset;
+            this.hasDynamicSort = hasDynamicSort;
+        }
+
+        @Override
+        public boolean hasDynamicSort() {
+            return hasDynamicSort;
         }
 
         @Override

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/SubqueryExpression.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/SubqueryExpression.java
@@ -33,7 +33,7 @@ public final class SubqueryExpression<T> extends AbstractExpression<T> {
     private final Type type;
     private final PersistentEntitySubquery<T> subquery;
 
-    public SubqueryExpression(@NonNull Type type,@NonNull  PersistentEntitySubquery<T> subquery) {
+    public SubqueryExpression(@NonNull Type type, @NonNull PersistentEntitySubquery<T> subquery) {
         super(subquery.getExpressionType());
         this.type = type;
         this.subquery = subquery;

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder2.java
@@ -87,7 +87,7 @@ public interface QueryBuilder2 {
      * @return The encoded query
      */
     @NonNull
-    QueryResult buildPagination(@NonNull Pageable pageable);
+    String buildPagination(@NonNull Pageable pageable);
 
     /**
      * The select query definition.
@@ -117,6 +117,13 @@ public interface QueryBuilder2 {
          * @return Is the selection marked as distinct.
          */
         default boolean isDistinct() {
+            return false;
+        }
+
+        /**
+         * @return If the query is supposted to
+         */
+        default boolean hasDynamicSort() {
             return false;
         }
 

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryResult.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryResult.java
@@ -51,8 +51,10 @@ public interface QueryResult {
 
     /**
      * @return A string representation of the aggregate part.
+     * @deprecated Not used
      */
     @Nullable
+    @Deprecated(forRemoval = true, since = "4.10")
     default String getAggregate() {
         return null;
     }
@@ -114,6 +116,19 @@ public interface QueryResult {
     @NonNull
     default Collection<JoinPath> getJoinPaths() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Creates a new encoded query.
+     *
+     * @param query                        The query
+     * @param parameterBindings            The parameters binding
+     * @return The query
+     * @since 4.10
+     */
+    @NonNull
+    static QueryResult of(@NonNull String query, @NonNull List<QueryParameterBinding> parameterBindings) {
+        return of(query, List.of(), parameterBindings);
     }
 
     /**
@@ -317,6 +332,50 @@ public interface QueryResult {
             public long getOffset() {
                 return offset;
             }
+
+            @NonNull
+            @Override
+            public String getQuery() {
+                return query;
+            }
+
+            @Override
+            public List<String> getQueryParts() {
+                return queryParts;
+            }
+
+            @Override
+            public List<QueryParameterBinding> getParameterBindings() {
+                return parameterBindings;
+            }
+
+            @Override
+            public Collection<JoinPath> getJoinPaths() {
+                return joinPaths;
+            }
+        };
+    }
+
+    /**
+     * Creates a new encoded query.
+     *
+     * @param query                        The query
+     * @param queryParts                   The queryParts
+     * @param parameterBindings            The parameters binding
+     * @param joinPaths                    The join paths
+     * @return The query
+     */
+    @NonNull
+    static QueryResult of(
+            @NonNull String query,
+            @NonNull List<String> queryParts,
+            @NonNull List<QueryParameterBinding> parameterBindings,
+            @Nullable
+            Collection<JoinPath> joinPaths) {
+        ArgumentUtils.requireNonNull("query", query);
+        ArgumentUtils.requireNonNull("parameterBindings", parameterBindings);
+
+        return new QueryResult() {
 
             @NonNull
             @Override

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/jpa/JpaQueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/jpa/JpaQueryBuilder2.java
@@ -34,6 +34,7 @@ import io.micronaut.data.model.naming.NamingStrategy;
 import io.micronaut.data.model.query.JoinPath;
 import io.micronaut.data.model.query.builder.QueryResult;
 import io.micronaut.data.model.query.builder.sql.AbstractSqlLikeQueryBuilder2;
+import io.micronaut.data.model.query.builder.sql.Dialect;
 
 import java.util.HashSet;
 import java.util.List;
@@ -231,8 +232,28 @@ public final class JpaQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 {
 
     @NonNull
     @Override
-    public QueryResult buildPagination(@NonNull Pageable pageable) {
+    public String buildPagination(@NonNull Pageable pageable) {
         throw new UnsupportedOperationException("JPA-QL does not support pagination in query definitions");
+    }
+
+    @Override
+    public QueryResult buildSelect(@NonNull AnnotationMetadata annotationMetadata, @NonNull SelectQueryDefinition definition) {
+        QueryBuilder queryBuilder = new QueryBuilder();
+        QueryState queryState = buildQuery(annotationMetadata, definition, queryBuilder, false, null);
+
+        return QueryResult.of(
+            queryState.getFinalQuery(),
+            queryState.getQueryParts(),
+            queryState.getParameterBindings(),
+            definition.limit(),
+            definition.offset(),
+            queryState.getJoinPaths()
+        );
+    }
+
+    @Override
+    protected void appendLimitAndOffset(Dialect dialect, int limit, long offset, StringBuilder builder) {
+        // JPA doesn't support limit and offset in JPQL
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder2.java
@@ -41,8 +41,6 @@ import io.micronaut.data.model.Association;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.Embedded;
 import io.micronaut.data.model.JsonDataType;
-import io.micronaut.data.model.Pageable;
-import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.PersistentAssociationPath;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentEntityUtils;
@@ -50,7 +48,6 @@ import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.PersistentPropertyPath;
 import io.micronaut.data.model.naming.NamingStrategy;
 import io.micronaut.data.model.query.JoinPath;
-import io.micronaut.data.model.query.builder.QueryBuilder;
 import io.micronaut.data.model.query.builder.QueryParameterBinding;
 import io.micronaut.data.model.query.builder.QueryResult;
 import jakarta.persistence.criteria.Selection;
@@ -1068,60 +1065,6 @@ public class SqlQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 implements Sq
             .orElseGet(() -> unescapedTableName + SEQ_SUFFIX);
     }
 
-    @NonNull
-    @Override
-    public QueryResult buildPagination(@NonNull Pageable pageable) {
-        int size = pageable.getSize();
-        if (size > 0) {
-            StringBuilder builder = new StringBuilder(" ");
-            long from = pageable.getMode() == Mode.OFFSET ? pageable.getOffset() : 0;
-            switch (dialect) {
-                case H2:
-                case MYSQL:
-                    if (from == 0) {
-                        builder.append("LIMIT ").append(size);
-                    } else {
-                        builder.append("LIMIT ").append(from).append(',').append(size);
-                    }
-                    break;
-                case POSTGRES:
-                    builder.append("LIMIT ").append(size).append(" ");
-                    if (from != 0) {
-                        builder.append("OFFSET ").append(from);
-                    }
-                    break;
-
-                case SQL_SERVER:
-                    // SQL server requires OFFSET always
-                    if (from == 0) {
-                        builder.append("OFFSET 0 ROWS ");
-                    }
-                    // intentional fall through
-                case ANSI:
-                case ORACLE:
-                default:
-                    if (from != 0) {
-                        builder.append("OFFSET ").append(from).append(" ROWS ");
-                    }
-                    builder.append("FETCH NEXT ").append(size).append(" ROWS ONLY ");
-                    break;
-            }
-            return QueryResult.of(
-                builder.toString(),
-                Collections.emptyList(),
-                Collections.emptyList(),
-                Collections.emptyMap()
-            );
-        } else {
-            return QueryResult.of(
-                "",
-                Collections.emptyList(),
-                Collections.emptyList(),
-                Collections.emptyMap()
-            );
-        }
-    }
-
     @Override
     protected String getAliasName(PersistentEntity entity) {
         return entity.getAliasName();
@@ -1550,6 +1493,32 @@ public class SqlQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 implements Sq
     @Override
     public Class<? extends Annotation> annotationType() {
         return SqlQueryConfiguration.DialectConfiguration.class;
+    }
+
+    @Override
+    public QueryResult buildSelect(@NonNull AnnotationMetadata annotationMetadata, @NonNull SelectQueryDefinition definition) {
+        QueryBuilder queryBuilder = new QueryBuilder();
+
+        if (definition.hasDynamicSort()) {
+            QueryState queryState = buildQuery(annotationMetadata, definition, queryBuilder, false, null);
+
+            return QueryResult.of(
+                queryState.getFinalQuery(),
+                queryState.getQueryParts(),
+                queryState.getParameterBindings(),
+                definition.limit(),
+                definition.offset(),
+                queryState.getJoinPaths()
+            );
+        }
+        QueryState queryState = buildQuery(annotationMetadata, definition, queryBuilder, true, null);
+
+        return QueryResult.of(
+            queryState.getFinalQuery(),
+            queryState.getQueryParts(),
+            queryState.getParameterBindings(),
+            queryState.getJoinPaths()
+        );
     }
 
     private static class DialectConfig {

--- a/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/MethodMatchSourcePersistentEntityCriteriaBuilderImpl.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/MethodMatchSourcePersistentEntityCriteriaBuilderImpl.java
@@ -50,6 +50,10 @@ public final class MethodMatchSourcePersistentEntityCriteriaBuilderImpl extends 
         this.dataTypes = Utils.getConfiguredDataTypes(matchContext.getRepositoryClass());
     }
 
+    public MethodMatchContext getMethodMatchContext() {
+        return methodMatchContext;
+    }
+
     @Override
     public SourcePersistentEntityCriteriaQuery<Object> createQuery() {
         return new SourcePersistentEntityCriteriaQueryImpl<>(methodMatchContext::getEntity, this);

--- a/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/QueryResultAnalyzer.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/QueryResultAnalyzer.java
@@ -20,7 +20,6 @@ import io.micronaut.data.model.jpa.criteria.ISelection;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;
 import io.micronaut.data.model.jpa.criteria.PersistentEntitySubquery;
 import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
-import io.micronaut.data.model.jpa.criteria.impl.IParameterExpression;
 import io.micronaut.data.model.jpa.criteria.impl.expression.BinaryExpression;
 import io.micronaut.data.model.jpa.criteria.impl.expression.FunctionExpression;
 import io.micronaut.data.model.jpa.criteria.impl.expression.IdExpression;

--- a/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/SourcePersistentEntityCriteriaQueryImpl.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/SourcePersistentEntityCriteriaQueryImpl.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.data.processor.model.criteria.impl;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.data.annotation.TypeRole;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.jpa.criteria.ISelection;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;
@@ -80,5 +82,13 @@ final class SourcePersistentEntityCriteriaQueryImpl<T> extends AbstractPersisten
     @Override
     public <U> PersistentEntitySubquery<U> subquery(Class<U> type) {
         return new SourcePersistentEntitySubqueryImpl<>(this, entityResolver, criteriaBuilder);
+    }
+
+    @Override
+    protected boolean hasDynamicSort() {
+        if (criteriaBuilder instanceof MethodMatchSourcePersistentEntityCriteriaBuilderImpl mmcb) {
+            return mmcb.getMethodMatchContext().hasParameterInRole(TypeRole.SORT);
+        }
+        return false;
     }
 }

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -463,11 +463,11 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
                 int max = queryResult.getMax();
                 if (max > -1) {
-                    annotationBuilder.member(DataMethod.META_MEMBER_PAGE_SIZE, max);
+                    annotationBuilder.member(DataMethod.META_MEMBER_LIMIT, max);
                 }
                 long offset = queryResult.getOffset();
                 if (offset > 0) {
-                    annotationBuilder.member(DataMethod.META_MEMBER_PAGE_INDEX, offset);
+                    annotationBuilder.member(DataMethod.META_MEMBER_OFFSET, offset);
                 }
             }
 

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/criteria/QueryCriteriaMethodMatch.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.data.processor.visitors.finders.criteria;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
@@ -40,7 +41,6 @@ import io.micronaut.data.processor.visitors.finders.MethodMatchInfo;
 import io.micronaut.data.processor.visitors.finders.MethodNameParser;
 import io.micronaut.data.processor.visitors.finders.QueryMatchId;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ParameterElement;
 import jakarta.persistence.criteria.Order;
@@ -203,12 +203,9 @@ public class QueryCriteriaMethodMatch extends AbstractCriteriaMethodMatch {
             }
         }
 
-        final AnnotationMetadataHierarchy annotationMetadataHierarchy = new AnnotationMetadataHierarchy(
-                matchContext.getRepositoryClass().getAnnotationMetadata(),
-                matchContext.getAnnotationMetadata()
-        );
+        final AnnotationMetadata annotationMetadata = matchContext.getMethodElement();
         QueryBuilder queryBuilder = matchContext.getQueryBuilder();
-        QueryResult queryResult = ((QueryResultPersistentEntityCriteriaQuery) criteriaQuery).buildQuery(annotationMetadataHierarchy, queryBuilder);
+        QueryResult queryResult = ((QueryResultPersistentEntityCriteriaQuery) criteriaQuery).buildQuery(annotationMetadata, queryBuilder);
 
         ClassElement genericReturnType = matchContext.getReturnType();
         if (TypeUtils.isReactiveOrFuture(genericReturnType)) {
@@ -216,7 +213,7 @@ public class QueryCriteriaMethodMatch extends AbstractCriteriaMethodMatch {
         }
         QueryResult countQueryResult = null;
         if (matchContext.isTypeInRole(genericReturnType, TypeRole.PAGE) || matchContext.isTypeInRole(genericReturnType, TypeRole.CURSORED_PAGE)) {
-            countQueryResult = ((QueryResultPersistentEntityCriteriaQuery) criteriaQuery).buildCountQuery(annotationMetadataHierarchy, queryBuilder);
+            countQueryResult = ((QueryResultPersistentEntityCriteriaQuery) criteriaQuery).buildCountQuery(annotationMetadata, queryBuilder);
         }
 
         return new MethodMatchInfo(

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -1765,7 +1765,7 @@ interface BookRepository extends GenericRepository<Book, Long> {
         when:
             def queryTop3ByAuthorNameOrderByTitle = repository.findPossibleMethods("queryTop3ByAuthorNameOrderByTitle").findFirst().get()
         then:
-            getQuery(queryTop3ByAuthorNameOrderByTitle) == '''SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ INNER JOIN "author" book_author_ ON book_."author_id"=book_author_."id" WHERE (book_author_."name" = ?) ORDER BY book_."title" ASC'''
+            getQuery(queryTop3ByAuthorNameOrderByTitle) == '''SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ INNER JOIN "author" book_author_ ON book_."author_id"=book_author_."id" WHERE (book_author_."name" = ?) ORDER BY book_."title" ASC LIMIT 3'''
             getParameterBindingPaths(queryTop3ByAuthorNameOrderByTitle) == [""] as String[]
             getParameterPropertyPaths(queryTop3ByAuthorNameOrderByTitle) == ["author.name"] as String[]
     }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/FindSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/FindSpec.groovy
@@ -411,8 +411,55 @@ interface TestRepository extends CrudRepository<Book, Long> {
         when:
             def method = repository.findPossibleMethods("findTop30OrderByTitle").findFirst().get()
         then:
+            method.stringValue(Query).get() == 'SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ ORDER BY book_."title" ASC LIMIT 30'
+            method.intValue(DataMethod, DataMethod.META_MEMBER_PAGE_SIZE).isEmpty()
+            method.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).isEmpty()
+    }
+
+    void "test top with sort"() {
+        given:
+            def repository = buildRepository('test.TestRepository', """
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.Sort;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.entities.Book;
+
+@JdbcRepository(dialect= Dialect.POSTGRES)
+@Executable
+interface TestRepository extends CrudRepository<Book, Long> {
+
+    List<Book> findTop30OrderByTitle(Sort sort);
+
+}
+""")
+        when:
+            def method = repository.findPossibleMethods("findTop30OrderByTitle").findFirst().get()
+        then:
             method.stringValue(Query).get() == 'SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ ORDER BY book_."title" ASC'
-            method.intValue(DataMethod, DataMethod.META_MEMBER_PAGE_SIZE).getAsInt() == 30
+            method.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).isPresent()
+    }
+
+    void "test top JPA"() {
+        given:
+            def repository = buildRepository('test.TestRepository', """
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.entities.Book;
+
+@Repository
+interface TestRepository extends CrudRepository<Book, Long> {
+
+    List<Book> findTop30OrderByTitle();
+
+}
+""")
+        when:
+            def method = repository.findPossibleMethods("findTop30OrderByTitle").findFirst().get()
+        then:
+            method.stringValue(Query).get() == 'SELECT book_ FROM io.micronaut.data.tck.entities.Book AS book_ ORDER BY book_.title ASC'
+            method.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).getAsInt() == 30
     }
 
     void "test project association"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JpaOrderBySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/JpaOrderBySpec.groovy
@@ -84,7 +84,7 @@ interface MyInterface extends GenericRepository<Person, Long> {
         listName.synthesize(Query).value() == "SELECT ${alias}.name FROM $Person.name AS ${alias} ORDER BY ${alias}.name ASC"
         listName.synthesize(DataMethod).resultType() == String
         listTop3.synthesize(Query).value() == "SELECT ${alias} FROM $Person.name AS ${alias} ORDER BY ${alias}.name ASC"
-        listTop3.synthesize(DataMethod).pageSize() == 3
+        listTop3.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).getAsInt() == 3
         findByCompanyUrlOrderByCompanyUrl.synthesize(Query).value() == "SELECT ${alias} FROM $Person.name AS ${alias} JOIN ${alias}.company ${alias}${companyAlias} WHERE (${alias}${companyAlias}.url = :p1) ORDER BY ${alias}${companyAlias}.url ASC"
     }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/reactive/AbstractReactiveSpecificationInterceptor.java
@@ -76,12 +76,17 @@ public abstract class AbstractReactiveSpecificationInterceptor<T, R> extends Abs
         Set<JoinPath> methodJoinPaths = getMethodJoinPaths(methodKey, context);
         if (reactiveCriteriaOperations != null) {
             CriteriaQuery<Object> criteriaQuery = buildQuery(context, type, methodJoinPaths);
-            Pageable pageable = getPageable(context);
+            Pageable pageable = getPageableInRole(context);
             if (pageable != null) {
                 if (pageable.getMode() != Mode.OFFSET) {
                     throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by hibernate operations");
                 }
                 return reactiveCriteriaOperations.findAll(criteriaQuery, (int) pageable.getOffset(), pageable.getSize());
+            }
+            int offset = getOffset(context);
+            int limit = getLimit(context);
+            if (offset > 0 || limit > 0) {
+                return reactiveCriteriaOperations.findAll(criteriaQuery, offset, limit);
             }
             return reactiveCriteriaOperations.findAll(criteriaQuery);
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/DefaultSqlPreparedQuery.java
@@ -188,16 +188,16 @@ public class DefaultSqlPreparedQuery<E, R> extends DefaultBindableParametersPrep
                 added.append(buildCursorPagination(cursored.cursor().orElse(null), sort));
             }
             if (sort.isSorted()) {
-                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()).getQuery());
+                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()));
             } else if (isSqlServerWithoutOrderBy(query, sqlStoredQuery.getDialect())) {
                 // SQL server requires order by
                 sort = sortById(persistentEntity);
-                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()).getQuery());
+                added.append(queryBuilder.buildOrderBy("", persistentEntity, sqlStoredQuery.getAnnotationMetadata(), sort, isNative()));
             }
             if (isSingleResult && pageable.getOffset() > 0) {
                 pageable = Pageable.from(pageable.getNumber(), 1);
             }
-            added.append(queryBuilder.buildPagination(pageable).getQuery());
+            added.append(queryBuilder.buildPagination(pageable));
             int forUpdateIndex = query.lastIndexOf(SqlQueryBuilder.STANDARD_FOR_UPDATE_CLAUSE);
             if (forUpdateIndex == -1) {
                 forUpdateIndex = query.lastIndexOf(SqlQueryBuilder.SQL_SERVER_FOR_UPDATE_CLAUSE);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/DefaultStoredQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/DefaultStoredQuery.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.micronaut.data.intercept.annotation.DataMethod.META_MEMBER_LIMIT;
 import static io.micronaut.data.intercept.annotation.DataMethod.META_MEMBER_PAGE_SIZE;
 
 /**
@@ -113,6 +114,7 @@ public final class DefaultStoredQuery<E, RT> extends DefaultStoredDataOperation<
                 .map(c -> c == SqlQueryBuilder.class).orElse(false);
         this.hasPageable = method.stringValue(DATA_METHOD_ANN_NAME, TypeRole.PAGEABLE).isPresent() ||
                 method.stringValue(DATA_METHOD_ANN_NAME, TypeRole.SORT).isPresent() ||
+                method.intValue(DATA_METHOD_ANN_NAME, META_MEMBER_LIMIT).orElse(-1) > -1 ||
                 method.intValue(DATA_METHOD_ANN_NAME, META_MEMBER_PAGE_SIZE).orElse(-1) > -1;
 
         if (isCount) {


### PR DESCRIPTION
For MongoDB we don't need to store limit, offset in the metadata for the runtime.
For JBDC we can generate the SQL query directly if there is no runtime sorting.