### PR TITLE
Improve the Oracle client info propagation feature.

### DIFF
--- a/data-connection-jdbc/src/main/java/io/micronaut/data/connection/jdbc/oracle/OracleClientInfoConnectionCustomizer.java
+++ b/data-connection-jdbc/src/main/java/io/micronaut/data/connection/jdbc/oracle/OracleClientInfoConnectionCustomizer.java
@@ -25,6 +25,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.data.connection.ConnectionDefinition;
@@ -67,26 +68,20 @@ final class OracleClientInfoConnectionCustomizer implements ConnectionCustomizer
     private static final String VALUE_MEMBER = "value";
     private static final String INTERCEPTED_SUFFIX = "$Intercepted";
 
-    /**
-     * Constant for the Oracle connection client info client ID property name.
-     */
     private static final String ORACLE_CLIENT_ID = "OCSID.CLIENTID";
-    /**
-     * Constant for the Oracle connection client info module property name.
-     */
     private static final String ORACLE_MODULE = "OCSID.MODULE";
-    /**
-     * Constant for the Oracle connection client info action property name.
-     */
     private static final String ORACLE_ACTION = "OCSID.ACTION";
-    /**
-     * Constant for the Oracle connection database product name.
-     */
+    private static final String ORACLE_CLIENT_INFO = "OCSID.CLIENT_INFO";
     private static final String ORACLE_CONNECTION_DATABASE_PRODUCT_NAME = "Oracle";
 
     private static final Logger LOG = LoggerFactory.getLogger(OracleClientInfoConnectionCustomizer.class);
 
     private static final Map<Class<?>, String> MODULE_CLASS_MAP = new ConcurrentHashMap<>(100);
+
+    // The driver is supposed to expose this via DataBaseMetadata.getClientInfoProperties() but the Oracle driver
+    // doesn't do so as of release 23.7.0.25.1, so we hard-code it here. This bug is being fixed so a future
+    // release will supply the correct information.
+    private static final int MAX_VALUE_LENGTH = 64;
 
     @Nullable
     private final String applicationName;
@@ -105,6 +100,20 @@ final class OracleClientInfoConnectionCustomizer implements ConnectionCustomizer
         }
     }
 
+    private static String truncate(String name, String value) {
+        if (value.length() > MAX_VALUE_LENGTH) {
+            LOG.trace("Truncating client info value '{}' for {} as it is longer than {} chars", value, name, MAX_VALUE_LENGTH);
+            return value.substring(0, MAX_VALUE_LENGTH);
+        } else {
+            return value;
+        }
+    }
+
+    private static String preprocessClassName(Class<?> clazz) {
+        // Oracle imposes a limit of 64 chars on class names, and we can easily blow through that.
+        return NameUtils.getShortenedName(clazz.getName().replace(INTERCEPTED_SUFFIX, ""));
+    }
+
     @Override
     public <R> Function<ConnectionStatus<Connection>, R> intercept(Function<ConnectionStatus<Connection>, R> operation) {
         return connectionStatus -> {
@@ -118,22 +127,21 @@ final class OracleClientInfoConnectionCustomizer implements ConnectionCustomizer
                 // Clear client info for connection if it was Oracle connection and client info was set previously
                 clearClientInfo(connectionStatus, connectionClientInfo);
             }
-
         };
     }
 
     private void applyClientInfo(@NonNull ConnectionStatus<Connection> connectionStatus, @NonNull Map<String, String> connectionClientInfo) {
         if (CollectionUtils.isNotEmpty(connectionClientInfo)) {
             Connection connection = connectionStatus.getConnection();
-            LOG.trace("Setting connection tracing info to the Oracle connection");
             try {
                 for (Map.Entry<String, String> additionalInfo : connectionClientInfo.entrySet()) {
                     String name = additionalInfo.getKey();
-                    String value = additionalInfo.getValue();
+                    // Oracle imposes a limit of 64 chars on class names, and we can easily blow through that.
+                    String value = truncate(name, additionalInfo.getValue());
                     connection.setClientInfo(name, value);
                 }
             } catch (SQLClientInfoException e) {
-                LOG.debug("Failed to set connection tracing info", e);
+                LOG.warn("Failed to set connection tracing info: {}", connectionClientInfo, e);
             }
         }
     }
@@ -191,11 +199,14 @@ final class OracleClientInfoConnectionCustomizer implements ConnectionCustomizer
         }
         if (annotationMetadata instanceof MethodInvocationContext<?, ?> methodInvocationContext) {
             clientInfoAttributes.putIfAbsent(ORACLE_MODULE,
-                MODULE_CLASS_MAP.computeIfAbsent(methodInvocationContext.getTarget().getClass(),
-                    clazz -> clazz.getName().replace(INTERCEPTED_SUFFIX, ""))
+                MODULE_CLASS_MAP.computeIfAbsent(
+                    methodInvocationContext.getTarget().getClass(),
+                    OracleClientInfoConnectionCustomizer::preprocessClassName
+                )
             );
             clientInfoAttributes.putIfAbsent(ORACLE_ACTION, methodInvocationContext.getName());
         }
+        clientInfoAttributes.putIfAbsent(ORACLE_CLIENT_INFO, Thread.currentThread().getName());
         return clientInfoAttributes;
     }
 }

--- a/src/main/docs/guide/dbc/jdbc/jdbcConfiguration.adoc
+++ b/src/main/docs/guide/dbc/jdbc/jdbcConfiguration.adoc
@@ -61,22 +61,36 @@ As seen in the configuration above you should also configure the dialect. Althou
 
 IMPORTANT: The dialect setting in configuration does *not* replace the need to ensure the correct dialect is set at the repository. If the dialect is H2 in configuration, the repository should have `@JdbcRepository(dialect = Dialect.H2)` / `@R2dbcRepository(dialect = Dialect.H2)`. Because repositories are computed at compile time, the configuration value is not known at that time.
 
-=== Connection client info tracing
+=== Tracing calls from Java to Oracle Database sessions
 
-In order to trace SQL calls using `java.sql.Connection.setClientInfo(String, String)` method, you can
-annotate a repository with the ann:data.connection.annotation.ClientInfo[] annotation or ann:data.connection.annotation.ClientInfo.Attribute[] for individual client info.
+Specify the configuration property `datasources.<datasource-name>.enable-oracle-client-info=true` on a per datasource basis to link database sessions with Java thread activity. By default, this will set:
 
-Note that the ann:data.connection.annotation.ClientInfo.Attribute[] annotation can be used on either the class or the method, thus allowing customization of the  module or action individually.
+- The value of `micronaut.application.name` as the `CLIENTID`.
+- The class/interface name of the repository as the `MODULE`, potentially with the package name shortened.
+- The method name from the repository as the `ACTION`.
+- The JVM thread name as the `CLIENT_INFO`.
 
-For Oracle database, following attributes can be set to the connection client info: `OCSID.MODULE`, `OCSID.ACTION` and `OCSID.CLIENTID` and provided in ann:data.connection.annotation.ClientInfo.Attribute[].
-If some of these attributes are not provided then Micronaut Data Jdbc is going to populate values automatically for Oracle connections:
+This metadata appears in the `V$SESSION` view and can be used to figure out what a thread is doing inside the database. The following query is useful to see what SQL is executing:
 
-*** `OCSID.MODULE` will get the value of the class name where annotation `@ClientInfo.Attribute` is added (usually Micronaut Data repository class)
-*** `OCSID.ACTION` will get the value of the method name which is annotated with `@ClientInfo.Attribute` annotation
-*** `OCSID.CLIENTID` will get the value of the Micronaut application name, if configured
+[source,sql]
+----
+SELECT
+    s.sid,
+    s.serial#,
+    s.client_identifier as app_name,
+    s.client_info as thread_name,
+    s.module as repository_name,
+    s.action as repository_method,
+    q.sql_text,
+    s.event,
+    s.wait_time,
+    s.seconds_in_wait
+FROM v$session s
+LEFT JOIN v$sql q ON s.sql_id = q.sql_id
+WHERE s.username = USER
+----
 
-Please note this feature is currently supported only for Oracle database connections. In order to enable Oracle JDBC connection client info to be set,
-you need to specify the configuration property `datasources.<datasource-name>.enable-oracle-client-info=true` on a per datasource basis.
+You can control the values of `ACTION`, `MODULE`, `CLIENTID` and `CLIENT_INFO` with the ann:data.connection.annotation.ClientInfo[] annotation on repositories. Note that the ann:data.connection.annotation.ClientInfo.Attribute[] annotation can be used on either the class or the method, thus allowing customization of the  module or action individually. You should prefix the key with `OCSID.` e.g. `OCSID.ACTION` when setting client info this way. Oracle imposes a maximum length of 64 characters for these values, therefore thread, class and method names may be shortened or truncated to fit.
 
 TIP: See the guide for https://guides.micronaut.io/latest/micronaut-data-jdbc-repository.html[Access a Database with Micronaut Data JDBC] to learn more.
 


### PR DESCRIPTION
1. Fix an exception that could occur if class/module names were too long.
2. Propagate the Java thread name as the action if none is set from annotation metadata.
3. Add a useful utility query to the documentation.