### PR TITLE
fix: NullPointerException when fetching entities having @Transient properties #3519

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/JpaTransientPropertySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/JpaTransientPropertySpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.data.jdbc.h2
+
+import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
+import io.micronaut.data.tck.entities.Book
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+@H2DBProperties
+class JpaTransientPropertySpec  extends Specification {
+
+    @Inject
+    H2BookRepository bookRepository
+
+    void "test JpaSpecificationExecutor with transient properties"() {
+        given: 'a PredicateSpecification'
+        PredicateSpecification<Book> spec = (root, criteriaBuilder) -> criteriaBuilder.equal(root.get("title"), "Random title")
+
+        when: 'a book is searched using JpaSpecificationExecutor'
+        bookRepository.findAll(spec)
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -353,7 +353,8 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
     @Override
     public RuntimePersistentProperty<T> getPropertyByNameIgnoreCase(String name) {
         for (RuntimePersistentProperty<T> property : allPersistentProperties) {
-            if (property.getName().equalsIgnoreCase(name)) {
+            String propertyName = property.getName();
+            if (propertyName != null && propertyName.equalsIgnoreCase(name)) {
                 return property;
             }
         }


### PR DESCRIPTION
I wanted to add a test showcasing the problem but wasn't able to reproduce the problem within the Micronaut Data test suite.

I don't know how to manipulate the order of introspected `beanProperties` passed to `RuntimePersistentEntity`.
In my application and the reproducer linked in #3519 the `@Transient` properties are the first properties in `beanProperties` causing the NullPointerException while iterating through `allPersistentProperties`. When playing around with `Book` and `Author` entity in the test suite, the transient properties are always at the end of `beanProperties` collection.