### PR TITLE
Create KotlinCrudRepository that does not suspend. Removes need for Optional

### DIFF
--- a/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/KotlinJpaSpecificationExecutor.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/KotlinJpaSpecificationExecutor.kt
@@ -1,0 +1,129 @@
+package io.micronaut.data.repository.jpa.kotlin
+
+import io.micronaut.data.model.Page
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
+import io.micronaut.data.repository.jpa.criteria.DeleteSpecification
+import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
+import io.micronaut.data.repository.jpa.criteria.QuerySpecification
+import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
+
+/**
+ * Interface to allow execution of query/delete/update methods using dynamic JPA criteria API.
+ *
+ * Based on Spring Data's 'org.springframework.data.jpa.repository.JpaSpecificationExecutor'.
+ *
+ * @param <T> The entity type
+ * @author Denis Stepanov
+ * @since 3.2
+ */
+interface KotlinJpaSpecificationExecutor<T> {
+
+    /**
+     * Returns a single entity matching the given [QuerySpecification].
+     *
+     * @param spec The query specification
+     * @return optional found result
+     */
+    fun findOne(spec: QuerySpecification<T>?): T?
+
+    /**
+     * Returns a single entity matching the given [PredicateSpecification].
+     *
+     * @param spec The query specification
+     * @return optional found result
+     */
+    fun findOne(spec: PredicateSpecification<T>?): T?
+
+    /**
+     * Returns all entities matching the given [QuerySpecification].
+     *
+     * @param spec The query specification
+     * @return found results
+     */
+    fun findAll(spec: QuerySpecification<T>?): List<T>
+
+    /**
+     * Returns all entities matching the given [PredicateSpecification].
+     *
+     * @param spec The query specification
+     * @return found results
+     */
+    fun findAll(spec: PredicateSpecification<T>?): List<T>
+
+    /**
+     * Returns a [Page] of entities matching the given [QuerySpecification].
+     *
+     * @param spec     The query specification
+     * @param pageable The pageable object
+     * @return a page
+     */
+    fun findAll(spec: QuerySpecification<T>?, pageable: Pageable): Page<T>
+
+    /**
+     * Returns a [Page] of entities matching the given [QuerySpecification].
+     *
+     * @param spec     The query specification
+     * @param pageable The pageable object
+     * @return a page
+     */
+    fun findAll(spec: PredicateSpecification<T>?, pageable: Pageable): Page<T>
+
+    /**
+     * Returns all entities matching the given [QuerySpecification] and [Sort].
+     *
+     * @param spec The query specification
+     * @param sort The sort object
+     * @return found results
+     */
+    fun findAll(spec: QuerySpecification<T>?, sort: Sort): List<T>
+
+    /**
+     * Returns all entities matching the given [QuerySpecification] and [Sort].
+     *
+     * @param spec The query specification
+     * @param sort The sort object
+     * @return found results
+     */
+    fun findAll(spec: PredicateSpecification<T>?, sort: Sort): List<T>
+
+    /**
+     * Returns the number of instances that the given [QuerySpecification] will return.
+     *
+     * @param spec The query specification
+     * @return the number of instances.
+     */
+    fun count(spec: QuerySpecification<T>?): Long
+
+    /**
+     * Returns the number of instances that the given [QuerySpecification] will return.
+     *
+     * @param spec The query specification
+     * @return the number of instances.
+     */
+    fun count(spec: PredicateSpecification<T>?): Long
+
+    /**
+     * Deletes all entities matching the given [DeleteSpecification].
+     *
+     * @param spec The delete specification
+     * @return the number records deleted.
+     */
+    fun deleteAll(spec: DeleteSpecification<T>?): Long
+
+    /**
+     * Deletes all entities matching the given [PredicateSpecification].
+     *
+     * @param spec The delete specification
+     * @return the number records deleted.
+     */
+    fun deleteAll(spec: PredicateSpecification<T>?): Long
+
+    /**
+     * Updates all entities matching the given [UpdateSpecification].
+     *
+     * @param spec The update specification
+     * @return the number records updated.
+     */
+    fun updateAll(spec: UpdateSpecification<T>?): Long
+}

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/KotlinJpaSpecificationExecutor.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/KotlinJpaSpecificationExecutor.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.data.repository.jpa.kotlin
 
 import io.micronaut.data.model.Page

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinCrudRepository.kt
@@ -1,0 +1,113 @@
+package io.micronaut.data.repository.kotlin
+
+import io.micronaut.core.annotation.Blocking
+import io.micronaut.data.repository.GenericRepository
+
+/**
+ * Interface for CRUD repository using Kotlin.
+ *
+ * @param <E> The entity type
+ * @param <ID> The ID type
+ *
+ * @author Denis Stepanov
+ * @since 3.1.0
+ */
+@Suppress("unused", "KDocUnresolvedReference")
+@Blocking
+interface KotlinCrudRepository<E, ID> : GenericRepository<E, ID> {
+
+    /**
+     * Saves the given valid entity, returning a possibly new entity representing the saved state. Note that certain implementations may not be able to detect whether a save or update should be performed and may always perform an insert. The [.update] method can be used in this case to explicitly request an update.
+     *
+     * @param entity The entity to save. Must not be null.
+     * @return The saved entity will never be null.
+     * @param <S> The generic type
+     */
+    fun <S : E> save(entity: S): S
+
+    /**
+     * This method issues an explicit update for the given entity. The method differs from [.save] in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
+     *
+     * @param entity The entity to save. Must not be null.
+     * @return The updated entity will never be null.
+     * @param <S> The generic type
+     */
+    fun <S : E> update(entity: S): S
+
+    /**
+     * This method issues an explicit update for the given entities. The method differs from [.saveAll] in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
+     *
+     * @param entities The entities to update. Must not be null.
+     * @return The updated entities will never be null.
+     * @param <S> The generic type
+     */
+    fun <S : E> updateAll(entities: Iterable<S>): Iterable<S>
+
+    /**
+     * Saves all given entities, possibly returning new instances representing the saved state.
+     *
+     * @param entities The entities to save. Must not be null.
+     * @param <S> The generic type
+     * @return The saved entities objects. will never be null.
+     */
+    fun <S : E?> saveAll(entities: Iterable<S>): Iterable<S>
+
+    /**
+     * Retrieves an entity by its id.
+     *
+     * @param id The ID of the entity to retrieve. Must not be null.
+     * @return the entity with the given id or none.
+     */
+    fun findById(id: ID): E?
+
+    /**
+     * Returns whether an entity with the given id exists.
+     *
+     * @param id must not be null.
+     * @return true if an entity with the given id exists, false otherwise.
+     */
+    fun existsById(id: ID): Boolean
+
+    /**
+     * Returns all instances of the type.
+     *
+     * @return all entities
+     */
+    fun findAll(): Iterable<E>
+
+    /**
+     * Returns the number of entities available.
+     *
+     * @return the number of entities
+     */
+    fun count(): Long
+
+    /**
+     * Deletes the entity with the given id.
+     *
+     * @param id the id.
+     */
+    fun deleteById(id: ID): Int
+
+    /**
+     * Deletes a given entity.
+     *
+     * @param entity The entity to delete
+     * @return the number of entities deleted
+     */
+    fun delete(entity: E): Int
+
+    /**
+     * Deletes the given entities.
+     *
+     * @param entities The entities to delete
+     * @return the number of entities deleted
+     */
+    fun deleteAll(entities: Iterable<E>): Int
+
+    /**
+     * Deletes all entities managed by the repository.
+     * @return the number of entities deleted
+     */
+    fun deleteAll(): Int
+}

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinCrudRepository.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.data.repository.kotlin
 
 import io.micronaut.core.annotation.Blocking

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinPageableCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinPageableCrudRepository.kt
@@ -1,0 +1,34 @@
+package io.micronaut.data.repository.kotlin
+
+import io.micronaut.core.annotation.Blocking
+import io.micronaut.data.model.Page
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
+
+/**
+ * A repository that supports pagination.
+ *
+ * @param <E> The entity type
+ * @param <ID> The ID type
+ * @author Denis Stepanov
+ * @since 3.4.0
+ */
+@Blocking
+interface KotlinPageableCrudRepository<E, ID> : KotlinCrudRepository<E, ID> {
+
+    /**
+     * Find all results for the given sort order.
+     *
+     * @param sort The sort
+     * @return The iterable results
+     */
+    fun findAll(sort: Sort): Iterable<E>
+
+    /**
+     * Finds all records for the given pageable.
+     *
+     * @param pageable The pageable.
+     * @return The results
+     */
+    fun findAll(pageable: Pageable): Page<E>
+}

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinPageableCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/KotlinPageableCrudRepository.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.data.repository.kotlin
 
 import io.micronaut.core.annotation.Blocking

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AbstractBookRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AbstractBookRepository.kt
@@ -3,13 +3,11 @@ package example
 
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jdbc.runtime.JdbcOperations
-import io.micronaut.data.repository.CrudRepository
-
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 import jakarta.transaction.Transactional
-import kotlin.streams.toList
 
 @Repository
-abstract class AbstractBookRepository(private val jdbcOperations: JdbcOperations) : CrudRepository<Book, Long> {
+abstract class AbstractBookRepository(private val jdbcOperations: JdbcOperations) : KotlinCrudRepository<Book, Long> {
 
     @Transactional
     open fun findByTitle(title: String): List<Book> {

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AuthorRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/AuthorRepository.kt
@@ -3,9 +3,9 @@ package example
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import io.micronaut.data.repository.jpa.JpaSpecificationExecutor
+import io.micronaut.data.repository.jpa.kotlin.KotlinJpaSpecificationExecutor
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
 @Join(value = "genres", type = Join.Type.LEFT_FETCH)
-interface AuthorRepository : CrudRepository<Author, Long>, JpaSpecificationExecutor<Author>
+interface AuthorRepository : KotlinCrudRepository<Author, Long>, KotlinJpaSpecificationExecutor<Author>

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
@@ -11,11 +11,11 @@ import io.micronaut.data.annotation.sql.Procedure
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.*
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 import jakarta.transaction.Transactional
 
 @JdbcRepository(dialect = Dialect.H2) // <1>
-interface BookRepository : CrudRepository<Book, Long> { // <2>
+interface BookRepository : KotlinCrudRepository<Book, Long> { // <2>
 // end::repository[]
 
     // tag::simple[]
@@ -95,7 +95,7 @@ interface BookRepository : CrudRepository<Book, Long> { // <2>
     // end::update2[]
 
     // tag::deleteall[]
-    override fun deleteAll()
+    override fun deleteAll(): Int
     // end::deleteall[]
 
     @Transactional(Transactional.TxType.MANDATORY)

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/CartRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/CartRepository.kt
@@ -3,11 +3,10 @@ package example
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import java.util.*
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface CartRepository : CrudRepository<Cart, Long> {
+interface CartRepository : KotlinCrudRepository<Cart, Long> {
     @Join("items")
-    override fun findById(id: Long): Optional<Cart>
+    override fun findById(id: Long): Cart?
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ClientRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ClientRepository.kt
@@ -3,8 +3,8 @@ package example
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
 @Join(value = "relationship.status", type = Join.Type.LEFT_FETCH)
-interface ClientRepository : CrudRepository<Client, Long>
+interface ClientRepository : KotlinCrudRepository<Client, Long>

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/CourseRatingRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/CourseRatingRepository.kt
@@ -2,8 +2,7 @@ package example
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface CourseRatingRepository : CrudRepository<CourseRating, Long> {
-}
+interface CourseRatingRepository : KotlinCrudRepository<CourseRating, Long>

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ManufacturerRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ManufacturerRepository.kt
@@ -2,10 +2,10 @@ package example
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface ManufacturerRepository : CrudRepository<Manufacturer, Long> {
+interface ManufacturerRepository : KotlinCrudRepository<Manufacturer, Long> {
 
     fun save(name: String): Manufacturer
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ParentRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ParentRepository.kt
@@ -3,13 +3,12 @@ package example
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import java.util.Optional
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-abstract class ParentRepository : CrudRepository<Parent, Int> {
+abstract class ParentRepository : KotlinCrudRepository<Parent, Int> {
 
     @Join(value = "children", type = Join.Type.FETCH)
-    abstract override fun findById(id: Int): Optional<Parent>
+    abstract override fun findById(id: Int): Parent?
 
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ParentRepositoryForCustomDb.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ParentRepositoryForCustomDb.kt
@@ -1,16 +1,14 @@
 package example
 
 import io.micronaut.data.annotation.Join
-import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import java.util.Optional
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dataSource = "custom", dialect = Dialect.H2)
-abstract class ParentRepositoryForCustomDb : CrudRepository<Parent, Int> {
+abstract class ParentRepositoryForCustomDb : KotlinCrudRepository<Parent, Int> {
 
     @Join(value = "children", type = Join.Type.FETCH)
-    abstract override fun findById(id: Int): Optional<Parent>
+    abstract override fun findById(id: Int): Parent?
 
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/PersonRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/PersonRepository.kt
@@ -5,31 +5,30 @@ import io.micronaut.data.model.Page
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import io.micronaut.data.repository.jpa.JpaSpecificationExecutor
 import io.micronaut.data.repository.jpa.criteria.DeleteSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification
+import io.micronaut.data.repository.jpa.kotlin.KotlinJpaSpecificationExecutor
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 import io.micronaut.data.runtime.criteria.delete
 import io.micronaut.data.runtime.criteria.get
 import io.micronaut.data.runtime.criteria.query
 import io.micronaut.data.runtime.criteria.update
 import io.micronaut.data.runtime.criteria.where
-import java.util.*
 
 // tag::repository[]
 @JdbcRepository(dialect = Dialect.H2)
-interface PersonRepository : CrudRepository<Person, Long>, JpaSpecificationExecutor<Person> {
+interface PersonRepository : KotlinCrudRepository<Person, Long>, KotlinJpaSpecificationExecutor<Person> {
     // end::repository[]
     override
     // tag::find[]
-    fun findOne(spec: PredicateSpecification<Person>?): Optional<Person>
+    fun findOne(spec: PredicateSpecification<Person>?): Person?
 
     // end::find[]
     override
     // tag::find[]
-    fun findOne(spec: QuerySpecification<Person>?): Optional<Person>
+    fun findOne(spec: QuerySpecification<Person>?): Person?
 
     // end::find[]
     override

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProductManager.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProductManager.kt
@@ -48,7 +48,7 @@ class ProductManager(
 
     fun findUsingRepo(name: String): Product? {
         return transactionManager.executeRead { status -> // <5>
-            productRepository.findByName(name).orElse(null)
+            productRepository.findByName(name)
         }
     }
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProductRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/ProductRepository.kt
@@ -4,15 +4,15 @@ package example
 import io.micronaut.data.annotation.*
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 import io.reactivex.Maybe
 import io.reactivex.Single
-import java.util.Optional
 import java.util.concurrent.CompletableFuture
+
 // tag::join[]
 // tag::async[]
 @JdbcRepository(dialect = Dialect.H2)
-interface ProductRepository : CrudRepository<Product, Long> {
+interface ProductRepository : KotlinCrudRepository<Product, Long> {
 // end::join[]
 // end::async[]
 
@@ -45,7 +45,7 @@ interface ProductRepository : CrudRepository<Product, Long> {
     // end::native[]
 
     @Join("manufacturer")
-    fun findByName(str: String): Optional<Product>
+    fun findByName(str: String): Product?
 
 // tag::join[]
 // tag::async[]

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/RelationshipStatusRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/RelationshipStatusRepository.kt
@@ -2,7 +2,7 @@ package example
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface RelationshipStatusRepository : CrudRepository<RelationshipStatus, Long>
+interface RelationshipStatusRepository : KotlinCrudRepository<RelationshipStatus, Long>

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/SaleRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/SaleRepository.kt
@@ -6,12 +6,13 @@ import io.micronaut.data.annotation.repeatable.JoinSpecifications
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 import java.util.Optional
 
 @JdbcRepository(dialect = Dialect.H2)
-interface SaleRepository : CrudRepository<Sale, Long> {
+interface SaleRepository : KotlinCrudRepository<Sale, Long> {
 
     @JoinSpecifications(value = [Join("product"), Join("product.manufacturer")])
-    override fun findById(aLong: Long): Optional<Sale>
+    override fun findById(id: Long): Sale?
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/StudentRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/StudentRepository.kt
@@ -1,17 +1,15 @@
 package example
 
-import io.micronaut.core.annotation.NonNull
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.annotation.repeatable.JoinSpecifications
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
-import java.util.*
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface StudentRepository : CrudRepository<Student, Long> {
+interface StudentRepository : KotlinCrudRepository<Student, Long> {
     @Join("courses")
-    override fun findById(@NonNull id: Long?): Optional<Student>
+    override fun findById(id: Long): Student?
 
     @JoinSpecifications(
             Join(value = "courses", type = Join.Type.LEFT_FETCH),
@@ -19,5 +17,5 @@ interface StudentRepository : CrudRepository<Student, Long> {
             Join(value = "ratings.course", type = Join.Type.LEFT_FETCH),
             Join(value = "ratings.student", type = Join.Type.LEFT_FETCH)
     )
-    fun queryById(aLong: Long): Optional<Student>
+    fun queryById(aLong: Long): Student?
 }

--- a/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/UserRepository.kt
+++ b/doc-examples/jdbc-example-kotlin/src/main/kotlin/example/UserRepository.kt
@@ -4,13 +4,13 @@ package example
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.model.query.builder.sql.Dialect
-import io.micronaut.data.repository.CrudRepository
+import io.micronaut.data.repository.kotlin.KotlinCrudRepository
 
 @JdbcRepository(dialect = Dialect.H2)
-interface UserRepository : CrudRepository<User, Long> { // <1>
+interface UserRepository : KotlinCrudRepository<User, Long> { // <1>
 
     @Query("UPDATE user SET enabled = false WHERE id = :id") // <2>
-    override fun deleteById(id: Long)
+    override fun deleteById(id: Long): Int
 
     @Query("SELECT * FROM user WHERE enabled = false") // <3>
     fun findDisabled(): List<User>

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/BookRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/BookRepositorySpec.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.*
 
 @MicronautTest
 class BookRepositorySpec {
@@ -68,7 +67,7 @@ class BookRepositorySpec {
 
         // Read: Read a book from the database
         // tag::read[]
-        book = bookRepository.findById(id).orElse(null)
+        book = bookRepository.findById(id)!!
         // end::read[]
         assertNotNull(book)
         assertEquals("The Stand", book.title)
@@ -81,7 +80,7 @@ class BookRepositorySpec {
         // tag::update[]
         bookRepository.update(book.id, "Changed")
         // end::update[]
-        book = bookRepository.findById(id).orElse(null)
+        book = bookRepository.findById(id)!!
         assertEquals("Changed", book.title)
 
         // Delete: Delete the book
@@ -94,16 +93,18 @@ class BookRepositorySpec {
     @Test
     fun testPageable() {
         // tag::saveall[]
-        bookRepository.saveAll(Arrays.asList(
-                Book(0,"The Stand", 1000),
-                Book(0,"The Shining", 600),
-                Book(0,"The Power of the Dog", 500),
-                Book(0,"The Border", 700),
-                Book(0,"Along Came a Spider", 300),
-                Book(0,"Pet Cemetery", 400),
-                Book(0,"A Game of Thrones", 900),
-                Book(0,"A Clash of Kings", 1100)
-        ))
+        bookRepository.saveAll(
+            listOf(
+                Book(0, "The Stand", 1000),
+                Book(0, "The Shining", 600),
+                Book(0, "The Power of the Dog", 500),
+                Book(0, "The Border", 700),
+                Book(0, "Along Came a Spider", 300),
+                Book(0, "Pet Cemetery", 400),
+                Book(0, "A Game of Thrones", 900),
+                Book(0, "A Clash of Kings", 1100)
+            )
+        )
         // end::saveall[]
 
         // tag::pageable[]
@@ -234,8 +235,8 @@ class BookRepositorySpec {
             Review("Member", "Interesting"))))
 
         val books = bookRepository.searchBooksByTitle("Dummy Book")
-        assertEquals(1, books.size);
-        val book = books.get(0)
+        assertEquals(1, books.size)
+        val book = books[0]
         assertEquals("Dummy Book", book.title)
         assertEquals(2, book.reviews.size)
     }

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/CartRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/CartRepositorySpec.kt
@@ -19,7 +19,7 @@ class CartRepositorySpec(private val cartRepository: CartRepository?) {
         assertEquals(2, cart.items.size)
         assertNotNull(cart.items[0].id)
         assertNotNull(cart.items[1].id)
-        cart = cartRepository.findById(cart.id!!).orElse(null)
+        cart = cartRepository.findById(cart.id!!)!!
         assertNotNull(cart)
         assertNotNull(cart.id)
         assertNotNull(cart.items)

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/EmbeddedRelationsTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/EmbeddedRelationsTest.kt
@@ -6,7 +6,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.micronaut.test.annotation.Sql
-import kotlin.jvm.optionals.getOrNull
 
 @MicronautTest
 @Sql("classpath:embedded-relations.sql")
@@ -17,7 +16,7 @@ class EmbeddedRelationsTest(
 ) : StringSpec({
 
     "client is saved with relationship status" {
-        val status = relationshipStatusRepository.findById(1).getOrNull()
+        val status = relationshipStatusRepository.findById(1)
 
         status.shouldNotBeNull()
         status.name shouldBe "Active"

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ExistsTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ExistsTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import java.util.*
 
 @MicronautTest(transactional = false)

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentRepositoryTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentRepositoryTest.kt
@@ -28,13 +28,13 @@ class ParentRepositoryTest {
         assertNotNull(saved.id)
         saved.children.forEach { assertNotNull(it.id) }
 
-        val found = repository.findById(saved.id!!).get()
+        val found = repository.findById(saved.id!!)!!
         println(found)
         found.children.forEach { assertNotNull(it.parent) }
 
         val modifiedParent = found.copy(name = found.name + " mod!")
         repository.update(modifiedParent)
-        val found2 = repository.findById(saved.id!!).get()
+        val found2 = repository.findById(saved.id!!)!!
         assertTrue(found2.name.endsWith(" mod!"))
         assertTrue(found2.children.size == 3)
     }

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentSuspendRepositoryTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/ParentSuspendRepositoryTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import jakarta.inject.Inject
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonRepositorySpec.kt
@@ -39,7 +39,7 @@ internal class PersonRepositorySpec {
     @Test
     fun testFind() {
         // tag::find[]
-        val denis: Person? = personRepository.findOne(nameEquals("Denis")).orElse(null)
+        val denis: Person? = personRepository.findOne(nameEquals("Denis"))
 
         val countAgeLess30: Long = personRepository.count(ageIsLessThan(30))
 

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/PersonSuspendRepositorySpec.kt
@@ -13,8 +13,6 @@ import io.micronaut.data.model.Sort
 import jakarta.inject.Inject
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification.not
-import io.micronaut.data.runtime.criteria.get
-import io.micronaut.data.runtime.criteria.where
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/SaleRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/SaleRepositorySpec.kt
@@ -24,7 +24,7 @@ class SaleRepositorySpec(
         )
         assertEquals(1, sale.quantity.amount)
 
-        sale = saleRepository.findById(sale.id!!).orElse(sale)
+        sale = saleRepository.findById(sale.id!!) ?: sale
         assertNotNull(sale)
         assertEquals(1, sale.quantity.amount)
     }

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/StudentRepositorySpec.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/StudentRepositorySpec.kt
@@ -20,7 +20,7 @@ class StudentRepositorySpec(private val studentRepository: StudentRepository,
         assertNotNull(student.courses[0].id)
         assertNotNull(student.courses[1].id)
         studentRepository.update(student)
-        student = studentRepository.findById(student.id).get()
+        student = studentRepository.findById(student.id!!)!!
         assertNotNull(student.id)
         assertEquals(1, student.version)
         assertEquals("Denis", student.name)
@@ -31,7 +31,7 @@ class StudentRepositorySpec(private val studentRepository: StudentRepository,
         assertEquals("Physics", student.courses[1].name)
         val rating = CourseRating(student, student.courses[1], 5)
         courseRatingRepository.save(rating)
-        student = studentRepository.queryById(student.id!!).orElse(null)
+        student = studentRepository.queryById(student.id!!)!!
         assertNotNull(student.id)
         assertEquals("Denis", student.name)
         assertNotNull(student.courses)

--- a/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/TxParallelControllerTest.kt
+++ b/doc-examples/jdbc-example-kotlin/src/test/kotlin/example/TxParallelControllerTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.RepeatedTest
 
 @MicronautTest
 internal class TxParallelControllerTest(
-    @Client("/") val client: HttpClient,
+    @param:Client("/") val client: HttpClient,
     var repo: DemoRepository
 ) {
 


### PR DESCRIPTION
With fancy new Java features like Project Loom, I don't want to use a `CoroutineCrudRepository`. And using the java-based `CrudRepository` is no fun either because then I have to have `Optional<>` polluting my code.

I added 3 files:
```
data-model/
    src/main/kotlin/io/micronaut/data/repository/
        jpa/kotlin/KotlinJpaSpecificationExecutor.kt
        kotlin/
            KotlinCrudRepository.kt
            KotlinPageableCrudRepository.kt
```

I also changed all the tests in `doc-examples/jdbc-example-kotlin` that use `CrudRepository` to now use `KotlinCrudRepository`.

Let me know if that's enough for tests. I can always add more.