### PR TITLE
Support CTE in raw query method matching

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
@@ -64,9 +64,9 @@ public class RawQueryMethodMatcher implements MethodMatcher {
     private static final String SELECT = "select";
     private static final String DELETE = "delete";
     private static final String UPDATE = "update";
-    private static final String RETURNING = " returning ";
     private static final String INSERT = "insert";
 
+    private static final Pattern RETURNING_PATTERN = Pattern.compile(".*\\breturning\\b.*");
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("([^:\\\\]*)((?<![:]):([a-zA-Z0-9]+))([^:]*)");
 
     @Override
@@ -176,12 +176,12 @@ public class RawQueryMethodMatcher implements MethodMatcher {
         if (query.startsWith(SELECT)) {
             return DataMethod.OperationType.QUERY;
         } else if (query.startsWith(DELETE)) {
-            if (query.contains(RETURNING)) {
+            if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.DELETE_RETURNING;
             }
             return DataMethod.OperationType.DELETE;
         } else if (query.startsWith(UPDATE)) {
-            if (query.contains(RETURNING)) {
+            if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.UPDATE_RETURNING;
             }
             if (DeleteMethodMatcher.METHOD_PATTERN.matcher(methodName.toLowerCase(Locale.ENGLISH)).matches()) {
@@ -189,7 +189,7 @@ public class RawQueryMethodMatcher implements MethodMatcher {
             }
             return DataMethod.OperationType.UPDATE;
         } else if (query.startsWith(INSERT)) {
-            if (query.contains(RETURNING)) {
+            if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.INSERT_RETURNING;
             }
             return DataMethod.OperationType.INSERT;

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
@@ -61,12 +61,11 @@ import java.util.regex.Pattern;
  */
 public class RawQueryMethodMatcher implements MethodMatcher {
 
-    private static final String SELECT = "select";
-    private static final String DELETE = "delete";
-    private static final String UPDATE = "update";
-    private static final String INSERT = "insert";
-
+    private static final Pattern UPDATE_PATTERN = Pattern.compile(".*\\bupdate\\b.*");
+    private static final Pattern DELETE_PATTERN = Pattern.compile(".*\\bdelete\\b.*");
+    private static final Pattern INSERT_PATTERN = Pattern.compile(".*\\binsert\\b.*");
     private static final Pattern RETURNING_PATTERN = Pattern.compile(".*\\breturning\\b.*");
+
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("([^:\\\\]*)((?<![:]):([a-zA-Z0-9]+))([^:]*)");
 
     @Override
@@ -173,14 +172,13 @@ public class RawQueryMethodMatcher implements MethodMatcher {
 
     private DataMethod.OperationType findOperationType(String methodName, String query, boolean readOnly) {
         query = query.trim().toLowerCase(Locale.ENGLISH);
-        if (query.startsWith(SELECT)) {
-            return DataMethod.OperationType.QUERY;
-        } else if (query.startsWith(DELETE)) {
+
+        if (DELETE_PATTERN.matcher(query).find()) {
             if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.DELETE_RETURNING;
             }
             return DataMethod.OperationType.DELETE;
-        } else if (query.startsWith(UPDATE)) {
+        } else if (UPDATE_PATTERN.matcher(query).find()) {
             if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.UPDATE_RETURNING;
             }
@@ -188,7 +186,7 @@ public class RawQueryMethodMatcher implements MethodMatcher {
                 return DataMethod.OperationType.DELETE;
             }
             return DataMethod.OperationType.UPDATE;
-        } else if (query.startsWith(INSERT)) {
+        } else if (INSERT_PATTERN.matcher(query).find()) {
             if (RETURNING_PATTERN.matcher(query).find()) {
                 return DataMethod.OperationType.INSERT_RETURNING;
             }


### PR DESCRIPTION
Add support of CTE for raw query method matching by no longer relying on the start key word of the SQL query but by checking the query against patterns

Fixes #1944 