### PR TITLE
Fix mapping with embedded field with generic type

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2RepositorySpec.groovy
@@ -16,6 +16,9 @@
 package io.micronaut.data.jdbc.h2
 
 import groovy.transform.Memoized
+import io.micronaut.data.tck.entities.embedded.BookEntity
+import io.micronaut.data.tck.entities.embedded.BookState
+import io.micronaut.data.tck.entities.embedded.ResourceEntity
 import io.micronaut.data.tck.repositories.AuthorRepository
 import io.micronaut.data.tck.repositories.BasicTypesRepository
 import io.micronaut.data.tck.repositories.BookDtoRepository
@@ -112,6 +115,9 @@ class H2RepositorySpec extends AbstractRepositorySpec implements H2TestPropertyP
 
     @Shared
     H2EntityWithIdClass2Repository entityWithIdClass2Repo = context.getBean(H2EntityWithIdClass2Repository)
+
+    @Shared
+    H2BookEntityRepository bookEntityRepository = context.getBean(H2BookEntityRepository)
 
     @Override
     EntityWithIdClassRepository getEntityWithIdClassRepository() {
@@ -293,4 +299,12 @@ class H2RepositorySpec extends AbstractRepositorySpec implements H2TestPropertyP
         cleanupData()
     }
 
+    void "find by embedded entity field"() {
+        when:
+        def bookEntity = new BookEntity(1L, new ResourceEntity<BookState>("1984", BookState.BORROWED))
+        bookEntityRepository.save(bookEntity)
+        def result = bookEntityRepository.findAllByResourceState(BookState.BORROWED)
+        then:
+        result
+    }
 }

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2BookEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2BookEntityRepository.java
@@ -1,0 +1,9 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.embedded.BookEntityRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2BookEntityRepository extends BookEntityRepository {
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2HouseEntityRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/h2/H2HouseEntityRepository.java
@@ -1,0 +1,9 @@
+package io.micronaut.data.jdbc.h2;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.repositories.embedded.HouseEntityRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface H2HouseEntityRepository extends HouseEntityRepository {
+}

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -184,7 +184,8 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
             @Override
             public SourcePersistentEntity apply(ClassElement classElement) {
-                return entityMap.computeIfAbsent(classElement.getName(), s -> {
+                String classNameKey = getClassNameKey(classElement);
+                return entityMap.computeIfAbsent(classNameKey, s -> {
                     if (classElement.hasAnnotation("io.micronaut.data.annotation.Embeddable")) {
                         embeddedMappedEntityVisitor.visitClass(classElement, context);
                     } else {
@@ -753,6 +754,34 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
                     .member("jsonDataType", jsonDataType)
                     .member("column", column));
             }
+        }
+    }
+
+    /**
+     * Generates key for the entityMap using {@link ClassElement}.
+     * If class element has generic types then will use all bound generic types in the key like
+     * for example {@code Entity<CustomKeyType, CustomValueType>} and for non-generic class element
+     * will just return class name.
+     * This is needed when there are for example multiple embedded fields with the same type
+     * but different generic type argument.
+     *
+     * @param classElement The class element
+     * @return The key for entityMap created from the class element
+     */
+    private String getClassNameKey(ClassElement classElement) {
+        List<? extends ClassElement> boundGenericTypes = classElement.getBoundGenericTypes();
+        if (CollectionUtils.isNotEmpty(boundGenericTypes)) {
+            StringBuilder keyBuff = new StringBuilder(classElement.getName());
+            keyBuff.append("<");
+            for (ClassElement boundGenericType : boundGenericTypes) {
+                keyBuff.append(boundGenericType.getName());
+                keyBuff.append(",");
+            }
+            keyBuff.deleteCharAt(keyBuff.length() - 1);
+            keyBuff.append(">");
+            return keyBuff.toString();
+        } else {
+            return classElement.getName();
         }
     }
 }

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -1992,4 +1992,28 @@ interface TestRepository extends GenericRepository<Book, Long> {
         expect:
             getQuery(findByAuthorInListMethod) == "SELECT book_.`id`,book_.`author_id`,book_.`genre_id`,book_.`title`,book_.`total_pages`,book_.`publisher_id`,book_.`last_updated` FROM `book` book_ WHERE (book_.`author_id` IN (?))"
     }
+
+    void "test repository with reused embedded entity"() {
+        when:
+        buildRepository('test.TestRepository', """
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.repository.GenericRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.tck.entities.embedded.BookEntity;
+import io.micronaut.data.tck.entities.embedded.BookState;
+import io.micronaut.data.tck.entities.embedded.HouseEntity;
+import io.micronaut.data.tck.entities.embedded.HouseState;
+import java.util.List;
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface TestRepository extends GenericRepository<HouseEntity, Long> {
+    List<HouseEntity> findAllByResourceState(HouseState state);
+}
+@JdbcRepository(dialect = Dialect.POSTGRES)
+interface OtherRepository extends GenericRepository<BookEntity, Long> {
+    List<BookEntity> findAllByResourceState(BookState state);
+}
+""")
+        then:
+        noExceptionThrown()
+    }
 }

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BaseEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BaseEntity.java
@@ -1,0 +1,8 @@
+package io.micronaut.data.tck.entities.embedded;
+
+public interface BaseEntity<I, S extends Enum<S>> {
+
+    I id();
+
+    ResourceEntity<S> resource();
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BookEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BookEntity.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.tck.entities.embedded;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import jakarta.persistence.Embedded;
+
+@MappedEntity
+public record BookEntity(
+    @Id Long id,
+    @Embedded ResourceEntity<BookState> resource
+) implements BaseEntity<Long, BookState> {
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BookState.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/BookState.java
@@ -1,0 +1,7 @@
+package io.micronaut.data.tck.entities.embedded;
+
+public enum BookState {
+    BORROWED,
+    READ,
+    RETURNED
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/HouseEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/HouseEntity.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.tck.entities.embedded;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import jakarta.persistence.Embedded;
+
+@MappedEntity
+public record HouseEntity(
+    @Id Long id,
+    @Embedded ResourceEntity<HouseState> resource
+) implements BaseEntity<Long, HouseState> {
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/HouseState.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/HouseState.java
@@ -1,0 +1,6 @@
+package io.micronaut.data.tck.entities.embedded;
+
+public enum HouseState {
+    BUILDING,
+    FINISHED
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/ResourceEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/ResourceEntity.java
@@ -1,0 +1,17 @@
+package io.micronaut.data.tck.entities.embedded;
+
+import io.micronaut.data.annotation.Embeddable;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
+import jakarta.persistence.Convert;
+
+@Embeddable
+public record ResourceEntity<S extends Enum<S>>(
+
+    String displayName,
+
+    @TypeDef(type = DataType.STRING)
+    @Convert(converter = StateConverter.class)
+    S state
+) {
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/StateConverter.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/embedded/StateConverter.java
@@ -1,0 +1,37 @@
+package io.micronaut.data.tck.entities.embedded;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class StateConverter<Enum> implements AttributeConverter<java.lang.Enum, String> {
+
+    @Override
+    public String convertToDatabaseColumn(java.lang.Enum anEnum) {
+        if (anEnum == null) {
+            return null;
+        }
+        return anEnum.name();
+    }
+
+    @Override
+    public java.lang.Enum convertToEntityAttribute(String string) {
+        if (string == null) {
+            return null;
+        }
+        // Because enum generics in ResourceEntity then implement this
+        // simple converter just to be able to run tests
+        if (string.equals("BORROWED")) {
+            return BookState.BORROWED;
+        } else if (string.equals("READ")) {
+            return BookState.READ;
+        } else if (string.equals("RETURNED")) {
+            return BookState.RETURNED;
+        } else if (string.equals("BUILDING")) {
+            return HouseState.BUILDING;
+        } else if (string.equals("FINISHED")) {
+            return HouseState.FINISHED;
+        }
+        throw new IllegalStateException("Unexpected enum value: " + string);
+    }
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/embedded/BookEntityRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/embedded/BookEntityRepository.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.tck.repositories.embedded;
+
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.embedded.BookEntity;
+import io.micronaut.data.tck.entities.embedded.BookState;
+
+import java.util.List;
+
+public interface BookEntityRepository extends CrudRepository<BookEntity, Long> {
+
+    List<BookEntity> findAllByResourceState(BookState state);
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/embedded/HouseEntityRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/embedded/HouseEntityRepository.java
@@ -1,0 +1,12 @@
+package io.micronaut.data.tck.repositories.embedded;
+
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.embedded.HouseEntity;
+import io.micronaut.data.tck.entities.embedded.HouseState;
+
+import java.util.List;
+
+public interface HouseEntityRepository extends CrudRepository<HouseEntity, Long> {
+
+    List<HouseEntity> findAllByResourceState(HouseState state);
+}


### PR DESCRIPTION
Without this fix, compile error being thrown
> error: Unable to implement Repository method: H2BookEntityRepository.findAllByResourceState(BookState state). Parameter [io.micronaut.data.tck.entities.embedded.BookState state] is not compatible with property [io.micronaut.data.tck.entities.embedded.HouseState state] of entity: io.micronaut.data.tck.entities.embedded.ResourceEntity

Because `entityMap` used in `RepositoryTypeElementVisitor` uses `classElement.getName()` but when there is embedded class with generic type then the error happens so we need to make map key use type parameters as well.