### PR TITLE
Fix potential NPE with null total size value

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
+++ b/data-model/src/main/java/io/micronaut/data/model/DefaultPage.java
@@ -34,6 +34,8 @@ import java.util.Objects;
 @Serdeable
 class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
 
+    static final long NO_TOTAL_SIZE = -1L;
+
     private final long totalSize;
 
     /**
@@ -53,12 +55,12 @@ class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
             @JsonProperty("totalSize")
             Long totalSize) {
         super(content, pageable);
-        this.totalSize = totalSize;
+        this.totalSize = totalSize != null ? totalSize : NO_TOTAL_SIZE;
     }
 
     @Override
     public boolean hasTotalSize() {
-        return totalSize != -1L;
+        return totalSize != NO_TOTAL_SIZE;
     }
 
     @Override

--- a/data-model/src/test/groovy/io/micronaut/data/model/DefaultPageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/DefaultPageSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model
+
+import spock.lang.Specification
+
+import static io.micronaut.data.model.DefaultPage.NO_TOTAL_SIZE
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Unroll
+
+@MicronautTest
+class DefaultPageSpec extends Specification {
+
+    @Unroll
+    void "test default page creation with content #content, pageable #pageable and total size #totalSize"() {
+        given:
+        def page = new DefaultPage<String>(content, pageable, totalSize)
+
+        expect:
+        page.content == content
+        page.hasTotalSize() == (expectedTotalSize > NO_TOTAL_SIZE)
+        page.size == pageable.size
+        page.totalSize == expectedTotalSize
+
+        where:
+        content     | pageable              | totalSize     | expectedTotalSize
+        ["test"]    | Pageable.from(1)      | 10            | 10
+        ["test"]    | Pageable.from(1)      | null          | NO_TOTAL_SIZE
+    }
+}


### PR DESCRIPTION
Address the bug outlined in https://github.com/micronaut-projects/micronaut-data/issues/3462.  

This PR adds a null check to the `totalSize` in  the `DefaultPage` constructor and if null, sets the total size to the no size value (-1).  This should address a potential NPE caused when a pageable with offset and no total is used.