### PR TITLE
Log debug instead of warn when introspected entity cannot be mapped and falls back to mongo deserialize

### DIFF
--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/AbstractMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/AbstractMongoRepositoryOperations.java
@@ -163,17 +163,12 @@ abstract sealed class AbstractMongoRepositoryOperations<Dtb> extends AbstractRep
         if (resultType == BsonDocument.class) {
             return (R) result;
         }
-        Optional<BeanIntrospection<R>> introspection = BeanIntrospector.SHARED.findIntrospection(resultType);
-        if (introspection.isPresent()) {
-            try {
-                return mapIntrospectedObject(result, resultType);
-            } catch (Exception e) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Failed to map @Introspection annotated result. " +
-                        "Now attempting to fallback and read object from the document. Error: {}", e.getMessage());
-                }
-            }
+
+        Optional<R> maybeConverted = convertUsingIntrospected(result, resultType);
+        if (maybeConverted.isPresent()) {
+            return maybeConverted.get();
         }
+
         BsonValue value;
         if (result == null) {
             value = BsonNull.VALUE;
@@ -198,6 +193,42 @@ abstract sealed class AbstractMongoRepositoryOperations<Dtb> extends AbstractRep
         return conversionService.convertRequired(MongoUtils.toValue(value), resultType);
     }
 
+    /**
+     * Attempts to convert a BSON document into an instance of the specified result type using introspection.
+     *
+     * If the result type has been annotated with `@Introspection`, this method will attempt to use the provided
+     * `BeanIntrospection` to map the BSON document onto an instance of the result type.
+     *
+     * If the mapping fails or if no `BeanIntrospection` is found for the result type, an empty `Optional` is returned.
+     *
+     * @param result      The BSON document containing the data to be mapped
+     * @param resultType  The type of the object being mapped
+     * @param <R>         The type parameter representing the result type
+     * @return An `Optional` containing the mapped object, or an empty `Optional` if mapping failed or no `BeanIntrospection` was found
+     */
+    protected <R> Optional<R> convertUsingIntrospected(BsonDocument result, Class<R> resultType) {
+        Optional<BeanIntrospection<R>> introspection = BeanIntrospector.SHARED.findIntrospection(resultType);
+        if (introspection.isPresent()) {
+            try {
+                return Optional.of(mapIntrospectedObject(result, resultType));
+            } catch (Exception e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to map @Introspection annotated result. " +
+                        "Now attempting to fallback and read object from the document. Error: {}", e.getMessage());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Maps an introspected object from a BSON document.
+     *
+     * @param result      The BSON document containing the data to be mapped
+     * @param resultType  The type of the object being mapped
+     * @param <R>         The type parameter representing the result type
+     * @return An instance of the specified result type, populated with data from the BSON document
+     */
     private <R> R mapIntrospectedObject(BsonDocument result, Class<R> resultType) {
         return (new BeanIntrospectionMapper<BsonDocument, R>() {
             @Override

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/AbstractMongoRepositoryOperations.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/operations/AbstractMongoRepositoryOperations.java
@@ -168,8 +168,10 @@ abstract sealed class AbstractMongoRepositoryOperations<Dtb> extends AbstractRep
             try {
                 return mapIntrospectedObject(result, resultType);
             } catch (Exception e) {
-                LOG.warn("Failed to map @Introspection annotated result. " +
-                    "Now attempting to fallback and read object from the document. Error: {}", e.getMessage());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to map @Introspection annotated result. " +
+                        "Now attempting to fallback and read object from the document. Error: {}", e.getMessage());
+                }
             }
         }
         BsonValue value;
@@ -178,9 +180,9 @@ abstract sealed class AbstractMongoRepositoryOperations<Dtb> extends AbstractRep
         } else if (result.size() == 1) {
             value = result.values().iterator().next();
         } else if (result.size() == 2) {
-            Optional<Map.Entry<String, BsonValue>> id = result.entrySet().stream().filter(f -> !f.getKey().equals("_id")).findFirst();
-            if (id.isPresent()) {
-                value = id.get().getValue();
+            Optional<Map.Entry<String, BsonValue>> nonIdValue = result.entrySet().stream().filter(f -> !f.getKey().equals("_id")).findFirst();
+            if (nonIdValue.isPresent()) {
+                value = nonIdValue.get().getValue();
             } else {
                 value = result.values().iterator().next();
             }

--- a/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoDocumentRepositorySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/document/mongodb/MongoDocumentRepositorySpec.groovy
@@ -10,8 +10,10 @@ import com.mongodb.client.model.Updates
 import groovy.transform.Memoized
 import io.micronaut.data.document.mongodb.entities.ComplexEntity
 import io.micronaut.data.document.mongodb.entities.ComplexValue
+import io.micronaut.data.document.mongodb.entities.Customer
 import io.micronaut.data.document.mongodb.entities.ElementRow
 import io.micronaut.data.document.mongodb.repositories.ComplexEntityRepository
+import io.micronaut.data.document.mongodb.repositories.CustomerRepository
 import io.micronaut.data.document.mongodb.repositories.ElementRowRepository
 import io.micronaut.data.document.mongodb.repositories.MongoAuthorRepository
 import io.micronaut.data.document.mongodb.repositories.MongoCriteriaPersonRepository
@@ -892,6 +894,23 @@ class MongoDocumentRepositorySpec extends AbstractDocumentRepositorySpec impleme
             people.collect{ it.id }.containsAll(limitedPeople2.collect{ it.id })
     }
 
+    void "test DTO retrieval"() {
+        when:
+        def customer = new Customer("1", "first", "last", List.of())
+        def saved = customerRepository.save(customer)
+        def loaded = customerRepository.findById(saved.id)
+        then:
+        loaded.present
+        loaded.get().id == saved.id
+        when:
+        def customerViews = customerRepository.viewFindAll();
+        then:
+        customerViews.size() == 1
+        customerViews[0].id == saved.id
+        cleanup:
+        customerRepository.deleteAll()
+    }
+
     @Memoized
     MongoExecutorPersonRepository getMongoExecutorPersonRepository() {
         return context.getBean(MongoExecutorPersonRepository)
@@ -958,5 +977,10 @@ class MongoDocumentRepositorySpec extends AbstractDocumentRepositorySpec impleme
     @Memoized
     ComplexEntityRepository getComplexEntityRepository() {
         return context.getBean(ComplexEntityRepository)
+    }
+
+    @Memoized
+    CustomerRepository getCustomerRepository() {
+        return context.getBean(CustomerRepository)
     }
 }

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/ChangeLog.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/ChangeLog.java
@@ -1,0 +1,4 @@
+package io.micronaut.data.document.mongodb.entities;
+
+public record ChangeLog(String message) {
+}

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/Customer.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/Customer.java
@@ -1,0 +1,60 @@
+package io.micronaut.data.document.mongodb.entities;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+import java.util.List;
+
+@MappedEntity
+public final class Customer {
+    @Id
+    @GeneratedValue
+    private String id;
+    private String firstName;
+    private String lastName;
+
+    private List<ChangeLog> changeLogs;
+
+    public Customer() {
+    }
+
+    public Customer(String id, String firstName, String lastName, List<ChangeLog> changeLogs) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.changeLogs = changeLogs;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public List<ChangeLog> getChangeLogs() {
+        return changeLogs;
+    }
+
+    public void setChangeLogs(List<ChangeLog> changeLogs) {
+        this.changeLogs = changeLogs;
+    }
+}

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/CustomerView.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/entities/CustomerView.java
@@ -1,0 +1,11 @@
+package io.micronaut.data.document.mongodb.entities;
+
+import io.micronaut.core.annotation.Introspected;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+import static org.bson.BsonType.OBJECT_ID;
+
+@Introspected
+public record CustomerView(@BsonId @BsonRepresentation(OBJECT_ID) String id, String firstName, String lastName) {
+}

--- a/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/CustomerRepository.java
+++ b/data-mongodb/src/test/java/io/micronaut/data/document/mongodb/repositories/CustomerRepository.java
@@ -1,0 +1,16 @@
+package io.micronaut.data.document.mongodb.repositories;
+
+import io.micronaut.data.document.mongodb.entities.Customer;
+import io.micronaut.data.document.mongodb.entities.CustomerView;
+import io.micronaut.data.mongodb.annotation.MongoFindQuery;
+import io.micronaut.data.mongodb.annotation.MongoRepository;
+import io.micronaut.data.repository.CrudRepository;
+
+import java.util.List;
+
+@MongoRepository
+public interface CustomerRepository extends CrudRepository<Customer, String> {
+
+    @MongoFindQuery(filter = "{}", project = "{ changeLogs: 0}")
+    List<CustomerView> viewFindAll();
+}


### PR DESCRIPTION
The reported [issue](https://github.com/micronaut-projects/micronaut-data/issues/3260) is not failing but just seeing logged warning. This PR keeps the same behavior added in https://github.com/micronaut-projects/micronaut-data/pull/2950, adds test from the issue and changes log from warn to debug.