### PR TITLE
doc: fix Jakarta Data artifact Id

### DIFF
--- a/src/main/docs/guide/shared/jakartaData.adoc
+++ b/src/main/docs/guide/shared/jakartaData.adoc
@@ -5,7 +5,7 @@ Micronaut Data provides implementation support for the https://jakarta.ee/specif
 ## Configuration
 To use Jakarta Data annotations in your Micronaut project, ensure you have the following dependency:
 
-dependency:jakarta.data:jakarta-data-api[]
+dependency:jakarta.data:jakarta.data-api[]
 
 ## Key features
 


### PR DESCRIPTION
Apparently there was a release with artifact id `jakarta-data-api` https://central.sonatype.com/artifact/jakarta.data/jakarta-data-api: 

but the correct one seems to be: 
https://central.sonatype.com/artifact/jakarta.data/jakarta.data-api

A user submitted a PR to starter: https://github.com/micronaut-projects/micronaut-starter/pull/2828