### PR TITLE
Fix regression issues

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/CursoredPage.java
@@ -129,7 +129,7 @@ public interface CursoredPage<T> extends Page<T> {
             return (CursoredPage<T2>) EMPTY;
         }
         List<T2> content = getContent().stream().map(function).collect(Collectors.toList());
-        return new DefaultCursoredPage<>(content, getPageable(), getCursors(), hasTotalSize() ? getTotalSize() : null);
+        return new DefaultCursoredPage<>(content, getPageable(), getCursors(), hasTotalSize() ? getTotalSize() : -1);
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder2.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder2.java
@@ -55,6 +55,8 @@ import io.micronaut.data.model.schema.sql.SqlSequenceMapping;
 import io.micronaut.data.model.schema.sql.SqlTableMapping;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Selection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -103,6 +105,8 @@ public class SqlQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 {
     private static final String JDBC_REPO_ANNOTATION = "io.micronaut.data.jdbc.annotation.JdbcRepository";
     private static final String DIALECT_ATTR = "dialect";
     private static final String REFERENCED_COLUMN_NAME = "referencedColumnName";
+
+    private static final Logger LOG = LoggerFactory.getLogger(SqlQueryBuilder2.class);
 
     private final Dialect dialect;
     private final Map<Dialect, DialectConfig> perDialectConfig = new EnumMap<>(Dialect.class);
@@ -352,17 +356,7 @@ public class SqlQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 {
                 addToCollectionIfNotContains(createStatements, createSchemaStatement);
             }
             for (SqlTableMapping table : tables) {
-                if (sqlTableMappingByTableName.containsKey(table.name())) {
-                    SqlTableMapping existingSqlTableMapping = sqlTableMappingByTableName.get(table.name());
-                    if (existingSqlTableMapping.type() == SqlTableMapping.TableType.JOIN) {
-                        // Remove ad-hoc join table created from one of the entities relation mappings and not an actual entity
-                        sqlTableMappingByTableName.remove(table.name());
-                    } else if (table.type() == SqlTableMapping.TableType.JOIN) {
-                        // Skip this table mapping ad-hoc join table created from one of the entities relation mappings and not an actual entity
-                        continue;
-                    }
-                }
-                sqlTableMappingByTableName.put(table.name(), table);
+                addTable(table, sqlTableMappingByTableName);
             }
         }
 
@@ -373,6 +367,28 @@ public class SqlQueryBuilder2 extends AbstractSqlLikeQueryBuilder2 {
         }
 
         return createStatements.toArray(new String[0]);
+    }
+
+    private void addTable(SqlTableMapping table, Map<String, SqlTableMapping> sqlTableMappingByTableName) {
+        boolean addTable = true;
+        if (sqlTableMappingByTableName.containsKey(table.name())) {
+            SqlTableMapping existingSqlTableMapping = sqlTableMappingByTableName.get(table.name());
+            if (table.type() == existingSqlTableMapping.type()) {
+                if (LOG.isWarnEnabled() && table.type() == SqlTableMapping.TableType.MAIN) {
+                    LOG.warn("Table with name {} has more than one mapped entity. Will use table {}", table.name(), existingSqlTableMapping);
+                }
+                addTable = false;
+            } else if (existingSqlTableMapping.type() == SqlTableMapping.TableType.JOIN) {
+                // Remove ad-hoc join table created from one of the entities relation mappings and not an actual entity
+                sqlTableMappingByTableName.remove(table.name());
+            } else if (table.type() == SqlTableMapping.TableType.JOIN) {
+                // Skip this table mapping ad-hoc join table created from one of the entities relation mappings and not an actual entity
+                addTable = false;
+            }
+        }
+        if (addTable) {
+            sqlTableMappingByTableName.put(table.name(), table);
+        }
     }
 
     private void addTableCreateStatements(List<String> createStatements, SqlTableMapping table, String schema, boolean escape) {

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractCursoredPageSpec.groovy
@@ -280,6 +280,20 @@ abstract class AbstractCursoredPageSpec extends Specification {
         then:
         page.getContent().size() == books.size()
         page.getTotalSize() == books.size()
+        def pageOfTitles = page.map { it.title }
+        pageOfTitles.hasTotalSize()
+        def titles = pageOfTitles.content
+        titles.contains("Book 1") && titles.contains("Book 2")
+
+        when:"Try to fetch next (last) page"
+        page = bookRepository.findAll(page.nextPageable().withoutTotal())
+        pageOfTitles = page.map { it.title }
+        !pageOfTitles.hasTotalSize()
+        titles = pageOfTitles.content
+
+        then:"Next page fetch returns empty result"
+        noExceptionThrown()
+        titles.empty
 
         cleanup:
         bookRepository.deleteAll()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.9.3"
+micronaut = "4.9.4"
 micronaut-platform = "4.8.3"
 micronaut-docs = "2.0.0"
 micronaut-gradle-plugin = "4.5.3"


### PR DESCRIPTION
Got issue with `CursoredPageable` when `requestTotal = false()` since constructor accepts `long` since 4.13.0 changes and when passed `null` throws `NullPointerException`
Also added some logging when more than one mapped entity with the same table name is present. The behavior will be the same as pre 4.13.0 (first populated table SQL would be created), just add warn logging in this case.