### PR TITLE
Update AbstractReactorTransactionOperations to handle publisher creation exceptions

### DIFF
--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
@@ -332,12 +332,20 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     @NonNull
     private Publisher<Void> doCommit(@NonNull DefaultReactiveTransactionStatus<C> status) {
         Flux<Void> op;
-        if (status.isRollbackOnly()) {
-            op = Flux.from(rollbackTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
-        } else {
-            op = Flux.from(commitTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
-        }
-        return op.as(flux -> doFinish(flux, status));
+		try {
+			if (status.isRollbackOnly()) {
+				op = Flux.from(rollbackTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
+			} else {
+				op = Flux.from(commitTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
+			}
+		} catch (Exception e) {
+			// Sometimes an exception can be thrown creating the publishers for rollback or commit.
+			// An example of this, is if the connection has been closed prematurely by the DBMS.
+			// We should ensure we always return a Publisher to allow downstream consumers to properly
+			// detect and handle these type of errors.
+			op = Flux.error(e);
+		}
+		return op.as(flux -> doFinish(flux, status));
     }
 
     @NonNull
@@ -346,12 +354,20 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
             LOG.warn("Rolling back transaction on error: " + throwable.getMessage(), throwable);
         }
         Flux<Void> abort;
-        TransactionDefinition definition = status.getTransactionDefinition();
-        if (definition.rollbackOn(throwable)) {
-            abort = Flux.from(rollbackTransaction(status.getConnectionStatus(), definition));
-        } else {
-            abort = Flux.error(throwable);
-        }
+		try {
+			TransactionDefinition definition = status.getTransactionDefinition();
+			if (definition.rollbackOn(throwable)) {
+				abort = Flux.from(rollbackTransaction(status.getConnectionStatus(), definition));
+			} else {
+				abort = Flux.error(throwable);
+			}
+		} catch (Exception e) {
+			// Sometimes an exception can be thrown creating the publishers for rollback or commit.
+			// An example of this, is if the connection has been closed prematurely by the DBMS.
+			// We should ensure we always return a Publisher to allow downstream consumers to properly
+			// detect and handle these type of errors.
+			abort = Flux.error(e);
+		}
         return abort.onErrorResume((rollbackError) -> {
             if (rollbackError != throwable && LOG.isWarnEnabled()) {
                 LOG.warn("Error occurred during transaction rollback: " + rollbackError.getMessage(), rollbackError);


### PR DESCRIPTION
fix: Ensure publisher returned when committing or rollback

When an exception is raised while creating the Publisher for the commit/rollback operations, the error was not propagated downstream. Add defensive code to return an error-publisher instead of allowing the exception to bubble to reactors default un-handled exception handler.