### PR TITLE
Fix null check for persistent property to prevent NullPointerException

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -353,8 +353,7 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity impleme
     @Override
     public RuntimePersistentProperty<T> getPropertyByNameIgnoreCase(String name) {
         for (RuntimePersistentProperty<T> property : allPersistentProperties) {
-            String propertyName = property.getName();
-            if (propertyName != null && propertyName.equalsIgnoreCase(name)) {
+            if (property != null && property.getName().equalsIgnoreCase(name)) {
                 return property;
             }
         }


### PR DESCRIPTION
Should finally fix #3519.

I still wasn't able to reproduce the error in the test suite but successfully tested a local build against the [reproducer of the bug](https://github.com/davidsonnabend/micronaut-data-transient-properties).