### PR TITLE
Pass EntityEventContext to getApplicableProperties so subclasses can access the current property values

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,6 +61,7 @@ jobs:
           [ -f ./setup.sh ] && ./setup.sh || [ ! -f ./setup.sh ]
 
       - name: "🚔 Sonatype Scan"
+        if: env.OSS_INDEX_PASSWORD != '' && matrix.java == '17'
         id: sonatypescan
         run: |
           ./gradlew ossIndexAudit --no-parallel --info

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -21,5 +21,4 @@ dependencies {
     implementation libs.gradle.spring.boot
     implementation libs.gradle.spring.dependencies
     implementation libs.gradle.shadow
-    implementation(libs.sonatype.scan)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.data-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.data-module.gradle
@@ -1,16 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.data-base"
     id "io.micronaut.build.internal.module"
-    id("org.sonatype.gradle.plugins.scan")
-}
-String ossIndexUsername = System.getenv("OSS_INDEX_USERNAME") ?: project.properties["ossIndexUsername"]
-String ossIndexPassword = System.getenv("OSS_INDEX_PASSWORD") ?: project.properties["ossIndexPassword"]
-boolean sonatypePluginConfigured = ossIndexUsername != null && ossIndexPassword != null
-if (sonatypePluginConfigured) {
-    ossIndexAudit {
-        username = ossIndexUsername
-        password = ossIndexPassword
-    }
 }
 dependencies {
     testRuntimeOnly mnSerde.micronaut.serde.jackson

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListener.java
@@ -17,6 +17,7 @@ package io.micronaut.data.runtime.event.listeners;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.data.event.EntityEventContext;
 import io.micronaut.data.event.EntityEventListener;
 import io.micronaut.data.model.PersistentProperty;
 import io.micronaut.data.model.runtime.RuntimePersistentEntity;
@@ -86,9 +87,21 @@ public abstract class AutoPopulatedEntityEventListener implements EntityEventLis
 
     /**
      * Returns the applicable properties for this listener.
+     * @param context The context
+     * @return the properties
+     * @since 4.14
+     */
+    protected @NonNull RuntimePersistentProperty<Object>[] getApplicableProperties(EntityEventContext<Object> context) {
+        return getApplicableProperties(context.getPersistentEntity());
+    }
+
+    /**
+     * Returns the applicable properties for this listener.
      * @param entity The entity
      * @return the properties
+     * @deprecated Use {@link #getApplicableProperties(EntityEventContext)} instead
      */
+    @Deprecated(forRemoval = true)
     protected @NonNull RuntimePersistentProperty<Object>[] getApplicableProperties(RuntimePersistentEntity<Object> entity) {
         final RuntimePersistentProperty<Object>[] properties = applicableProperties.get(entity);
         if (properties != null) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoTimestampEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoTimestampEntityEventListener.java
@@ -108,7 +108,7 @@ public class AutoTimestampEntityEventListener extends AutoPopulatedEntityEventLi
     }
 
     private void autoTimestampIfNecessary(@NonNull EntityEventContext<Object> context, boolean isUpdate) {
-        final RuntimePersistentProperty<Object>[] applicableProperties = getApplicableProperties(context.getPersistentEntity());
+        final RuntimePersistentProperty<Object>[] applicableProperties = getApplicableProperties(context);
         Object now = dateTimeProvider.getNow();
         for (RuntimePersistentProperty<Object> property : applicableProperties) {
             if (isUpdate) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/TenantIdEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/TenantIdEntityEventListener.java
@@ -74,7 +74,7 @@ public class TenantIdEntityEventListener extends AutoPopulatedEntityEventListene
 
     @Override
     public boolean prePersist(@NonNull EntityEventContext<Object> context) {
-        for (RuntimePersistentProperty<Object> property : getApplicableProperties(context.getPersistentEntity())) {
+        for (RuntimePersistentProperty<Object> property : getApplicableProperties(context)) {
             if (property.getAnnotationMetadata().hasStereotype(TenantId.class)) {
                 if (property.getProperty().get(context.getEntity()) != null) {
                     // Skip existing value

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/UUIDGeneratingEntityEventListener.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/UUIDGeneratingEntityEventListener.java
@@ -52,7 +52,7 @@ public class UUIDGeneratingEntityEventListener extends AutoPopulatedEntityEventL
 
     @Override
     public boolean prePersist(@NonNull EntityEventContext<Object> context) {
-        final RuntimePersistentProperty<Object>[] persistentProperties = getApplicableProperties(context.getPersistentEntity());
+        final RuntimePersistentProperty<Object>[] persistentProperties = getApplicableProperties(context);
         for (RuntimePersistentProperty<Object> persistentProperty : persistentProperties) {
             final BeanProperty<Object, Object> property = persistentProperty.getProperty();
             context.setProperty(property, UUID.randomUUID());

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListenerSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/event/listeners/AutoPopulatedEntityEventListenerSpec.groovy
@@ -1,0 +1,111 @@
+package io.micronaut.data.runtime.event.listeners
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.data.annotation.AutoPopulated
+import io.micronaut.data.annotation.DateCreated
+import io.micronaut.data.annotation.DateUpdated
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.event.PrePersist
+import io.micronaut.data.event.EntityEventContext
+import io.micronaut.data.model.PersistentEntity
+import io.micronaut.data.model.runtime.RuntimePersistentProperty
+import io.micronaut.data.runtime.convert.DataConversionService
+import io.micronaut.data.runtime.date.DateTimeProvider
+import io.micronaut.data.runtime.event.DefaultEntityEventContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.Instant
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "AutoPopulatedEntityEventListenerSpec")
+class AutoPopulatedEntityEventListenerSpec extends Specification {
+
+    @Inject
+    TestAutoPopulatedEntityEventListener entityEventListener
+
+    void "test values are generated when previous values are null"() {
+        given:
+            def entity = new TestEntity(id: UUID.randomUUID(), legacyCreateTime: null, createTime: null, updateTime: null)
+            def eventContext = new DefaultEntityEventContext(PersistentEntity.of(TestEntity), entity)
+            entityEventListener.supports(eventContext.getPersistentEntity(), PrePersist)
+        when:
+            entityEventListener.prePersist(eventContext)
+        then:
+            entity.legacyCreateTime != null
+            entity.createTime != null
+            entity.updateTime != null
+    }
+
+    void "test DateCreated values are generated when previous values are null and DateUpdated is always generated"() {
+        given:
+            def legacyCreateTime = Instant.now().minusSeconds(200)
+            def originalUpdateTime = Instant.now().minusSeconds(100)
+            def entity = new TestEntity(id: UUID.randomUUID(), legacyCreateTime: legacyCreateTime, createTime: null, updateTime: originalUpdateTime)
+            def eventContext = new DefaultEntityEventContext(PersistentEntity.of(TestEntity), entity)
+            entityEventListener.supports(eventContext.getPersistentEntity(), PrePersist)
+        when:
+            entityEventListener.prePersist(eventContext)
+        then:
+            entity.legacyCreateTime == legacyCreateTime
+            entity.createTime != null
+            entity.updateTime != null && entity.updateTime != originalUpdateTime
+    }
+
+    @MappedEntity
+    static class TestEntity {
+        @Id
+        @AutoPopulated
+        UUID id;
+
+        @DateCreated
+        Instant legacyCreateTime;
+
+        @DateCreated
+        Instant createTime;
+
+        @DateUpdated
+        Instant updateTime;
+    }
+
+    /**
+     * An event listener which works like AutoTimestampEntityEventListener but keeps non-null values
+     * for fields with `@DateCreated`. Like what you might want if you have to insert legacy values
+     * into the database.
+     */
+    @Singleton
+    @Replaces(AutoTimestampEntityEventListener.class)
+    @Requires(property = "spec.name", value = "AutoPopulatedEntityEventListenerSpec")
+    static class TestAutoPopulatedEntityEventListener extends AutoTimestampEntityEventListener {
+
+        @Inject
+        TestAutoPopulatedEntityEventListener(
+            DateTimeProvider<?> dateTimeProvider,
+            DataConversionService conversionService) {
+            super(dateTimeProvider, conversionService);
+        }
+
+        @Override
+        @NonNull
+        protected RuntimePersistentProperty<Object>[] getApplicableProperties(EntityEventContext<Object> context) {
+            @SuppressWarnings("unchecked")
+            final RuntimePersistentProperty<Object>[] applicableProperties =
+                Arrays.stream(super.getApplicableProperties(context))
+                    .filter(
+                        property ->
+                            // properties are "applicable" if the current value is null
+                            property.getProperty().get(context.getEntity()) == null
+                                // or if the property is updatable (like for @DateUpdated)
+                                || property.getAnnotationMetadata().booleanValue(AutoPopulated.class, AutoPopulated.UPDATABLE)
+                                .orElse(true))
+                    .toArray(RuntimePersistentProperty[]::new);
+
+            return applicableProperties;
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,6 @@ jmh-gradle-plugin = "0.7.3"
 spring-boot-gradle-plugin = "3.5.5"
 spring-dependency-management-gradle-plugin = "1.1.7"
 shadow-gradle-plugin = "8.0.0"
-sonatype-scan = "3.1.3"
 
 # Dependency versions which are found in the platform BOM
 # meaning that they should be extracted into their own BOM
@@ -143,4 +142,4 @@ gradle-jmh = { module = "me.champeau.jmh:jmh-gradle-plugin", version.ref = "jmh-
 gradle-spring-boot = { module = "org.springframework.boot:spring-boot-gradle-plugin", version.ref = "spring-boot-gradle-plugin" }
 gradle-spring-dependencies = { module = "io.spring.gradle:dependency-management-plugin", version.ref = "spring-dependency-management-gradle-plugin" }
 gradle-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "shadow-gradle-plugin" }
-sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
+


### PR DESCRIPTION
Currently, `AutoPopulatedEntityEventListener#getApplicableProperties()` accepts the RuntimePersistentEntity to determine the applicable properties which should be handled. This prevents subclasses from accessing the EntityEventContext.

This PR changes it to pass the EntityEventContext instead. The old method is deprecated for removal but kept in case there are subclasses which use or override that method. One use case for this is to keep existing values, as mentioned in https://github.com/micronaut-projects/micronaut-data/issues/3514; the existing property values can be used to filter the applicable properties to remove the properties which already have non-null values.