### PR TITLE
Fix Sort backward compatibility serialization

### DIFF
--- a/data-jdbc/src/test/resources/application.yml
+++ b/data-jdbc/src/test/resources/application.yml
@@ -9,7 +9,7 @@ test-resources:
       startup-timeout: 300s
       image-name: mysql:8.4.5
     oracle:
-      startup-timeout: 600s
+      startup-timeout: 300s
       db-name: test
     postgres:
       startup-timeout: 300s

--- a/data-model/src/main/java/io/micronaut/data/model/Sort.java
+++ b/data-model/src/main/java/io/micronaut/data/model/Sort.java
@@ -141,6 +141,7 @@ public interface Sort {
      * The ordering of results.
      */
     @Serdeable
+    @JsonIgnoreProperties(ignoreUnknown = true)
     class Order {
         private final String property;
         private final Direction direction;
@@ -264,7 +265,6 @@ public interface Sort {
         /**
          * @return Is the order ascending
          */
-        @JsonIgnore
         public boolean isAscending() {
             return getDirection() == Direction.ASC;
         }

--- a/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/data-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -174,7 +174,7 @@ class PageSpec extends Specification {
         def json = serdeMapper.writeValueAsString(sort)
 
         then:
-        json == '{"orderBy":[{"ignoreCase":false,"direction":"ASC","property":"property"}]}'
+        json == '{"orderBy":[{"ignoreCase":false,"direction":"ASC","property":"property","ascending":true}]}'
         def deserializedSort = serdeMapper.readValue(json, Sort)
         deserializedSort == sort
     }

--- a/data-r2dbc/src/test/resources/application.yaml
+++ b/data-r2dbc/src/test/resources/application.yaml
@@ -9,8 +9,7 @@ test-resources:
       startup-timeout: 300s
       image-name: mysql:8.4.5
     oracle:
-      startup-timeout: 600s
-      db-name: test
+      startup-timeout: 300s
     postgres:
       startup-timeout: 300s
 
@@ -18,7 +17,3 @@ micronaut:
   http:
     client:
       read-timeout: 5m
-  test:
-    resources:
-      client:
-        read-timeout: 10m


### PR DESCRIPTION
PR https://github.com/micronaut-projects/micronaut-data/pull/3536 added `@JsonIgnore` to `Sort.isAscending` and it should be like that but it breaks backwards compatibility in patch release so this reverts it but provides fix that was needed on that PR the other way.