### PR TITLE
Pagination with JOINs for repository methods

### DIFF
--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder2.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/CosmosSqlQueryBuilder2.java
@@ -24,8 +24,6 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.repeatable.WhereSpecifications;
 import io.micronaut.data.model.Association;
-import io.micronaut.data.model.Pageable;
-import io.micronaut.data.model.Pageable.Mode;
 import io.micronaut.data.model.PersistentAssociationPath;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentPropertyPath;
@@ -374,20 +372,11 @@ public final class CosmosSqlQueryBuilder2 extends SqlQueryBuilder2 {
         };
     }
 
-    @NonNull
     @Override
-    public String buildPagination(@NonNull Pageable pageable) {
-        if (pageable.getMode() != Mode.OFFSET) {
-            throw new UnsupportedOperationException("Pageable mode " + pageable.getMode() + " is not supported by cosmos operations");
-        }
-        int size = pageable.getSize();
-        if (size > 0) {
-            StringBuilder builder = new StringBuilder(" ");
-            long from = pageable.getOffset();
-            builder.append("OFFSET ").append(from).append(" LIMIT ").append(size).append(" ");
-            return builder.toString();
+    public String buildLimitAndOffset(long limit, long offset) {
+        if (limit > 0) {
+            return " OFFSET " + offset + " LIMIT " + limit + " ";
         }
         return "";
     }
-
 }

--- a/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder2.java
+++ b/data-document-model/src/main/java/io/micronaut/data/document/model/query/builder/MongoQueryBuilder2.java
@@ -28,7 +28,6 @@ import io.micronaut.data.annotation.TypeRole;
 import io.micronaut.data.document.mongo.MongoAnnotations;
 import io.micronaut.data.exceptions.MappingException;
 import io.micronaut.data.model.Association;
-import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentEntityUtils;
 import io.micronaut.data.model.PersistentProperty;
@@ -623,7 +622,7 @@ public final class MongoQueryBuilder2 implements QueryBuilder2 {
     }
 
     @Override
-    public String buildPagination(Pageable pageable) {
+    public String buildLimitAndOffset(long limit, long offset) {
         throw new UnsupportedOperationException();
     }
 

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
@@ -16,14 +16,8 @@
 package io.micronaut.data.jdbc.h2
 
 import groovy.transform.Memoized
-import io.micronaut.data.model.Page
-import io.micronaut.data.model.Pageable
-import io.micronaut.data.model.Sort
-import io.micronaut.data.tck.entities.Book
-import io.micronaut.data.tck.entities.Student
 import io.micronaut.data.tck.repositories.*
 import io.micronaut.data.tck.tests.AbstractRepositorySpec
-import spock.lang.PendingFeature
 import spock.lang.Shared
 
 import static io.micronaut.data.tck.repositories.PersonRepository.Specifications.findNameSubqueryEq

--- a/data-model/src/main/java/io/micronaut/data/annotation/TypeRole.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/TypeRole.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.data.annotation;
 
+import io.micronaut.core.annotation.Experimental;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -40,6 +42,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 public @interface TypeRole {
+
     /**
      * The parameter that is used for pagination.
      */
@@ -79,6 +82,12 @@ public @interface TypeRole {
      * The parameter that is used to represent a {@link io.micronaut.data.model.CursoredPage}.
      */
     String CURSORED_PAGE = "cursoredPage";
+
+    /**
+     * The parameter that is used for pageable which is no un-paged.
+     */
+    @Experimental
+    String PAGEABLE_REQUIRED = "pageableRequired";
 
     /**
      * The name of the role.

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethod.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.intercept.DataInterceptor;
 import io.micronaut.data.model.DataType;
 
-import java.io.Serializable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -90,34 +89,6 @@ public @interface DataMethod {
      */
     @Deprecated(forRemoval = true)
     String META_MEMBER_PARAMETER_BINDING = "parameterBinding";
-
-    /**
-     * The member name that holds parameter binding paths.
-     * @deprecated No longer used
-     */
-    @Deprecated(forRemoval = true)
-    String META_MEMBER_PARAMETER_BINDING_PATHS = META_MEMBER_PARAMETER_BINDING + "Paths";
-
-    /**
-     * The member name that holds parameter auto-populated property paths.
-     * @deprecated No longer used
-     */
-    @Deprecated(forRemoval = true)
-    String META_MEMBER_PARAMETER_AUTO_POPULATED_PROPERTY_PATHS = META_MEMBER_PARAMETER_BINDING + "AutoPopulatedPaths";
-
-    /**
-     * The member name that holds parameter auto-populated property paths.
-     * @deprecated No longer used
-     */
-    @Deprecated(forRemoval = true)
-    String META_MEMBER_PARAMETER_AUTO_POPULATED_PREVIOUS_PROPERTY_PATHS = META_MEMBER_PARAMETER_BINDING + "AutoPopulatedPreviousPaths";
-
-    /**
-     * The member name that holds parameter auto-populated property paths.
-     * @deprecated No longer used
-     */
-    @Deprecated(forRemoval = true)
-    String META_MEMBER_PARAMETER_AUTO_POPULATED_PREVIOUS_PROPERTY_INDEXES = META_MEMBER_PARAMETER_BINDING + "AutoPopulatedPrevious";
 
     /**
      * The ID type.
@@ -236,15 +207,6 @@ public @interface DataMethod {
      * @return The result data type.
      */
     DataType resultDataType() default DataType.OBJECT;
-
-    /**
-     * The identifier type for the method being executed.
-     *
-     * @return The ID type
-     * @deprecated Not used
-     */
-    @Deprecated(forRemoval = true, since = "4.10")
-    Class<?> idType() default Serializable.class;
 
     /**
      * The parameter binding defines which method arguments bind to which

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethodQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethodQuery.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.intercept.annotation;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.data.model.DataType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Internal annotation used describe the stored query definition.
+ *
+ * @author Denis Stepanov
+ * @since 4.10
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Internal
+@Inherited
+public @interface DataMethodQuery {
+
+    /**
+     * The annotation name.
+     */
+    String NAME = DataMethodQuery.class.getName();
+
+    /**
+     * The member that holds the query value.
+     */
+    String META_MEMBER_QUERY = "query";
+
+    /**
+     * The member that holds the native query value.
+     */
+    String META_MEMBER_NATIVE = "nativeQuery";
+
+    /**
+     * Whether the user is a raw user specified query.
+     */
+    String META_MEMBER_RAW_QUERY = "rawQuery";
+
+    /**
+     * The member that holds the is procedure value.
+     */
+    String META_MEMBER_PROCEDURE = "procedure";
+
+    /**
+     * The member that holds expandable query parts.
+     */
+    String META_MEMBER_EXPANDABLE_QUERY = "expandableQuery";
+
+    /**
+     * The member name that holds the result type.
+     */
+    String META_MEMBER_RESULT_TYPE = "resultType";
+
+    /**
+     * The member name that holds the result type.
+     */
+    String META_MEMBER_RESULT_DATA_TYPE = "resultDataType";
+
+    /**
+     * The parameter that holds the offset value.
+     */
+    String META_MEMBER_OFFSET = "offset";
+
+    /**
+     * The parameter that holds the limit value.
+     */
+    String META_MEMBER_LIMIT = "limit";
+
+    /**
+     * Does the query result in a DTO object.
+     */
+    String META_MEMBER_DTO = "dto";
+
+    /**
+     * Does the query contains optimistic lock.
+     */
+    String META_MEMBER_OPTIMISTIC_LOCK = "optimisticLock";
+
+    /**
+     * Meta member for storing the parameters.
+     */
+    String META_MEMBER_PARAMETERS = "parameters";
+
+    /**
+     * The member name that holds the root entity type.
+     */
+    String META_MEMBER_OPERATION_TYPE = "opType";
+
+    /**
+     * The computed result type. This represents the type that is to be read from the database. For example for a {@link java.util.List}
+     * this would return the value of the generic type parameter {@code E}. Or for an entity result the return type itself.
+     *
+     * @return The result type
+     */
+    Class<?> resultType() default void.class;
+
+    /**
+     * @return The result data type.
+     */
+    DataType resultDataType() default DataType.OBJECT;
+
+    /**
+     * @return The query parameters
+     */
+    DataMethodQueryParameter[] parameters() default {};
+
+    /**
+     * @return True if the method represents the procedure invocation.
+     * @since 4.2.0
+     */
+    boolean procedure() default false;
+
+    /**
+     * Describes the operation type.
+     */
+    enum OperationType {
+        /**
+         * A query operation.
+         */
+        QUERY,
+        /**
+         * A count operation.
+         */
+        COUNT,
+        /**
+         * An exists operation.
+         */
+        EXISTS,
+        /**
+         * An update operation.
+         */
+        UPDATE,
+        /**
+         * An update returning operation.
+         */
+        UPDATE_RETURNING,
+        /**
+         * A delete operation.
+         */
+        DELETE,
+        /**
+         * An delete returning operation.
+         */
+        DELETE_RETURNING,
+        /**
+         * An insert operation.
+         */
+        INSERT,
+        /**
+         * An insert returning operation.
+         */
+        INSERT_RETURNING,
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethodQueryParameter.java
+++ b/data-model/src/main/java/io/micronaut/data/intercept/annotation/DataMethodQueryParameter.java
@@ -97,6 +97,16 @@ public @interface DataMethodQueryParameter {
     String META_MEMBER_EXPRESSION = "expression";
 
     /**
+     * The member name that holds the role name.
+     */
+    String META_MEMBER_ROLE = "role";
+
+    /**
+     * The member name that holds the table alias.
+     */
+    String META_MEMBER_TABLE_ALIAS = "tableAlias";
+
+    /**
      * @return The query parameter value
      */
     String value() default "";

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaDelete.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaDelete.java
@@ -18,22 +18,14 @@ package io.micronaut.data.model.jpa.criteria.impl;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.data.annotation.Join;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.jpa.criteria.ExpressionType;
 import io.micronaut.data.model.jpa.criteria.IExpression;
-import io.micronaut.data.model.jpa.criteria.IPredicate;
-import io.micronaut.data.model.jpa.criteria.ISelection;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityCriteriaDelete;
 import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;
 import io.micronaut.data.model.jpa.criteria.PersistentEntitySubquery;
 import io.micronaut.data.model.jpa.criteria.impl.predicate.ConjunctionPredicate;
-import io.micronaut.data.model.jpa.criteria.impl.query.QueryModelPredicateVisitor;
-import io.micronaut.data.model.jpa.criteria.impl.query.QueryModelSelectionVisitor;
 import io.micronaut.data.model.jpa.criteria.impl.selection.CompoundSelection;
-import io.micronaut.data.model.jpa.criteria.impl.util.Joiner;
-import io.micronaut.data.model.query.QueryModel;
-import io.micronaut.data.model.query.builder.QueryBuilder;
 import io.micronaut.data.model.query.builder.QueryBuilder2;
 import io.micronaut.data.model.query.builder.QueryResult;
 import jakarta.persistence.criteria.Expression;
@@ -46,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static io.micronaut.data.model.jpa.criteria.impl.CriteriaUtils.notSupportedOperation;
 
@@ -64,48 +55,6 @@ public abstract class AbstractPersistentEntityCriteriaDelete<T> implements Persi
     protected Predicate predicate;
     protected PersistentEntityRoot<T> entityRoot;
     protected Selection<?> returning;
-
-    @NonNull
-    @Override
-    public QueryModel getQueryModel() {
-        if (entityRoot == null) {
-            throw new IllegalStateException("The root entity must be specified!");
-        }
-        QueryModel qm = QueryModel.from(entityRoot.getPersistentEntity());
-        Joiner joiner = new Joiner();
-        if (predicate instanceof IPredicate predicateVisitable) {
-            predicateVisitable.visitPredicate(createPredicateVisitor(qm));
-            predicateVisitable.visitPredicate(joiner);
-        }
-        if (returning instanceof ISelection<?> selectionVisitable) {
-            selectionVisitable.visitSelection(new QueryModelSelectionVisitor(qm, false));
-            selectionVisitable.visitSelection(joiner);
-        }
-        for (Map.Entry<String, Joiner.Joined> e : joiner.getJoins().entrySet()) {
-            qm.join(e.getKey(), Optional.ofNullable(e.getValue().getType()).orElse(Join.Type.DEFAULT), e.getValue().getAlias());
-        }
-        return qm;
-    }
-
-    /**
-     * Creates query model predicate visitor.
-     *
-     * @param queryModel The query model
-     * @return the visitor
-     */
-    @NonNull
-    protected QueryModelPredicateVisitor createPredicateVisitor(QueryModel queryModel) {
-        return new QueryModelPredicateVisitor(queryModel);
-    }
-
-    @Override
-    public QueryResult buildQuery(AnnotationMetadata annotationMetadata, QueryBuilder queryBuilder) {
-        QueryBuilder2 queryBuilder2 = QueryResultPersistentEntityCriteriaQuery.findQueryBuilder2(queryBuilder);
-        if (queryBuilder2 == null) {
-            return queryBuilder.buildDelete(annotationMetadata, getQueryModel());
-        }
-        return buildQuery(annotationMetadata, queryBuilder2);
-    }
 
     @Override
     public QueryResult buildQuery(AnnotationMetadata annotationMetadata, QueryBuilder2 queryBuilder) {

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/LegacyQueryModelQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/LegacyQueryModelQueryBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.jpa.criteria.impl;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.annotation.Join;
+import io.micronaut.data.model.Sort;
+import io.micronaut.data.model.jpa.criteria.IPredicate;
+import io.micronaut.data.model.jpa.criteria.ISelection;
+import io.micronaut.data.model.jpa.criteria.PersistentEntityRoot;
+import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
+import io.micronaut.data.model.jpa.criteria.impl.query.QueryModelPredicateVisitor;
+import io.micronaut.data.model.jpa.criteria.impl.query.QueryModelSelectionVisitor;
+import io.micronaut.data.model.jpa.criteria.impl.util.Joiner;
+import io.micronaut.data.model.query.QueryModel;
+import io.micronaut.data.model.query.builder.QueryBuilder;
+import io.micronaut.data.model.query.builder.QueryBuilder2;
+import io.micronaut.data.model.query.builder.QueryResult;
+import jakarta.persistence.criteria.Order;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.micronaut.data.model.jpa.criteria.impl.CriteriaUtils.requireProperty;
+
+/**
+ * The Legacy query builder wrapper.
+ *
+ * @author Denis Stepanov
+ * @since 4.10
+ */
+@Internal
+final class LegacyQueryModelQueryBuilder implements QueryBuilder2 {
+
+    private final QueryBuilder queryBuilder;
+
+    LegacyQueryModelQueryBuilder(QueryBuilder queryBuilder) {
+        this.queryBuilder = queryBuilder;
+    }
+
+    @NonNull
+    private QueryModelPredicateVisitor createPredicateVisitor(QueryModel queryModel) {
+        return new QueryModelPredicateVisitor(queryModel);
+    }
+
+    @Override
+    public QueryResult buildInsert(AnnotationMetadata repositoryMetadata, InsertQueryDefinition definition) {
+        throw new IllegalStateException("Not supported");
+    }
+
+    @Override
+    public QueryResult buildSelect(AnnotationMetadata annotationMetadata, SelectQueryDefinition definition) {
+        QueryModel qm = QueryModel.from(definition.persistentEntity());
+        Joiner joiner = new Joiner();
+        if (definition.predicate() instanceof IPredicate predicateVisitable) {
+            predicateVisitable.visitPredicate(createPredicateVisitor(qm));
+            predicateVisitable.visitPredicate(joiner);
+        }
+        PersistentEntityRoot<?> entityRoot = (PersistentEntityRoot<?>) definition.root();
+        if (definition.selection() instanceof ISelection<?> selectionVisitable) {
+            selectionVisitable.visitSelection(new QueryModelSelectionVisitor(qm, definition.isDistinct()));
+            selectionVisitable.visitSelection(joiner);
+            entityRoot.visitSelection(joiner);
+        } else {
+            entityRoot.visitSelection(new QueryModelSelectionVisitor(qm, definition.isDistinct()));
+            entityRoot.visitSelection(joiner);
+        }
+        List<Order> orders = definition.order();
+        if (orders != null && !orders.isEmpty()) {
+            List<Sort.Order> sortOrders = orders.stream().map(o -> {
+                PersistentPropertyPath<?> propertyPath = requireProperty(o.getExpression());
+                joiner.joinIfNeeded(propertyPath);
+                String name = propertyPath.getPathAsString();
+                if (o.isAscending()) {
+                    return Sort.Order.asc(name);
+                }
+                return Sort.Order.desc(name);
+            }).toList();
+            qm.sort(Sort.of(sortOrders));
+        }
+        for (Map.Entry<String, Joiner.Joined> e : joiner.getJoins().entrySet()) {
+            qm.join(e.getKey(), Optional.ofNullable(e.getValue().getType()).orElse(Join.Type.DEFAULT), e.getValue().getAlias());
+        }
+
+        qm.max(definition.limit());
+        qm.offset(definition.offset());
+        if (definition.isForUpdate()) {
+            qm.forUpdate();
+        }
+        return queryBuilder.buildQuery(annotationMetadata, qm);
+    }
+
+    @Override
+    public QueryResult buildUpdate(AnnotationMetadata annotationMetadata, UpdateQueryDefinition definition) {
+        QueryModel qm = QueryModel.from(definition.persistentEntity());
+        Joiner joiner = new Joiner();
+        if (definition.predicate() instanceof IPredicate predicateVisitable) {
+            predicateVisitable.visitPredicate(createPredicateVisitor(qm));
+            predicateVisitable.visitPredicate(joiner);
+        }
+        if (definition.returningSelection() instanceof ISelection<?> selectionVisitable) {
+            selectionVisitable.visitSelection(new QueryModelSelectionVisitor(qm, false));
+            selectionVisitable.visitSelection(joiner);
+        }
+        for (Map.Entry<String, Joiner.Joined> e : joiner.getJoins().entrySet()) {
+            qm.join(e.getKey(), Optional.ofNullable(e.getValue().getType()).orElse(Join.Type.DEFAULT), e.getValue().getAlias());
+        }
+        return queryBuilder.buildUpdate(qm, definition.propertiesToUpdate());
+    }
+
+    @Override
+    public QueryResult buildDelete(AnnotationMetadata annotationMetadata, DeleteQueryDefinition definition) {
+        if (definition.persistentEntity() == null) {
+            throw new IllegalStateException("The root entity must be specified!");
+        }
+        QueryModel qm = QueryModel.from(definition.persistentEntity());
+        Joiner joiner = new Joiner();
+        if (definition.predicate() instanceof IPredicate predicateVisitable) {
+            predicateVisitable.visitPredicate(createPredicateVisitor(qm));
+            predicateVisitable.visitPredicate(joiner);
+        }
+        if (definition.returningSelection() instanceof ISelection<?> selectionVisitable) {
+            selectionVisitable.visitSelection(new QueryModelSelectionVisitor(qm, false));
+            selectionVisitable.visitSelection(joiner);
+        }
+        for (Map.Entry<String, Joiner.Joined> e : joiner.getJoins().entrySet()) {
+            qm.join(e.getKey(), Optional.ofNullable(e.getValue().getType()).orElse(Join.Type.DEFAULT), e.getValue().getAlias());
+        }
+        return queryBuilder.buildDelete(qm);
+    }
+
+    @Override
+    public String buildLimitAndOffset(long limit, long offset) {
+        throw new IllegalStateException("Not supported");
+    }
+
+}

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryBuilder2.java
@@ -20,11 +20,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.query.JoinPath;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
 
 import java.util.Collection;
@@ -81,18 +81,26 @@ public interface QueryBuilder2 {
     QueryResult buildDelete(@NonNull AnnotationMetadata annotationMetadata, @NonNull DeleteQueryDefinition definition);
 
     /**
-     * Encode the pageable.
+     * Generate the limit and offset query.
      *
-     * @param pageable The pageable
+     * @param limit  The limit (-1 of not set)
+     * @param offset The offset (0 if not set)
      * @return The encoded query
      */
     @NonNull
-    String buildPagination(@NonNull Pageable pageable);
+    String buildLimitAndOffset(long limit, long offset);
 
     /**
      * The select query definition.
      */
     interface SelectQueryDefinition extends BaseQueryDefinition {
+
+        /**
+         * @return The root
+         */
+        @NonNull
+        Root<?> root();
+
 
         /**
          * @return The selection
@@ -121,10 +129,10 @@ public interface QueryBuilder2 {
         }
 
         /**
-         * @return The index of {@link Pageable} or {@link io.micronaut.data.model.Sort}.
+         * @return The parameters in role
          */
-        default int getParameterPageableOrSortIndex() {
-            return -1;
+        default Map<String, Integer> parametersInRole() {
+            return Map.of();
         }
 
     }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryParameterBinding.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/QueryParameterBinding.java
@@ -126,4 +126,26 @@ public interface QueryParameterBinding {
     default boolean isExpression() {
         return false;
     }
+
+    /**
+     * The role of the parameter.
+     *
+     * @return The role name or null
+     * @since 4.10
+     */
+    @Nullable
+    default String getRole() {
+        return null;
+    }
+
+    /**
+     * The table alias.
+     *
+     * @return The table alias
+     * @since 4.10
+     */
+    @Nullable
+    default String getTableAlias() {
+        return null;
+    }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/jpa/JpaQueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/jpa/JpaQueryBuilder2.java
@@ -25,7 +25,6 @@ import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.annotation.MappedProperty;
 import io.micronaut.data.model.Association;
 import io.micronaut.data.model.Embedded;
-import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.PersistentAssociationPath;
 import io.micronaut.data.model.PersistentEntity;
 import io.micronaut.data.model.PersistentProperty;
@@ -230,15 +229,19 @@ public final class JpaQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 {
         return queryString.append("DELETE ");
     }
 
-    @NonNull
     @Override
-    public String buildPagination(@NonNull Pageable pageable) {
+    public String buildLimitAndOffset(long limit, long offset) {
         throw new UnsupportedOperationException("JPA-QL does not support pagination in query definitions");
     }
 
     @Override
-    protected void appendLimitAndOffset(Dialect dialect, int limit, long offset, StringBuilder builder) {
+    protected void appendLimitAndOffset(Dialect dialect, long limit, long offset, StringBuilder builder) {
         // JPA doesn't support limit and offset in JPQL
+    }
+
+    @Override
+    protected void appendPaginationAndOrder(AnnotationMetadata annotationMetadata, SelectQueryDefinition definition, boolean pagination, QueryState queryState) {
+        appendOrder(annotationMetadata, definition.order(), queryState);
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/DelegatingQueryParameterBinding.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/DelegatingQueryParameterBinding.java
@@ -108,4 +108,13 @@ public abstract class DelegatingQueryParameterBinding implements QueryParameterB
         return delegate.getValue();
     }
 
+    @Override
+    public String getRole() {
+        return delegate.getRole();
+    }
+
+    @Override
+    public String getTableAlias() {
+        return delegate.getTableAlias();
+    }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/QueryParameterBinding.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/QueryParameterBinding.java
@@ -155,4 +155,22 @@ public interface QueryParameterBinding {
     default boolean isExpression() {
         return false;
     }
+
+    /**
+     * @return The parameter in role
+     * @since 4.10
+     */
+    @Nullable
+    default String getRole() {
+        return null;
+    }
+
+    /**
+     * @return The table alias
+     * @since 4.10
+     */
+    @Nullable
+    default String getTableAlias() {
+        return null;
+    }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
@@ -257,7 +257,7 @@ public interface StoredQuery<E, R> extends Named, StoredDataOperation<R> {
     }
 
     /**
-     * @return The limit of the query or 0 if none
+     * @return The offset of the query or 0 if none
      * @since 4.10
      */
     default int getOffset() {

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/StoredQuery.java
@@ -249,6 +249,22 @@ public interface StoredQuery<E, R> extends Named, StoredDataOperation<R> {
     }
 
     /**
+     * @return The limit of the query or -1 if none
+     * @since 4.10
+     */
+    default int getLimit() {
+        return -1;
+    }
+
+    /**
+     * @return The limit of the query or 0 if none
+     * @since 4.10
+     */
+    default int getOffset() {
+        return 0;
+    }
+
+    /**
      * Describes the operation type.
      */
     enum OperationType {

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/CountMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/CountMethodMatcher.java
@@ -53,7 +53,7 @@ public final class CountMethodMatcher extends AbstractMethodMatcher {
                 protected PersistentEntityCriteriaQuery<Object> createQuery(MethodMatchContext matchContext,
                                                                             PersistentEntityCriteriaBuilder cb,
                                                                             List<AnnotationValue<Join>> joinSpecs) {
-                    return super.createCountQuery(matchContext, cb, joinSpecs);
+                    return super.createDefaultCountQuery(matchContext, cb, joinSpecs);
                 }
 
                 @Override

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
@@ -47,10 +47,8 @@ import io.micronaut.inject.processing.ProcessingException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -307,11 +305,6 @@ public class RawQueryMethodMatcher implements MethodMatcher {
             @Override
             public List<QueryParameterBinding> getParameterBindings() {
                 return parameterBindings;
-            }
-
-            @Override
-            public Map<String, String> getAdditionalRequiredParameters() {
-                return Collections.emptyMap();
             }
         };
     }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -882,7 +882,6 @@ import io.micronaut.data.tck.entities.Author;
 @JdbcRepository(dialect = Dialect.H2)
 interface AuthorRepository extends GenericRepository<Author, Long> {
 
-//     With books join, making sure count query doesn't use join
     @Where("@.nick_name = :nickName")
     @Join(value = "books", type = Join.Type.FETCH)
     Page<Author> findByName(String name, String nickName, Pageable pageable);
@@ -907,10 +906,10 @@ interface AuthorRepository extends GenericRepository<Author, Long> {
         def findByNickNameCountQuery = getCountQuery(findByNickNameMethod)
 
         expect:
-        findAllQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
-        findAllCountQuery == 'SELECT COUNT(*) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
-        findByNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
-        findByNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
+        findAllQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`id` IN (SELECT author_author_.`id` FROM `author` author_author_ WHERE (author_author_.`id` IN (SELECT author_author_author_.`id` FROM `author` author_author_author_ INNER JOIN `book` author_author_author_books_ ON author_author_author_.`id`=author_author_author_books_.`author_id`))'
+        findAllCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
+        findByNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`id` IN (SELECT author_author_.`id` FROM `author` author_author_ WHERE (author_author_.`id` IN (SELECT author_author_author_.`id` FROM `author` author_author_author_ INNER JOIN `book` author_author_author_books_ ON author_author_author_.`id`=author_author_author_books_.`author_id` WHERE (author_author_author_.`name` = ?)))'
+        findByNameCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
         findByNickNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name` FROM `author` author_ WHERE (author_.`nick_name` = ? AND author_.name = ?)'
         findByNickNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ WHERE (author_.`nick_name` = ? AND author_.name = ?)'
         getResultDataType(findAllMethod) == DataType.ENTITY
@@ -971,17 +970,17 @@ interface AuthorRepository extends GenericRepository<Author, Long> {
             def findByNickNameExpressions = getParameterExpressions(findByNickNameMethod);
 
         expect:
-            findAllQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
-            findAllCountQuery == 'SELECT COUNT(*) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
-            findByNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
-            findByNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
+            findAllQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`id` IN (SELECT author_author_.`id` FROM `author` author_author_ WHERE (author_author_.`id` IN (SELECT author_author_author_.`id` FROM `author` author_author_author_ INNER JOIN `book` author_author_author_books_ ON author_author_author_.`id`=author_author_author_books_.`author_id`))'
+            findAllCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id`'
+            findByNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name`,author_books_.`id` AS books_id,author_books_.`author_id` AS books_author_id,author_books_.`genre_id` AS books_genre_id,author_books_.`title` AS books_title,author_books_.`total_pages` AS books_total_pages,author_books_.`publisher_id` AS books_publisher_id,author_books_.`last_updated` AS books_last_updated FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`id` IN (SELECT author_author_.`id` FROM `author` author_author_ WHERE (author_author_.`id` IN (SELECT author_author_author_.`id` FROM `author` author_author_author_ INNER JOIN `book` author_author_author_books_ ON author_author_author_.`id`=author_author_author_books_.`author_id` WHERE (author_author_author_.`name` = ?)))'
+            findByNameCountQuery == 'SELECT COUNT(DISTINCT(author_.`id`)) FROM `author` author_ INNER JOIN `book` author_books_ ON author_.`id`=author_books_.`author_id` WHERE (author_.`name` = ? AND author_.nick_name = ?)'
             findByNickNameQuery == 'SELECT author_.`id`,author_.`name`,author_.`nick_name` FROM `author` author_ WHERE (author_.`nick_name` = ? AND author_.name = ?)'
             findByNickNameCountQuery == 'SELECT COUNT(*) FROM `author` author_ WHERE (author_.`nick_name` = ? AND author_.name = ?)'
             getResultDataType(findAllMethod) == DataType.ENTITY
             getResultDataType(findByNameMethod) == DataType.ENTITY
             getResultDataType(findByNickNameMethod) == DataType.ENTITY
-            findByNameExpressions == [false, true] as Boolean[]
-            findByNickNameExpressions == [false, true] as Boolean[]
+            findByNameExpressions == [false, false, true, false] as Boolean[]
+            findByNickNameExpressions == [false, true, false] as Boolean[]
     }
 
     void "test distinct query"() {
@@ -1508,8 +1507,8 @@ interface EntityWithIdClassRepository extends GenericRepository<Book, Long> {
 """)
             def findAll = repository.findPossibleMethods("findAll").findFirst().get()
         expect:
-            getQuery(findAll) == 'SELECT book_ FROM io.micronaut.data.tck.entities.Book AS book_ JOIN FETCH book_.author book_author_'
-            getCountQuery(findAll) == 'SELECT COUNT(book_) FROM io.micronaut.data.tck.entities.Book AS book_ JOIN book_.author book_author_'
+            getQuery(findAll) == 'SELECT book_ FROM io.micronaut.data.tck.entities.Book AS book_ JOIN FETCH book_.author book_author_ WHERE (book_.id IN (SELECT book_book_.id FROM io.micronaut.data.tck.entities.Book AS book_book_ WHERE (book_book_.id IN (SELECT book_book_book_.id FROM io.micronaut.data.tck.entities.Book AS book_book_book_ JOIN book_book_book_.author book_book_book_author_))))'
+            getCountQuery(findAll) == 'SELECT COUNT(DISTINCT(book_)) FROM io.micronaut.data.tck.entities.Book AS book_ JOIN book_.author book_author_'
     }
 
     void "test criteria"() {
@@ -1930,8 +1929,8 @@ class Resource {
         def findByResourcesKindCountQuery = getCountQuery(findByResourcesKindMethod)
 
         expect:
-        findByResourcesNameCountQuery == 'SELECT COUNT(*) FROM `work_request` work_request_ INNER JOIN `resource` work_request_resources_ ON work_request_.`id`=work_request_resources_.`work_request_id` WHERE (work_request_resources_.`name` = ?)'
-        findByResourcesKindCountQuery == 'SELECT COUNT(*) FROM `work_request` work_request_ INNER JOIN `resource` work_request_resources_ ON work_request_.`id`=work_request_resources_.`work_request_id` WHERE (work_request_resources_.`kind` = ?)'
+        findByResourcesNameCountQuery == 'SELECT COUNT(DISTINCT(work_request_.`id`)) FROM `work_request` work_request_ INNER JOIN `resource` work_request_resources_ ON work_request_.`id`=work_request_resources_.`work_request_id` WHERE (work_request_resources_.`name` = ?)'
+        findByResourcesKindCountQuery == 'SELECT COUNT(DISTINCT(work_request_.`id`)) FROM `work_request` work_request_ INNER JOIN `resource` work_request_resources_ ON work_request_.`id`=work_request_resources_.`work_request_id` WHERE (work_request_resources_.`kind` = ?)'
     }
 
     void "test find using LIKE with custom query builder"() {
@@ -1993,4 +1992,58 @@ interface TestRepository extends GenericRepository<Book, Long> {
             getQuery(findByAuthorInListMethod) == "SELECT book_.`id`,book_.`author_id`,book_.`genre_id`,book_.`title`,book_.`total_pages`,book_.`publisher_id`,book_.`last_updated` FROM `book` book_ WHERE (book_.`author_id` IN (?))"
     }
 
+    void "test JOIN pagination"() {
+        given:
+        def repository = buildRepository('test.TestRepository', """
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.repository.GenericRepository;
+import io.micronaut.data.tck.entities.Book;
+import io.micronaut.data.tck.entities.Author;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+
+import java.util.List;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface TestRepository extends GenericRepository<Book, Long> {
+    @Join(value = "students", type = Join.Type.LEFT)
+    Page<Book> findAll(Pageable pageable);
+}
+
+""")
+        def findByAuthorInListMethod = repository.findPossibleMethods("findAll").findFirst().get()
+        def countQueryAnnotation = findByAuthorInListMethod.getAnnotation(DataMethod).getAnnotation(DataMethod.META_MEMBER_COUNT_QUERY).get()
+        expect:
+            getQuery(findByAuthorInListMethod) == """SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ LEFT JOIN "book_student" book_students_book_student_ ON book_."id"=book_students_book_student_."book_id"  LEFT JOIN "student" book_students_ ON book_students_book_student_."student_id"=book_students_."id" WHERE (book_."id" IN (SELECT book_book_."id" FROM "book" book_book_ WHERE (book_book_."id" IN (SELECT book_book_book_."id" FROM "book" book_book_book_ LEFT JOIN "book_student" book_book_book_students_book_student_ ON book_book_book_."id"=book_book_book_students_book_student_."book_id"  LEFT JOIN "student" book_book_book_students_ ON book_book_book_students_book_student_."student_id"=book_book_book_students_."id"))"""
+            countQueryAnnotation.stringValue().get() == """SELECT COUNT(DISTINCT(book_."id")) FROM "book" book_ LEFT JOIN "book_student" book_students_book_student_ ON book_."id"=book_students_book_student_."book_id"  LEFT JOIN "student" book_students_ ON book_students_book_student_."student_id"=book_students_."id\""""
+    }
+
+    void "test JOIN pagination 2"() {
+        given:
+        def repository = buildRepository('test.TestRepository', """
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.repository.GenericRepository;
+import io.micronaut.data.tck.entities.Book;
+import io.micronaut.data.tck.entities.Author;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+
+import java.util.List;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface TestRepository extends GenericRepository<Book, Long> {
+    @Join(value = "students", type = Join.Type.LEFT_FETCH)
+    Page<Book> findAllByStudentsNameIn(List<String> names, Pageable pageable);
+}
+
+""")
+        def findAllByStudentsNameIn = repository.findPossibleMethods("findAllByStudentsNameIn").findFirst().get()
+        def countQueryAnnotation = findAllByStudentsNameIn.getAnnotation(DataMethod).getAnnotation(DataMethod.META_MEMBER_COUNT_QUERY).get()
+        expect:
+            getQuery(findAllByStudentsNameIn) == """SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated",book_students_."id" AS students_id,book_students_."version" AS students_version,book_students_."name" AS students_name,book_students_."creation_time" AS students_creation_time,book_students_."last_updated_time" AS students_last_updated_time FROM "book" book_ LEFT JOIN "book_student" book_students_book_student_ ON book_."id"=book_students_book_student_."book_id"  LEFT JOIN "student" book_students_ ON book_students_book_student_."student_id"=book_students_."id" WHERE (book_."id" IN (SELECT book_book_."id" FROM "book" book_book_ WHERE (book_book_."id" IN (SELECT book_book_book_."id" FROM "book" book_book_book_ LEFT JOIN "book_student" book_book_book_students_book_student_ ON book_book_book_."id"=book_book_book_students_book_student_."book_id"  LEFT JOIN "student" book_book_book_students_ ON book_book_book_students_book_student_."student_id"=book_book_book_students_."id" WHERE (book_book_book_students_."name" IN (?))))"""
+            countQueryAnnotation.stringValue().get() == """SELECT COUNT(DISTINCT(book_."id")) FROM "book" book_ LEFT JOIN "book_student" book_students_book_student_ ON book_."id"=book_students_book_student_."book_id"  LEFT JOIN "student" book_students_ ON book_students_book_student_."student_id"=book_students_."id" WHERE (book_students_."name" IN (?))"""
+            countQueryAnnotation.getAnnotations("parameters").size() == 1
+    }
 }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/SqlParameterBindingSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/SqlParameterBindingSpec.groovy
@@ -128,8 +128,8 @@ interface ProjectRepository extends CrudRepository<Project, ProjectId> {
 
         expect:"The repository compiles"
         repository != null
-        getDataTypes(method) == [DataType.STRING, DataType.STRING]
-        getParameterBindingIndexes(method) == ["0", "1"]
+        getDataTypes(method) == [DataType.STRING, DataType.STRING, DataType.OBJECT]
+        getParameterBindingIndexes(method) == ["0", "1", "2"]
     }
 
     void "test non-sql compile repository"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/CrudRepositorySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/CrudRepositorySpec.groovy
@@ -80,8 +80,8 @@ import java.util.List;
 @io.micronaut.context.annotation.Executable
 interface MyInterface extends CrudRepository<Person, Long> {
 
-    List<Person> list(String name);   
-    
+    List<Person> list(String name);
+
     int count(String name);
 }
 """)
@@ -113,7 +113,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         existsMethod
         existsMethod.getArguments()[0].type == Long
         existsMethod.synthesize(DataMethod).rootEntity() == Person
-        existsMethod.synthesize(DataMethod).idType() == Long
         existsMethod.synthesize(DataMethod).interceptor() == ExistsByInterceptor
 
         when:"the findAll method is retrieved"
@@ -123,7 +122,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         findAll
         findAll.getReturnType().asArgument().getFirstTypeVariable().get().type == Person
         findAll.synthesize(DataMethod).rootEntity() == Person
-        findAll.synthesize(DataMethod).idType() == Long
         findAll.synthesize(DataMethod).interceptor() == FindAllInterceptor
 
         when:"the count method is retrieved"
@@ -133,7 +131,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         count
         count.getReturnType().type == long.class
         count.synthesize(DataMethod).rootEntity() == Person
-        count.synthesize(DataMethod).idType() == Long
         count.synthesize(DataMethod).interceptor() == CountInterceptor
 
         when:"the list method with named query paremeters is retrieved"
@@ -143,7 +140,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         listPeople
         listPeople.getReturnType().type == List.class
         listPeople.synthesize(DataMethod).rootEntity() == Person
-        listPeople.synthesize(DataMethod).idType() == Long
         listPeople.synthesize(DataMethod).interceptor() == FindAllInterceptor
 
         when:"the count method with named query parameters is retrieved"
@@ -153,7 +149,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         countPeople
         countPeople.getReturnType().type == int.class
         countPeople.synthesize(DataMethod).rootEntity() == Person
-        countPeople.synthesize(DataMethod).idType() == Long
 
         when:"the delete by id method is retrieved"
         def deleteById = beanDefinition.getRequiredMethod("deleteById", Long)
@@ -162,7 +157,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteById
         deleteById.getReturnType().type == void .class
         deleteById.synthesize(DataMethod).rootEntity() == Person
-        deleteById.synthesize(DataMethod).idType() == Long
         deleteById.synthesize(Query).value() == "DELETE $Person.name  AS ${alias} WHERE (${alias}.id = :p1)"
         deleteById.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
@@ -173,7 +167,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteAll
         deleteAll.getReturnType().type == void .class
         deleteAll.synthesize(DataMethod).rootEntity() == Person
-        deleteAll.synthesize(DataMethod).idType() == Long
         deleteAll.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
         when:"the deleteOne method is retrieved"
@@ -183,7 +176,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteOne
         deleteOne.getReturnType().type == void .class
         deleteOne.synthesize(DataMethod).rootEntity() == Person
-        deleteOne.synthesize(DataMethod).idType() == Long
         deleteOne.synthesize(DataMethod).interceptor() == DeleteOneInterceptor
 
         when:"the deleteAll with ids"
@@ -193,7 +185,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteIds
         deleteIds.getReturnType().type == void .class
         deleteIds.synthesize(DataMethod).rootEntity() == Person
-        deleteIds.synthesize(DataMethod).idType() == Long
         deleteIds.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
     }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/FindSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/FindSpec.groovy
@@ -27,7 +27,6 @@ import io.micronaut.data.model.query.builder.jpa.JpaQueryBuilder
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
 import spock.lang.Issue
-import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class FindSpec extends AbstractDataSpec {
@@ -417,7 +416,6 @@ interface TestRepository extends CrudRepository<Book, Long> {
             method.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).isEmpty()
     }
 
-    @PendingFeature
     void "test top with sort"() {
         given:
             def repository = buildRepository('test.TestRepository', """
@@ -438,7 +436,7 @@ interface TestRepository extends CrudRepository<Book, Long> {
         when:
             def method = repository.findPossibleMethods("findTop30OrderByTitle").findFirst().get()
         then:
-            method.stringValue(Query).get() == 'SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_ ORDER BY book_."title" ASC'
+            method.stringValue(Query).get() == 'SELECT book_."id",book_."author_id",book_."genre_id",book_."title",book_."total_pages",book_."publisher_id",book_."last_updated" FROM "book" book_'
             method.intValue(DataMethod, DataMethod.META_MEMBER_LIMIT).isPresent()
     }
 

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/SpringCrudRepositorySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/SpringCrudRepositorySpec.groovy
@@ -86,7 +86,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         existsMethod
         existsMethod.getArguments()[0].type == Long
         existsMethod.synthesize(DataMethod).rootEntity() == Person
-        existsMethod.synthesize(DataMethod).idType() == Long
         existsMethod.synthesize(DataMethod).interceptor() == ExistsByInterceptor
 
         when:"the findAll method is retrieved"
@@ -96,7 +95,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         findAll
         findAll.getReturnType().asArgument().getFirstTypeVariable().get().type == Person
         findAll.synthesize(DataMethod).rootEntity() == Person
-        findAll.synthesize(DataMethod).idType() == Long
         findAll.synthesize(DataMethod).interceptor() == FindAllInterceptor
 
         when:"the count method is retrieved"
@@ -106,7 +104,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         count
         count.getReturnType().type == long.class
         count.synthesize(DataMethod).rootEntity() == Person
-        count.synthesize(DataMethod).idType() == Long
         count.synthesize(DataMethod).interceptor() == CountInterceptor
 
         when:"the list method with named query paremeters is retrieved"
@@ -116,7 +113,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         listPeople
         listPeople.getReturnType().type == List.class
         listPeople.synthesize(DataMethod).rootEntity() == Person
-        listPeople.synthesize(DataMethod).idType() == Long
         listPeople.synthesize(DataMethod).interceptor() == FindAllInterceptor
 
         when:"the count method with named query parameters is retrieved"
@@ -126,7 +122,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         countPeople
         countPeople.getReturnType().type == int.class
         countPeople.synthesize(DataMethod).rootEntity() == Person
-        countPeople.synthesize(DataMethod).idType() == Long
 
         when:"the delete by id method is retrieved"
         def deleteById = beanDefinition.getRequiredMethod("deleteById", Long)
@@ -135,7 +130,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteById
         deleteById.getReturnType().type == void .class
         deleteById.synthesize(DataMethod).rootEntity() == Person
-        deleteById.synthesize(DataMethod).idType() == Long
         deleteById.synthesize(Query).value() == "DELETE $Person.name  AS ${alias} WHERE (${alias}.id = :p1)"
         deleteById.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
@@ -146,7 +140,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteAll
         deleteAll.getReturnType().type == void .class
         deleteAll.synthesize(DataMethod).rootEntity() == Person
-        deleteAll.synthesize(DataMethod).idType() == Long
         deleteAll.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
         when:"the deleteOne method is retrieved"
@@ -156,7 +149,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteOne
         deleteOne.getReturnType().type == void .class
         deleteOne.synthesize(DataMethod).rootEntity() == Person
-        deleteOne.synthesize(DataMethod).idType() == Long
         deleteOne.synthesize(DataMethod).interceptor() == DeleteOneInterceptor
 
         when:"the deleteAll with ids"
@@ -166,7 +158,6 @@ interface MyInterface extends CrudRepository<Person, Long> {
         deleteIds
         deleteIds.getReturnType().type == void .class
         deleteIds.synthesize(DataMethod).rootEntity() == Person
-        deleteIds.synthesize(DataMethod).idType() == Long
         deleteIds.synthesize(DataMethod).interceptor() == DeleteAllInterceptor
 
     }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/query/DefaultBindableParametersStoredQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/query/DefaultBindableParametersStoredQuery.java
@@ -25,8 +25,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.model.JsonDataType;
-import io.micronaut.data.model.Pageable;
 import io.micronaut.data.model.PersistentPropertyPath;
+import io.micronaut.data.model.Sort;
 import io.micronaut.data.model.runtime.DelegatingQueryParameterBinding;
 import io.micronaut.data.model.runtime.QueryParameterBinding;
 import io.micronaut.data.model.runtime.RuntimePersistentEntity;
@@ -202,7 +202,7 @@ public class DefaultBindableParametersStoredQuery<E, R> implements BindableParam
 
         List<Object> values;
         if (binding.isExpandable()) {
-            if (value instanceof Pageable) {
+            if (value instanceof Sort) {
                 return; // Skip
             }
             values = expandValue(value, binding.getDataType());

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/query/DefaultStoredQueryResolver.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/query/DefaultStoredQueryResolver.java
@@ -17,6 +17,7 @@ package io.micronaut.data.runtime.query;
 
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.data.annotation.DataAnnotationUtils;
@@ -31,6 +32,7 @@ import io.micronaut.data.operations.HintsCapableRepository;
 import io.micronaut.data.runtime.query.internal.DefaultStoredQuery;
 import io.micronaut.inject.ExecutableMethod;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 
 import static io.micronaut.data.model.runtime.StoredQuery.OperationType;
@@ -55,6 +57,16 @@ public abstract class DefaultStoredQueryResolver implements StoredQueryResolver 
 
     @Override
     public <E, R> StoredQuery<E, R> resolveCountQuery(MethodInvocationContext<?, ?> context) {
+        AnnotationValue<Annotation> dataMethodQuery = context.getAnnotation(DataMethod.NAME);
+        AnnotationValue<Annotation> countQuery = dataMethodQuery.getAnnotation(DataMethod.META_MEMBER_COUNT_QUERY).orElse(null);
+        if (countQuery != null) {
+            return new DefaultStoredQuery<>(
+                context.getExecutableMethod(),
+                countQuery,
+                getHintsCapableRepository()
+            );
+        }
+        // Previous way
         return new DefaultStoredQuery<>(
             context.getExecutableMethod(),
             true,

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/DelegateStoredQuery.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/DelegateStoredQuery.java
@@ -177,4 +177,14 @@ public interface DelegateStoredQuery<E, R> extends StoredQuery<E, R> {
     default Map<String, AnnotationValue<?>> getParameterExpressions() {
         return getStoredQueryDelegate().getParameterExpressions();
     }
+
+    @Override
+    default int getLimit() {
+        return getStoredQueryDelegate().getLimit();
+    }
+
+    @Override
+    default int getOffset() {
+        return getStoredQueryDelegate().getOffset();
+    }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/StoredQueryParameter.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/query/internal/StoredQueryParameter.java
@@ -45,6 +45,8 @@ public final class StoredQueryParameter implements QueryParameterBinding {
     private final List<QueryParameterBinding> all;
     private final boolean expression;
     private final Object value;
+    private final String role;
+    private final String tableAlias;
 
     private boolean previousInitialized;
     private QueryParameterBinding previousPopulatedValueParameter;
@@ -61,6 +63,8 @@ public final class StoredQueryParameter implements QueryParameterBinding {
                          boolean expandable,
                          final boolean expression,
                          Object value,
+                         String role,
+                         String tableAlias,
                          List<QueryParameterBinding> all) {
         this.name = name;
         this.dataType = dataType;
@@ -74,6 +78,8 @@ public final class StoredQueryParameter implements QueryParameterBinding {
         this.expandable = expandable;
         this.expression = expression;
         this.value = value;
+        this.role = role;
+        this.tableAlias = tableAlias;
         this.all = all;
     }
 
@@ -152,6 +158,16 @@ public final class StoredQueryParameter implements QueryParameterBinding {
     }
 
     @Override
+    public String getRole() {
+        return role;
+    }
+
+    @Override
+    public String getTableAlias() {
+        return tableAlias;
+    }
+
+    @Override
     public String toString() {
         return "StoredQueryParameter{" +
                 "name='" + name + '\'' +
@@ -165,6 +181,8 @@ public final class StoredQueryParameter implements QueryParameterBinding {
                 ", expandable=" + expandable +
                 ", expression=" + expression +
                 ", value=" + value +
+                ", role=" + role +
+                ", tableAlias=" + tableAlias +
                 '}';
     }
 }


### PR DESCRIPTION
- For repository methods with JOIN and pagenation, the query is generated as:
```
        // SQL tabular results with JOINs cannot be property limited by LIMIT and OFFSET
        // Create a query that can be paginated with JOINs using a subquery
        //
        // SELECT mainEntity.* FROM MyEntity mainEntity JOIN ... WHERE mainEntity.id in (
        //     SELECT paginationEntity.id FROM MyEntity paginationEntity WHERE paginationEntity.id in (
        //        SELECT filteredEntity.id FROM MyEntity filteredEntity JOIN ... WHERE ... ;
        //     ) ORDER BY ... LIMIT ... OFFSET ...
        // ) ORDER BY ...
        //
```
(In future version we can optimize it)
- Only valid for SQL and JPA builders - we might consider another layer between the query builder for repositories to generate queries
- The append of pagination / sort is implemented using an expandable functionality of queries. 
- The count query is now represented as a separate annotation (with backwards compatibility). In the next major version I would like to change to have:
    - DataMethod - basic representation of the method
    - "queryDefinition" - eveything about the query etc
    - "countQueryDefinition" - eveything about the count query etc
    - possibly a collection of queries, we can also support different dialects for one method if needed
- Not working for MySql now, because MySql doesn't support LIMIT in subqueries. It could be implemented using a JOIN - `SELECT ... JOIN (Select ... ) as filtered WHERE filtered.id = ID`, but our criteria don't support this kind of query yet
