### PR TITLE
Fix for runtime criteria containing multi level joins

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/PersistentEntityCommonAbstractCriteria.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/PersistentEntityCommonAbstractCriteria.java
@@ -33,7 +33,7 @@ public interface PersistentEntityCommonAbstractCriteria extends CommonAbstractCr
      * @param type The type
      * @param <U> The subquery type
      * @return A new subquery
-     * @see 4.10
+     * @since 4.10
      */
     <U> PersistentEntitySubquery<U> subquery(ExpressionType<U> type);
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -345,8 +345,7 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
                 }
             }
             if (CollectionUtils.isNotEmpty(joinPaths)) {
-                List<JoinPath> sortedJoinPaths = sortJoinPaths(joinPaths);
-                for (JoinPath joinPath : sortedJoinPaths) {
+                for (JoinPath joinPath : sortJoinPaths(joinPaths)) {
                     join(root, joinPath);
                 }
             }
@@ -387,8 +386,7 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
             }
         }
         if (CollectionUtils.isNotEmpty(joinPaths)) {
-            List<JoinPath> sortedJoinPaths = sortJoinPaths(joinPaths);
-            for (JoinPath joinPath : sortedJoinPaths) {
+            for (JoinPath joinPath : sortJoinPaths(joinPaths)) {
                 join(root, joinPath);
             }
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/criteria/AbstractSpecificationInterceptor.java
@@ -62,6 +62,8 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -343,7 +345,8 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
                 }
             }
             if (CollectionUtils.isNotEmpty(joinPaths)) {
-                for (JoinPath joinPath : joinPaths) {
+                List<JoinPath> sortedJoinPaths = sortJoinPaths(joinPaths);
+                for (JoinPath joinPath : sortedJoinPaths) {
                     join(root, joinPath);
                 }
             }
@@ -384,7 +387,8 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
             }
         }
         if (CollectionUtils.isNotEmpty(joinPaths)) {
-            for (JoinPath joinPath : joinPaths) {
+            List<JoinPath> sortedJoinPaths = sortJoinPaths(joinPaths);
+            for (JoinPath joinPath : sortedJoinPaths) {
                 join(root, joinPath);
             }
         }
@@ -588,4 +592,9 @@ public abstract class AbstractSpecificationInterceptor<T, R> extends AbstractQue
         COUNT, FIND_ONE, FIND_PAGE, FIND_ALL, DELETE_ALL, UPDATE_ALL, EXISTS
     }
 
+    private List<JoinPath> sortJoinPaths(Collection<JoinPath> joinPaths) {
+        List<JoinPath> sortedJoinPaths = new ArrayList<>(joinPaths);
+        sortedJoinPaths.sort((o1, o2) -> Comparator.comparingInt(String::length).thenComparing(String::compareTo).compare(o1.getPath(), o2.getPath()));
+        return sortedJoinPaths;
+    }
 }

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractRepositorySpec.groovy
@@ -2004,16 +2004,19 @@ abstract class AbstractRepositorySpec extends Specification {
         def book1 = author.getBooks().find { book -> book.title == "Book1" }
         def book2 = author.getBooks().find { book -> book.title == "Book2" }
         def book3 = author.getBooks().find { book -> book.title == "Book3" }
+        def book1pages = book1.pages.sort {it -> it.num}
+        def book2pages = book2.pages.sort {it -> it.num}
+        def book3pages = book3.pages.sort {it -> it.num}
         author.books.size() == 3 &&
                 book1.pages.size() == 1 &&
-                book1.pages[0].num == 1 &&
-                book2.pages.size() == 2 &&
-                book2.pages[0].num == 21 &&
-                book2.pages[1].num == 22 &&
-                book3.pages.size() == 3 &&
-                book3.pages[0].num == 31 &&
-                book3.pages[1].num == 32 &&
-                book3.pages[2].num == 33
+                book1pages[0].num == 1 &&
+                book2pages.size() == 2 &&
+                book2pages[0].num == 21 &&
+                book2pages[1].num == 22 &&
+                book3pages.size() == 3 &&
+                book3pages[0].num == 31 &&
+                book3pages[1].num == 32 &&
+                book3pages[2].num == 33
     }
 
     void "test one-to-one mappedBy"() {

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
@@ -155,7 +155,10 @@ public interface AuthorRepository extends CrudRepository<Author, Long>, JpaSpeci
         """)
     List<Author> findAllByNameCustom(String name);
 
-    class Specifications {
+    final class Specifications {
+
+        private Specifications() {
+        }
 
         static PredicateSpecification<Author> authorNameEquals(String name) {
             return (root, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);

--- a/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/repositories/AuthorRepository.java
@@ -26,6 +26,9 @@ import io.micronaut.data.model.CursoredPageable;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.repository.jpa.JpaSpecificationExecutor;
+import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
+import io.micronaut.data.repository.jpa.criteria.QuerySpecification;
 import io.micronaut.data.tck.entities.Author;
 
 import io.micronaut.core.annotation.Nullable;
@@ -37,7 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public interface AuthorRepository extends CrudRepository<Author, Long> {
+public interface AuthorRepository extends CrudRepository<Author, Long>, JpaSpecificationExecutor<Author> {
 
     @Join(value = "books", type = Join.Type.LEFT_FETCH)
     Author queryByName(String name);
@@ -47,6 +50,19 @@ public interface AuthorRepository extends CrudRepository<Author, Long> {
     @Join(value = "books", alias = "b", type = Join.Type.LEFT_FETCH)
     @Join(value = "books.pages", alias = "bp", type = Join.Type.LEFT_FETCH)
     Optional<Author> findById(@NonNull @NotNull Long aLong);
+
+    @Override
+    @Join(value = "books.pages", alias = "bp", type = Join.Type.LEFT_FETCH)
+    @Join(value = "books", alias = "b", type = Join.Type.LEFT_FETCH)
+    Optional<Author> findOne(PredicateSpecification<Author> specification);
+
+    @Override
+    @Join(value = "books.pages", alias = "bp", type = Join.Type.LEFT_FETCH)
+    List<Author> findAll(PredicateSpecification<Author> specification);
+
+    @Override
+    @Join(value = "books.pages", type = Join.Type.LEFT_FETCH)
+    Optional<Author> findOne(QuerySpecification<Author> specification);
 
     Author findByName(String name);
 
@@ -138,4 +154,15 @@ public interface AuthorRepository extends CrudRepository<Author, Long> {
         WHERE author_.name = :name
         """)
     List<Author> findAllByNameCustom(String name);
+
+    class Specifications {
+
+        static PredicateSpecification<Author> authorNameEquals(String name) {
+            return (root, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);
+        }
+
+        static QuerySpecification<Author> authorIdEquals(Long id) {
+            return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("id"), id);
+        }
+    }
 }


### PR DESCRIPTION
Fix for [issue](https://github.com/micronaut-projects/micronaut-data/issues/3304) with nested path joins used in `JpaSpeficifationExecutor` methods.