### PR TITLE
Repositories referencing classes that are not yet generated fail compilation

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -73,6 +73,7 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.ElementPostponedToNextRoundException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -321,6 +322,11 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
                 context.fail(matchContext.getUnableToImplementMessage() + e.getMessage(), e.getElement() == null ? element : e.getElement());
                 this.failing = true;
             } catch (Exception e) {
+                if (e.getClass().getSimpleName().equals("PostponeToNextRoundException")) {
+                    // rethrow postponed and don't fail compilation
+                    // this is not ideal since PostponeToNextRoundException is part of inject-java
+                    throw e;
+                }
                 matchContext.fail(e.getMessage());
                 this.failing = true;
             }

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -322,7 +322,7 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
                 context.fail(matchContext.getUnableToImplementMessage() + e.getMessage(), e.getElement() == null ? element : e.getElement());
                 this.failing = true;
             } catch (Exception e) {
-                if (e.getClass().getSimpleName().equals("PostponeToNextRoundException")) {
+                if (e instanceof ElementPostponedToNextRoundException || e.getClass().getSimpleName().equals("PostponeToNextRoundException")) {
                     // rethrow postponed and don't fail compilation
                     // this is not ideal since PostponeToNextRoundException is part of inject-java
                     throw e;


### PR DESCRIPTION
RepositoryTypeElementVisitor doesn't correctly handle PostponeToNextRoundException though it is unclear how this should be handled because the exception exists only in inject-java

This fix feels like a hack. Not sure what the alternative is.