### PR TITLE
Fix query failing when criteriaBuilder.conjunction() is used

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.2.3
+        uses: graalvm/setup-graalvm@v1.2.4
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 @DefaultImplementation(DefaultCursoredPage.class)
 public interface CursoredPage<T> extends Page<T> {
 
-    CursoredPage<?> EMPTY = new DefaultCursoredPage<>(Collections.emptyList(), Pageable.unpaged(), Collections.emptyList(), null);
+    CursoredPage<?> EMPTY = new DefaultCursoredPage<>(Collections.emptyList(), Pageable.unpaged(), Collections.emptyList(), -1L);
 
     /**
      * @return Whether this {@link CursoredPage} contains the total count of the records
@@ -125,6 +125,9 @@ public interface CursoredPage<T> extends Page<T> {
      */
     @Override
     default @NonNull <T2> CursoredPage<T2> map(Function<T, T2> function) {
+        if (this == EMPTY) {
+            return (CursoredPage<T2>) EMPTY;
+        }
         List<T2> content = getContent().stream().map(function).collect(Collectors.toList());
         return new DefaultCursoredPage<>(content, getPageable(), getCursors(), hasTotalSize() ? getTotalSize() : null);
     }

--- a/data-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Page.java
@@ -96,6 +96,9 @@ public interface Page<T> extends Slice<T> {
      */
     @Override
     default @NonNull <T2> Page<T2> map(Function<T, T2> function) {
+        if (this == EMPTY) {
+            return (Page<T2>) EMPTY;
+        }
         List<T2> content = getContent().stream().map(function).toList();
         return new DefaultPage<>(content, getPageable(), hasTotalSize() ? getTotalSize() : null);
     }

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaQuery.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/AbstractPersistentEntityCriteriaQuery.java
@@ -297,7 +297,11 @@ public abstract class AbstractPersistentEntityCriteriaQuery<T> implements Persis
 
     @Override
     public PersistentEntityCriteriaQuery<T> where(Expression<Boolean> restriction) {
-        predicate = new ConjunctionPredicate(Collections.singleton((IExpression<Boolean>) restriction));
+        if (restriction instanceof ConjunctionPredicate conjunctionPredicate) {
+            predicate = conjunctionPredicate;
+        } else {
+            predicate = new ConjunctionPredicate(Collections.singleton((IExpression<Boolean>) restriction));
+        }
         return this;
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder2.java
@@ -1816,14 +1816,21 @@ public abstract class AbstractSqlLikeQueryBuilder2 implements QueryBuilder2 {
 
         private void visitConjunctionPredicates(Collection<? extends IExpression<Boolean>> predicates) {
             Iterator<? extends IExpression<Boolean>> iterator = predicates.iterator();
+            boolean appendLogicalAnd = true;
             while (iterator.hasNext()) {
                 IExpression<Boolean> expression = iterator.next();
                 if (expression instanceof ConjunctionPredicate conjunctionPredicate) {
-                    visitConjunctionPredicates(conjunctionPredicate.getPredicates());
+                    Collection<? extends IExpression<Boolean>> conjunctionPredicates = conjunctionPredicate.getPredicates();
+                    if (CollectionUtils.isEmpty(conjunctionPredicates)) {
+                        // Nothing was added to the query so skip adding AND
+                        appendLogicalAnd = false;
+                    } else {
+                        visitConjunctionPredicates(conjunctionPredicates);
+                    }
                 } else {
                     visitPredicate(expression);
                 }
-                if (iterator.hasNext()) {
+                if (appendLogicalAnd && iterator.hasNext()) {
                     query.append(LOGICAL_AND);
                 }
             }

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -199,6 +199,24 @@ class PageSpec extends Specification {
         !mappedCursoredPage.hasTotalSize()
     }
 
+    void "empty page can be mapped "() {
+        when:
+        Page<String> page = Page.empty()
+        def copy = page.map { it -> it }
+        copy.getTotalSize()
+
+        then:
+        notThrown(Throwable)
+
+        when:
+        CursoredPage<String> cursoredPage = CursoredPage.empty()
+        def newCopy = cursoredPage.map {it -> it }
+        newCopy.getTotalSize()
+
+        then:
+        notThrown(Throwable)
+    }
+
     @EqualsAndHashCode
     @ToString
     @Serdeable

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -80,6 +80,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 import static io.micronaut.data.tck.repositories.BookSpecifications.hasChapter
+import static io.micronaut.data.tck.repositories.BookSpecifications.titleAndTotalPagesEquals
+import static io.micronaut.data.tck.repositories.BookSpecifications.titleAndTotalPagesEqualsUsingConjunction
 import static io.micronaut.data.tck.repositories.BookSpecifications.titleContains
 import static io.micronaut.data.tck.repositories.BookSpecifications.titleEquals
 import static io.micronaut.data.tck.repositories.BookSpecifications.titleEqualsWithJoin
@@ -2417,6 +2419,7 @@ abstract class AbstractRepositorySpec extends Specification {
 
         def book = new Book()
         book.setTitle("1984")
+        book.setTotalPages(360)
         book.setGenre(genre)
         def ch1 = new Chapter()
         ch1.setTitle("Ch1")
@@ -2440,6 +2443,8 @@ abstract class AbstractRepositorySpec extends Specification {
         def bookNotLoadedUsingJoinCriteriaByChapterTitle = bookRepository.findOne(hasChapter("Ch32"))
         def booksLoadedByChapterTitleQuery = bookRepository.findAllByChaptersTitle("Ch1")
         def booksLoadedByChapterTitleAndBookTitleQuery = bookRepository.findAllByChaptersTitleAndTitle("Ch1", book.title)
+        def booksLoadedByTitleAndTotalPagesUsingSimpleCriteria = bookRepository.findAll ( titleAndTotalPagesEquals("1984", 360))
+        def booksLoadedByTitleAndTotalPagesUsingConjunctionPredicate = bookRepository.findAll ( titleAndTotalPagesEqualsUsingConjunction("1984", 360))
 
         then:
         bookLoadedUsingFindAllByGenre.genre.genreName != null
@@ -2466,6 +2471,10 @@ abstract class AbstractRepositorySpec extends Specification {
         booksLoadedByChapterTitleAndBookTitleQuery[0].id == book.id
         // Chapters not loaded
         !CollectionUtils.isEmpty(booksLoadedByChapterTitleAndBookTitleQuery[0].chapters)
+        booksLoadedByTitleAndTotalPagesUsingConjunctionPredicate.size() == 1
+        booksLoadedByTitleAndTotalPagesUsingConjunctionPredicate[0].title == "1984"
+        booksLoadedByTitleAndTotalPagesUsingSimpleCriteria.size() == 1
+        booksLoadedByTitleAndTotalPagesUsingSimpleCriteria[0].title == "1984"
     }
 
     void "test loading books vs page repository and joins"() {

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookSpecifications.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookSpecifications.java
@@ -42,7 +42,7 @@ public final class BookSpecifications {
         return (root, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>(3);
             if (title != null) {
-                predicates.add(criteriaBuilder.equal(root.get("title"), title));
+                predicates.add(criteriaBuilder.equal(root.get(TITLE_FIELD), title));
             }
             if (totalPages > 0) {
                 predicates.add(criteriaBuilder.equal(root.get("totalPages"), totalPages));
@@ -59,7 +59,7 @@ public final class BookSpecifications {
             if (title != null) {
                 predicate =
                     criteriaBuilder.and(
-                        predicate, criteriaBuilder.equal(root.get("title"), title));
+                        predicate, criteriaBuilder.equal(root.get(TITLE_FIELD), title));
             }
             if (totalPages > 0) {
                 predicate =

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookSpecifications.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/BookSpecifications.java
@@ -5,11 +5,16 @@ import io.micronaut.data.model.jpa.criteria.PersistentEntityJoin;
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
 import io.micronaut.data.tck.entities.Book;
 
-public class BookSpecifications {
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class BookSpecifications {
 
     private static final String TITLE_FIELD = "title";
 
-    private BookSpecifications() {}
+    private BookSpecifications() {
+    }
 
     public static PredicateSpecification<Book> titleEquals(String title) {
         return (root, criteriaBuilder) -> criteriaBuilder.equal(root.get(TITLE_FIELD), title);
@@ -33,4 +38,40 @@ public class BookSpecifications {
         };
     }
 
+    public static PredicateSpecification<Book> titleAndTotalPagesEquals(String title, int totalPages) {
+        return (root, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>(3);
+            if (title != null) {
+                predicates.add(criteriaBuilder.equal(root.get("title"), title));
+            }
+            if (totalPages > 0) {
+                predicates.add(criteriaBuilder.equal(root.get("totalPages"), totalPages));
+            }
+            predicates.add(criteriaBuilder.isNotNull(root.get("id")));
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    public static PredicateSpecification<Book> titleAndTotalPagesEqualsUsingConjunction(String title, int totalPages) {
+        return (root, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+
+            if (title != null) {
+                predicate =
+                    criteriaBuilder.and(
+                        predicate, criteriaBuilder.equal(root.get("title"), title));
+            }
+            if (totalPages > 0) {
+                predicate =
+                    criteriaBuilder.and(
+                        predicate,
+                        criteriaBuilder.equal(
+                            root.get("totalPages"), totalPages));
+            }
+            predicate =
+                criteriaBuilder.and(
+                    predicate, criteriaBuilder.isNotNull(root.get("id")));
+            return predicate;
+        };
+    }
 }


### PR DESCRIPTION
Having `PredicateSpecification` like this 
```
public static PredicateSpecification<Book> titleAndTotalPagesEqualsUsingConjunction(String title, int totalPages) {
        return (root, criteriaBuilder) -> {
            Predicate predicate = criteriaBuilder.conjunction();

            if (title != null) {
                predicate =
                    criteriaBuilder.and(
                        predicate, criteriaBuilder.equal(root.get("title"), title));
            }
            if (totalPages > 0) {
                predicate =
                    criteriaBuilder.and(
                        predicate,
                        criteriaBuilder.equal(
                            root.get("totalPages"), totalPages));
            }
            predicate =
                criteriaBuilder.and(
                    predicate, criteriaBuilder.isNotNull(root.get("id")));
            return predicate;
        };
    }
```
the query generated will have `WHERE (AND title = ? AND total_pages = ? AND id IS NOT NULL)` so we need to get rid of an extra `AND` in the beginning.