### PR TITLE
No longer propagate synchronous transaction / connection by default

### DIFF
--- a/data-connection-hibernate/src/main/java/io/micronaut/data/hibernate/connection/HibernateConnectionConnectionOperations.java
+++ b/data-connection-hibernate/src/main/java/io/micronaut/data/hibernate/connection/HibernateConnectionConnectionOperations.java
@@ -61,11 +61,17 @@ public final class HibernateConnectionConnectionOperations implements Connection
         return hibernateConnectionOperations.execute(definition, connectionStatus -> callback.apply(createConnectionStatus(connectionStatus)));
     }
 
+    @Override
+    public boolean managesConnection(ConnectionStatus<Connection> connectionStatus) {
+        return false;
+    }
+
     private ConnectionStatus<Connection> createConnectionStatus(ConnectionStatus<Session> connectionStatus) {
         return new DefaultConnectionStatus<>(
             getConnection(connectionStatus.getConnection()),
             connectionStatus.getDefinition(),
-            connectionStatus.isNew()
+            connectionStatus.isNew(),
+            this
         );
     }
 

--- a/data-connection/src/main/java/io/micronaut/data/connection/ConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/ConnectionOperations.java
@@ -81,4 +81,14 @@ public interface ConnectionOperations<C> {
     default <R> R executeWrite(@NonNull Function<ConnectionStatus<C>, R> callback) {
         return execute(ConnectionDefinition.DEFAULT, callback);
     }
+
+    /**
+     * Determine whether the given connection status refers to a connection
+     * managed by this {@link ConnectionOperations} instance.
+     *
+     * @param connectionStatus The connection status to verify
+     * @return true if the connection is managed (i.e. created/supplied) by this operations instance
+     * @since 5.0
+     */
+    boolean managesConnection(@NonNull ConnectionStatus<C> connectionStatus);
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/ConnectionStatus.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/ConnectionStatus.java
@@ -16,6 +16,10 @@
 package io.micronaut.data.connection;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
+
+import java.util.function.Supplier;
 
 /**
  * The connection status.
@@ -24,17 +28,19 @@ import io.micronaut.core.annotation.NonNull;
  * @author Denis Stepanov
  * @since 4.0.0
  */
-public interface ConnectionStatus<C> {
+public interface ConnectionStatus<C> extends PropagatedContextElement {
 
     /**
      * A new connection value.
      * Based on the propagation value the connection manager might decide to reuse the existing connection.
+     *
      * @return true if the connection is new
      */
     boolean isNew();
 
     /**
      * The connection representation.
+     *
      * @return The connection representation
      */
     @NonNull
@@ -42,6 +48,7 @@ public interface ConnectionStatus<C> {
 
     /**
      * The connection definition.
+     *
      * @return The connection definition
      */
     @NonNull
@@ -49,7 +56,46 @@ public interface ConnectionStatus<C> {
 
     /**
      * Register connection synchronization.
+     *
      * @param synchronization The synchronization
      */
     void registerSynchronization(@NonNull ConnectionSynchronization synchronization);
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param propagatedContext The propagated context
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(PropagatedContext propagatedContext, Supplier<V> supplier) {
+        return propagatedContext.plus(this).propagate(supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(Supplier<V> supplier) {
+        return propagate(PropagatedContext.getOrEmpty(), supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param runnable The runnable
+     * @since 5.0
+     */
+    default void propagate(Runnable runnable) {
+        propagate(() -> {
+            runnable.run();
+            return null;
+        });
+    }
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/async/AsyncUsingReactiveConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/async/AsyncUsingReactiveConnectionOperations.java
@@ -60,15 +60,14 @@ public final class AsyncUsingReactiveConnectionOperations<C> implements AsyncCon
 
     @Override
     public <T> CompletionStage<T> withConnection(ConnectionDefinition definition, Function<ConnectionStatus<C>, CompletionStage<T>> handler) {
-        Mono<T> result = Mono.fromDirect(reactorConnectionOperations.withConnection(definition,
-            status -> Mono.deferContextual(contextView -> Mono.fromCompletionStage(() -> {
-                try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView)
-                    .orElseGet(PropagatedContext::getOrEmpty)
-                    .propagate()) {
-                    return handler.apply(status);
-                }
-            }))));
-        return onCompleteCompleteFuture(result);
+        return onCompleteCompleteFuture(Mono.fromDirect(reactorConnectionOperations.withConnection(definition,
+            status ->
+                Mono.deferContextual(contextView ->
+                    Mono.fromCompletionStage(() -> {
+                        PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty);
+                        return status.propagate(propagatedContext, () ->
+                            handler.apply(status));
+                    })))));
     }
 
     private static <T> CompletableFuture<T> onCompleteCompleteFuture(Publisher<T> publisher) {
@@ -96,16 +95,18 @@ public final class AsyncUsingReactiveConnectionOperations<C> implements AsyncCon
 
             @Override
             public void onError(Throwable t) {
-                try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
+                propagatedContext.propagate(() -> {
                     completableFuture.completeExceptionally(t);
-                }
+                    return null;
+                });
             }
 
             @Override
             public void onComplete() {
-                try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
+                propagatedContext.propagate(() -> {
                     completableFuture.complete(result);
-                }
+                    return null;
+                });
             }
         });
         return completableFuture;

--- a/data-connection/src/main/java/io/micronaut/data/connection/reactive/DefaultReactiveConnectionStatus.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/reactive/DefaultReactiveConnectionStatus.java
@@ -44,14 +44,20 @@ public final class DefaultReactiveConnectionStatus<C> implements ReactiveConnect
 
     private final C connection;
     private final ConnectionDefinition definition;
+    private final ReactorConnectionOperations<C> connectionOperations;
     private final boolean isNew;
 
     private List<ReactiveConnectionSynchronization> connectionSynchronizations;
 
-    public DefaultReactiveConnectionStatus(C connection, ConnectionDefinition definition, boolean isNew) {
+    public DefaultReactiveConnectionStatus(C connection, ConnectionDefinition definition, ReactorConnectionOperations<C> connectionOperations, boolean isNew) {
         this.connection = connection;
         this.definition = definition;
+        this.connectionOperations = connectionOperations;
         this.isNew = isNew;
+    }
+
+    public boolean isConnectionOf(ReactorConnectionOperations<C> connectionOperations) {
+        return this.connectionOperations == connectionOperations;
     }
 
     @Override

--- a/data-connection/src/main/java/io/micronaut/data/connection/reactive/ReactiveStreamsConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/reactive/ReactiveStreamsConnectionOperations.java
@@ -53,4 +53,14 @@ public interface ReactiveStreamsConnectionOperations<C> {
         return withConnection(ConnectionDefinition.DEFAULT, handler);
     }
 
+    /**
+     * Determine whether the given connection status refers to a connection
+     * managed by this {@link ReactiveStreamsConnectionOperations} instance.
+     *
+     * @param connectionStatus The connection status to verify
+     * @return true if the connection is managed (i.e. created/supplied) by this operations instance
+     * @since 5.0
+     */
+    boolean managesConnection(@NonNull ConnectionStatus<C> connectionStatus);
+
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
@@ -19,14 +19,12 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.propagation.PropagatedContextElement;
-import io.micronaut.data.connection.exceptions.ConnectionException;
-import io.micronaut.data.connection.exceptions.NoConnectionException;
 import io.micronaut.data.connection.ConnectionDefinition;
 import io.micronaut.data.connection.ConnectionOperations;
 import io.micronaut.data.connection.ConnectionStatus;
-import io.micronaut.data.connection.ConnectionSynchronization;
 import io.micronaut.data.connection.SynchronousConnectionManager;
+import io.micronaut.data.connection.exceptions.ConnectionException;
+import io.micronaut.data.connection.exceptions.NoConnectionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,14 +48,21 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
 
     private final List<ConnectionCustomizer<C>> connectionCustomizers = new ArrayList<>(10);
 
+    @Override
+    public boolean managesConnection(ConnectionStatus<C> connectionStatus) {
+        if (connectionStatus instanceof DefaultConnectionStatus<C> propagatedConnectionStatus) {
+            return propagatedConnectionStatus.isConnectionOf(this);
+        }
+        return false;
+    }
+
     /**
      * Adds a connection customizer to the list of customizers that will be notified before or after a call to the underlying data repository
      * is issues.
-     *
+     * <p>
      * The added customizer will be sorted according to its order using the {@link OrderUtil#sort(List)} method.
      *
      * @param connectionCustomizer the connection customizer to add
-     *
      * @since 4.11
      */
     public void addConnectionCustomizer(@NonNull ConnectionCustomizer<C> connectionCustomizer) {
@@ -89,21 +94,16 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
 
     @Override
     public final Optional<ConnectionStatus<C>> findConnectionStatus() {
-        return findContextElement()
-            .map(ConnectionPropagatedContextElement::status);
-    }
-
-    private Optional<ConnectionPropagatedContextElement<C>> findContextElement() {
         return PropagatedContext.getOrEmpty()
-            .findAll(ConnectionPropagatedContextElement.class)
-            .filter(element -> element.connectionOperations == this)
-            .map(element -> (ConnectionPropagatedContextElement<C>) element)
+            .findAll(ConnectionStatus.class)
+            .filter(element -> managesConnection(element))
+            .map(v -> (ConnectionStatus<C>) v)
             .findFirst();
     }
 
     @Override
     public final <R> R execute(@NonNull ConnectionDefinition definition, @NonNull Function<ConnectionStatus<C>, R> callback) {
-        ConnectionPropagatedContextElement<C> existingConnection = findContextElement().orElse(null);
+        ConnectionStatus<C> existingConnection = findConnectionStatus().orElse(null);
         for (ConnectionCustomizer<C> connectionCustomizer : connectionCustomizers) {
             callback = connectionCustomizer.intercept(callback);
         }
@@ -130,41 +130,35 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
         };
     }
 
-    private <R> R suspend(ConnectionPropagatedContextElement<C> existingConnectionContextElement,
+    private <R> R suspend(ConnectionStatus<C> existingConnection,
                           @NonNull Supplier<R> callback) {
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .minus(existingConnectionContextElement)
-            .propagate()) {
-            return callback.get();
-        }
+        return PropagatedContext.getOrEmpty()
+            .minus(existingConnection)
+            .propagate(callback);
     }
 
-    private <R> R withExistingConnectionInternal(@NonNull ConnectionPropagatedContextElement<C> existingContextElement, @NonNull Function<ConnectionStatus<C>, R> callback) {
-        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(
-            existingContextElement.status.getConnection(),
-            existingContextElement.status.getDefinition(),
-            false);
+    private <R> R withExistingConnectionInternal(@NonNull ConnectionStatus<C> existingStatus, @NonNull Function<ConnectionStatus<C>, R> callback) {
+        DefaultConnectionStatus<C> newStatus = new DefaultConnectionStatus<>(
+            existingStatus.getConnection(),
+            existingStatus.getDefinition(),
+            false,
+            this
+        );
         try {
-            setupConnection(status);
-            try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-                .replace(existingContextElement, new ConnectionPropagatedContextElement<>(this, status))
-                .propagate()) {
-                return callback.apply(status);
-            }
+            setupConnection(newStatus);
+            return PropagatedContext.getOrEmpty().minus(existingStatus).plus(newStatus).propagate(() -> callback.apply(newStatus));
         } finally {
-            complete(status);
+            complete(newStatus);
         }
     }
 
     private <R> R executeWithNewConnection(@NonNull ConnectionDefinition definition,
                                            @NonNull Function<ConnectionStatus<C>, R> callback) {
         C connection = openConnection(definition);
-        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(connection, definition, true);
-        try (PropagatedContext.Scope ignore = PropagatedContext.getOrEmpty()
-            .plus(new ConnectionPropagatedContextElement<>(this, status))
-            .propagate()) {
+        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(connection, definition, true, this);
+        try {
             setupConnection(status);
-            return callback.apply(status);
+            return status.propagate(() -> callback.apply(status));
         } finally {
             complete(status);
         }
@@ -173,25 +167,26 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
     @NonNull
     @Override
     public ConnectionStatus<C> getConnection(@NonNull ConnectionDefinition definition) {
-        ConnectionPropagatedContextElement<C> existingContextElement = findContextElement().orElse(null);
+        ConnectionStatus<C> existingConnection = findConnectionStatus().orElse(null);
         return switch (definition.getPropagationBehavior()) {
             case REQUIRED -> {
-                if (existingContextElement == null) {
+                if (existingConnection == null) {
                     yield openNewConnectionInternal(definition);
                 }
-                yield reuseExistingConnectionInternal(existingContextElement);
+                yield reuseExistingConnectionInternal(existingConnection);
             }
             case MANDATORY -> {
-                if (existingContextElement == null) {
+                if (existingConnection == null) {
                     throw new NoConnectionException();
                 }
-                yield reuseExistingConnectionInternal(existingContextElement);
+                yield reuseExistingConnectionInternal(existingConnection);
             }
             case REQUIRES_NEW -> {
-                if (existingContextElement == null) {
+                if (existingConnection == null) {
                     yield openNewConnectionInternal(definition);
                 }
-                yield suspendOpenConnection(existingContextElement, () -> openNewConnectionInternal(definition));
+                // Should we support suspending of the existing connection?
+                yield openNewConnectionInternal(definition);
             }
             default ->
                 throw new ConnectionException("Unknown propagation: " + definition.getPropagationBehavior());
@@ -217,53 +212,15 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
 
     private DefaultConnectionStatus<C> openNewConnectionInternal(@NonNull ConnectionDefinition definition) {
         C connection = openConnection(definition);
-        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(connection, definition, true);
-        ConnectionPropagatedContextElement<C> newConnectionContextElement = new ConnectionPropagatedContextElement<>(this, status);
-        PropagatedContext.getOrEmpty().plus(newConnectionContextElement).propagate();
-        status.registerSynchronization(new ConnectionSynchronization() {
-            @Override
-            public void executionComplete() {
-                PropagatedContext.getOrEmpty().minus(newConnectionContextElement).propagate();
-            }
-        });
-        return status;
+        return new DefaultConnectionStatus<>(connection, definition, true, this);
     }
 
-    private DefaultConnectionStatus<C> reuseExistingConnectionInternal(@NonNull ConnectionPropagatedContextElement<C> existingContextElement) {
-        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(
-            existingContextElement.status.getConnection(),
-            existingContextElement.status.getDefinition(),
-            false);
-        setupConnection(status);
-        ConnectionPropagatedContextElement<C> newConnectionElement = new ConnectionPropagatedContextElement<>(this, status);
-        PropagatedContext.getOrEmpty()
-            .replace(existingContextElement, newConnectionElement)
-            .propagate();
-        status.registerSynchronization(new ConnectionSynchronization() {
-            @Override
-            public void executionComplete() {
-                PropagatedContext.getOrEmpty().minus(newConnectionElement).plus(existingContextElement).propagate();
-            }
-        });
-        return status;
-    }
-
-    private DefaultConnectionStatus<C> suspendOpenConnection(ConnectionPropagatedContextElement<C> existingConnectionContextElement,
-                                                             @NonNull Supplier<DefaultConnectionStatus<C>> newStatusSupplier) {
-        PropagatedContext.getOrEmpty().minus(existingConnectionContextElement).propagate();
-        DefaultConnectionStatus<C> newStatus = newStatusSupplier.get();
-        newStatus.registerSynchronization(new ConnectionSynchronization() {
-            @Override
-            public void executionComplete() {
-                PropagatedContext.getOrEmpty().plus(existingConnectionContextElement).propagate();
-            }
-        });
-        return newStatus;
-    }
-
-    private record ConnectionPropagatedContextElement<C>(
-        ConnectionOperations<C> connectionOperations,
-        ConnectionStatus<C> status) implements PropagatedContextElement {
+    private DefaultConnectionStatus<C> reuseExistingConnectionInternal(@NonNull ConnectionStatus<C> existingStatus) {
+        return new DefaultConnectionStatus<>(
+            existingStatus.getConnection(),
+            existingStatus.getDefinition(),
+            false,
+            this);
     }
 
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * The abstract connection operations.
@@ -103,70 +102,18 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
 
     @Override
     public final <R> R execute(@NonNull ConnectionDefinition definition, @NonNull Function<ConnectionStatus<C>, R> callback) {
-        ConnectionStatus<C> existingConnection = findConnectionStatus().orElse(null);
-        for (ConnectionCustomizer<C> connectionCustomizer : connectionCustomizers) {
-            callback = connectionCustomizer.intercept(callback);
-        }
-        @NonNull Function<ConnectionStatus<C>, R> finalCallback = callback;
-        return switch (definition.getPropagationBehavior()) {
-            case REQUIRED -> {
-                if (existingConnection == null) {
-                    yield executeWithNewConnection(definition, callback);
-                }
-                yield withExistingConnectionInternal(existingConnection, callback);
-            }
-            case MANDATORY -> {
-                if (existingConnection == null) {
-                    throw new NoConnectionException("No existing connection found for connection marked with propagation 'mandatory'");
-                }
-                yield withExistingConnectionInternal(existingConnection, callback);
-            }
-            case REQUIRES_NEW -> {
-                if (existingConnection == null) {
-                    yield executeWithNewConnection(definition, callback);
-                }
-                yield suspend(existingConnection, () -> executeWithNewConnection(definition, finalCallback));
-            }
-        };
-    }
-
-    private <R> R suspend(ConnectionStatus<C> existingConnection,
-                          @NonNull Supplier<R> callback) {
-        return PropagatedContext.getOrEmpty()
-            .minus(existingConnection)
-            .propagate(callback);
-    }
-
-    private <R> R withExistingConnectionInternal(@NonNull ConnectionStatus<C> existingStatus, @NonNull Function<ConnectionStatus<C>, R> callback) {
-        DefaultConnectionStatus<C> newStatus = new DefaultConnectionStatus<>(
-            existingStatus.getConnection(),
-            existingStatus.getDefinition(),
-            false,
-            this
-        );
+        DefaultConnectionStatus<C> connection = getConnection(definition);
         try {
-            setupConnection(newStatus);
-            return PropagatedContext.getOrEmpty().minus(existingStatus).plus(newStatus).propagate(() -> callback.apply(newStatus));
+            setupConnection(connection);
+            return connection.propagate(() -> callback.apply(connection));
         } finally {
-            complete(newStatus);
-        }
-    }
-
-    private <R> R executeWithNewConnection(@NonNull ConnectionDefinition definition,
-                                           @NonNull Function<ConnectionStatus<C>, R> callback) {
-        C connection = openConnection(definition);
-        DefaultConnectionStatus<C> status = new DefaultConnectionStatus<>(connection, definition, true, this);
-        try {
-            setupConnection(status);
-            return status.propagate(() -> callback.apply(status));
-        } finally {
-            complete(status);
+            complete(connection);
         }
     }
 
     @NonNull
     @Override
-    public ConnectionStatus<C> getConnection(@NonNull ConnectionDefinition definition) {
+    public DefaultConnectionStatus<C> getConnection(@NonNull ConnectionDefinition definition) {
         ConnectionStatus<C> existingConnection = findConnectionStatus().orElse(null);
         return switch (definition.getPropagationBehavior()) {
             case REQUIRED -> {
@@ -177,7 +124,7 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
             }
             case MANDATORY -> {
                 if (existingConnection == null) {
-                    throw new NoConnectionException();
+                    throw new NoConnectionException("No existing connection found for connection marked with propagation 'mandatory'");
                 }
                 yield reuseExistingConnectionInternal(existingConnection);
             }

--- a/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractReactorConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractReactorConnectionOperations.java
@@ -19,13 +19,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.propagation.ReactorPropagation;
-import io.micronaut.core.propagation.PropagatedContextElement;
-import io.micronaut.data.connection.exceptions.NoConnectionException;
 import io.micronaut.data.connection.ConnectionDefinition;
-import io.micronaut.data.connection.reactive.DefaultReactiveConnectionStatus;
-import io.micronaut.data.connection.reactive.ReactiveStreamsConnectionOperations;
-import io.micronaut.data.connection.reactive.ReactorConnectionOperations;
 import io.micronaut.data.connection.ConnectionStatus;
+import io.micronaut.data.connection.exceptions.NoConnectionException;
+import io.micronaut.data.connection.reactive.DefaultReactiveConnectionStatus;
+import io.micronaut.data.connection.reactive.ReactorConnectionOperations;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -66,21 +64,25 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
     protected abstract Publisher<Void> closeConnection(@NonNull C connection, @NonNull ConnectionDefinition definition);
 
     @Override
-    public final Optional<ConnectionStatus<C>> findConnectionStatus(@NonNull ContextView contextView) {
-        return findPropagateContextElement(contextView)
-            .map(e -> (ConnectionStatus<C>) e.status);
+    public boolean managesConnection(ConnectionStatus<C> connectionStatus) {
+        if (connectionStatus instanceof DefaultReactiveConnectionStatus<C> reactiveConnectionStatus) {
+            return reactiveConnectionStatus.isConnectionOf(this);
+        }
+        return false;
     }
 
-    private Optional<ClientSessionPropagatedContext> findPropagateContextElement(ContextView contextView) {
-        return ReactorPropagation.findAllContextElements(contextView, ClientSessionPropagatedContext.class)
-            .filter(e -> e.connectionOperations == this)
+    @Override
+    public final Optional<ConnectionStatus<C>> findConnectionStatus(@NonNull ContextView contextView) {
+        return ReactorPropagation.findAllContextElements(contextView, ConnectionStatus.class)
+            .filter(e -> managesConnection(e))
+            .map(status -> (ConnectionStatus<C>) status)
             .findFirst();
     }
 
     @NonNull
     @Override
     public <T> Flux<T> withConnectionFlux(@NonNull ConnectionDefinition definition,
-                                                @NonNull Function<ConnectionStatus<C>, Flux<T>> callback) {
+                                          @NonNull Function<ConnectionStatus<C>, Flux<T>> callback) {
         Objects.requireNonNull(callback, "Callback cannot be null");
         return Flux.deferContextual(contextView -> {
             C connection = findConnection(contextView);
@@ -99,12 +101,12 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
     }
 
     private <T> Flux<T> existingConnectionFlux(ConnectionDefinition definition, Function<ConnectionStatus<C>, Flux<T>> callback, C clientSession) {
-        return applyCallbackFlux(callback, new DefaultReactiveConnectionStatus<>(clientSession, definition, false));
+        return applyCallbackFlux(callback, new DefaultReactiveConnectionStatus<>(clientSession, definition, this, false));
     }
 
     private <T> Flux<T> openConnectionFlux(ConnectionDefinition definition, Function<ConnectionStatus<C>, Flux<T>> callback) {
         return Flux.usingWhen(
-            Mono.from(openConnection(definition)).map(connection -> new DefaultReactiveConnectionStatus<>(connection, definition, true)),
+            Mono.from(openConnection(definition)).map(connection -> new DefaultReactiveConnectionStatus<>(connection, definition, this, true)),
             connectionStatus -> applyCallbackFlux(callback, connectionStatus).contextWrite(ctx -> addClientSession(ctx, connectionStatus)),
             connectionStatus -> connectionStatus.onComplete(() -> closeConnection(connectionStatus.getConnection(), definition)),
             (connectionStatus, throwable) -> connectionStatus.onError(throwable, () -> closeConnection(connectionStatus.getConnection(), definition)),
@@ -115,7 +117,7 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
     @NonNull
     @Override
     public <T> Mono<T> withConnectionMono(@NonNull ConnectionDefinition definition,
-                                                @NonNull Function<ConnectionStatus<C>, Mono<T>> callback) {
+                                          @NonNull Function<ConnectionStatus<C>, Mono<T>> callback) {
         Objects.requireNonNull(callback, "Callback cannot be null");
         return Mono.deferContextual(contextView -> {
             C connection = findConnection(contextView);
@@ -134,12 +136,12 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
     }
 
     private <T> Mono<T> existingConnectionMono(ConnectionDefinition definition, Function<ConnectionStatus<C>, Mono<T>> callback, C clientSession) {
-        return applyCallbackMono(callback, new DefaultReactiveConnectionStatus<>(clientSession, definition, false));
+        return applyCallbackMono(callback, new DefaultReactiveConnectionStatus<>(clientSession, definition, this, false));
     }
 
     private <T> Mono<T> openConnectionMono(ConnectionDefinition definition, Function<ConnectionStatus<C>, Mono<T>> callback) {
         return Mono.usingWhen(
-            Mono.from(openConnection(definition)).map(connection -> new DefaultReactiveConnectionStatus<>(connection, definition, true)),
+            Mono.from(openConnection(definition)).map(connection -> new DefaultReactiveConnectionStatus<>(connection, definition, this, true)),
             connectionStatus -> applyCallbackMono(callback, connectionStatus).contextWrite(ctx -> addClientSession(ctx, connectionStatus)),
             connectionStatus -> connectionStatus.onComplete(() -> closeConnection(connectionStatus.getConnection(), definition)),
             (connectionStatus, throwable) -> connectionStatus.onError(throwable, () -> closeConnection(connectionStatus.getConnection(), definition)),
@@ -155,7 +157,7 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
     private Context addClientSession(@NonNull Context context, @NonNull ConnectionStatus<C> status) {
         return ReactorPropagation.addContextElement(
             context,
-            new ClientSessionPropagatedContext<>(this, status)
+            status
         );
     }
 
@@ -182,9 +184,4 @@ public abstract class AbstractReactorConnectionOperations<C> implements ReactorC
         }
     }
 
-    private record ClientSessionPropagatedContext<C>(
-        ReactiveStreamsConnectionOperations<?> connectionOperations,
-        ConnectionStatus<C> status)
-        implements PropagatedContextElement {
-    }
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/support/DefaultConnectionStatus.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/DefaultConnectionStatus.java
@@ -75,8 +75,8 @@ public final class DefaultConnectionStatus<C> implements ConnectionStatus<C> {
         if (connectionSynchronizations == null) {
             connectionSynchronizations = new ArrayList<>(5);
         }
-        OrderUtil.sort(connectionSynchronizations);
         connectionSynchronizations.add(synchronization);
+        OrderUtil.sort(connectionSynchronizations);
     }
 
     private void forEachSynchronizations(Consumer<ConnectionSynchronization> consumer) {

--- a/data-connection/src/main/java/io/micronaut/data/connection/support/DefaultConnectionStatus.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/DefaultConnectionStatus.java
@@ -18,6 +18,7 @@ package io.micronaut.data.connection.support;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.data.connection.ConnectionDefinition;
+import io.micronaut.data.connection.ConnectionOperations;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.data.connection.ConnectionSynchronization;
 
@@ -27,7 +28,7 @@ import java.util.ListIterator;
 import java.util.function.Consumer;
 
 /**
- * The default connection status.
+ * The default propagated connection status.
  *
  * @param <C> The connection type
  * @author Denis Stepanov
@@ -39,13 +40,19 @@ public final class DefaultConnectionStatus<C> implements ConnectionStatus<C> {
     private final C connection;
     private final ConnectionDefinition definition;
     private final boolean isNew;
+    private final ConnectionOperations<C> connectionOperations;
 
     private List<ConnectionSynchronization> connectionSynchronizations;
 
-    public DefaultConnectionStatus(C connection, ConnectionDefinition definition, boolean isNew) {
+    public DefaultConnectionStatus(C connection, ConnectionDefinition definition, boolean isNew, ConnectionOperations<C> connectionOperations) {
         this.connection = connection;
         this.definition = definition;
         this.isNew = isNew;
+        this.connectionOperations = connectionOperations;
+    }
+
+    public boolean isConnectionOf(ConnectionOperations<C> connectionOperations) {
+        return this.connectionOperations == connectionOperations;
     }
 
     @Override
@@ -96,4 +103,5 @@ public final class DefaultConnectionStatus<C> implements ConnectionStatus<C> {
             forEachSynchronizations(ConnectionSynchronization::afterClosed);
         }
     }
+
 }

--- a/data-connection/src/main/java/io/micronaut/data/connection/sync/SynchronousConnectionOperationsFromReactiveConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/sync/SynchronousConnectionOperationsFromReactiveConnectionOperations.java
@@ -58,9 +58,8 @@ public final class SynchronousConnectionOperationsFromReactiveConnectionOperatio
     @Override
     public <R> R execute(ConnectionDefinition definition, Function<ConnectionStatus<T>, R> callback) {
         Mono<R> result = reactorConnectionOperations.withConnectionMono(definition, status -> Mono.deferContextual(contextView -> {
-            try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty).propagate()) {
-                return Mono.justOrEmpty(callback.apply(status));
-            }
+            PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty);
+            return status.propagate(propagatedContext, () -> Mono.justOrEmpty(callback.apply(status)));
         }).subscribeOn(scheduler)).contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, PropagatedContext.getOrEmpty()));
         return result.onErrorMap(e -> {
             if (e instanceof UndeclaredThrowableException) {
@@ -68,5 +67,10 @@ public final class SynchronousConnectionOperationsFromReactiveConnectionOperatio
             }
             return e;
         }).block();
+    }
+
+    @Override
+    public boolean managesConnection(ConnectionStatus<T> connectionStatus) {
+        return reactorConnectionOperations.managesConnection(connectionStatus);
     }
 }

--- a/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactorTransactionOperations.java
+++ b/data-hibernate-reactive/src/main/java/io/micronaut/data/hibernate/reactive/operations/DefaultHibernateReactorTransactionOperations.java
@@ -60,6 +60,14 @@ final class DefaultHibernateReactorTransactionOperations extends AbstractReactor
     }
 
     @Override
+    public boolean managesTransaction(ReactiveTransactionStatus<Stage.Session> transactionStatus) {
+        if (transactionStatus instanceof HibernateReactiveTransactionStatus status) {
+            return status.operations == this;
+        }
+        return super.managesTransaction(transactionStatus);
+    }
+
+    @Override
     protected <R> Flux<R> executeTransactionFlux(AbstractReactorTransactionOperations.DefaultReactiveTransactionStatus<Stage.Session> txStatus,
                                                  TransactionalCallback<Stage.Session, R> handler) {
         Flux<R> error = validateTransaction(txStatus);
@@ -85,37 +93,7 @@ final class DefaultHibernateReactorTransactionOperations extends AbstractReactor
     }
 
     private ReactiveTransactionStatus<Stage.Session> createTxStatus(DefaultReactiveTransactionStatus<Stage.Session> txStatus, Stage.Transaction transaction) {
-        return new ReactiveTransactionStatus<>() {
-            @Override
-            public ConnectionStatus<Stage.Session> getConnectionStatus() {
-                return txStatus.getConnectionStatus();
-            }
-
-            @Override
-            public boolean isNewTransaction() {
-                return txStatus.isNewTransaction();
-            }
-
-            @Override
-            public void setRollbackOnly() {
-                transaction.markForRollback();
-            }
-
-            @Override
-            public boolean isRollbackOnly() {
-                return transaction.isMarkedForRollback();
-            }
-
-            @Override
-            public boolean isCompleted() {
-                return txStatus.isCompleted();
-            }
-
-            @Override
-            public TransactionDefinition getTransactionDefinition() {
-                return txStatus.getTransactionDefinition();
-            }
-        };
+        return new HibernateReactiveTransactionStatus(txStatus, transaction, this);
     }
 
     private <R> Flux<R> validateTransaction(DefaultReactiveTransactionStatus<Stage.Session> txStatus) {
@@ -149,5 +127,41 @@ final class DefaultHibernateReactorTransactionOperations extends AbstractReactor
 
     private IllegalStateException notSupported() {
         return new IllegalStateException("Not supported");
+    }
+
+    private record HibernateReactiveTransactionStatus(
+        DefaultReactiveTransactionStatus<Stage.Session> txStatus,
+        Stage.Transaction transaction,
+        DefaultHibernateReactorTransactionOperations operations) implements ReactiveTransactionStatus<Stage.Session> {
+
+        @Override
+        public ConnectionStatus<Stage.Session> getConnectionStatus() {
+            return txStatus.getConnectionStatus();
+        }
+
+        @Override
+        public boolean isNewTransaction() {
+            return txStatus.isNewTransaction();
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            transaction.markForRollback();
+        }
+
+        @Override
+        public boolean isRollbackOnly() {
+            return transaction.isMarkedForRollback();
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return txStatus.isCompleted();
+        }
+
+        @Override
+        public TransactionDefinition getTransactionDefinition() {
+            return txStatus.getTransactionDefinition();
+        }
     }
 }

--- a/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/propagate/FooService.java
+++ b/data-hibernate-reactive/src/test/groovy/io/micronaut/data/hibernate/reactive/propagate/FooService.java
@@ -19,9 +19,10 @@ public class FooService {
     Mono<Foo> create() {
         return repository.save(new Foo(requestContext.getId(), "DEFAULT_NAME"))
             .flatMap(entity -> Mono.deferContextual(contextView -> {
-                try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
+                ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate(() -> {
                     entity.setName(requestContext.getName());
-                }
+                    return null;
+                });
                 return repository.update(entity);
             }));
     }
@@ -29,11 +30,11 @@ public class FooService {
     @Transactional
     Mono<Foo> createTransactional() {
         return Mono.deferContextual(contextView -> {
-            try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
+            return ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate(() -> {
                 return repository.save(
                     new Foo(requestContext.getId(), requestContext.getName())
                 );
-            }
+            });
         });
     }
 

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
@@ -706,9 +706,8 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
             if (tx != null) {
                 try {
                     return Flux.deferContextual(contextView -> {
-                        try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
-                            return callback.apply(tx.getConnection());
-                        }
+                        PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty());
+                        return tx.propagate(propagatedContext, () -> callback.apply(tx.getConnection()));
                     });
                 } catch (Exception e) {
                     return Flux.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
@@ -717,9 +716,8 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
             return connectionOperations.withConnectionFlux(
                 isWrite ? ConnectionDefinition.DEFAULT : ConnectionDefinition.READ_ONLY,
                 status -> Flux.deferContextual(contextView -> {
-                    try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
-                        return callback.apply(status.getConnection());
-                    }
+                    PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty());
+                    return status.propagate(propagatedContext, () -> callback.apply(status.getConnection()));
                 })
             );
         }
@@ -733,9 +731,8 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
             if (tx != null) {
                 try {
                     return Mono.deferContextual(contextView -> {
-                        try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
-                            return callback.apply(tx.getConnection());
-                        }
+                        PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty());
+                        return tx.propagate(propagatedContext, () -> callback.apply(tx.getConnection()));
                     });
                 } catch (Exception e) {
                     return Mono.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
@@ -744,9 +741,8 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
             return connectionOperations.withConnectionMono(
                 isWrite ? ConnectionDefinition.DEFAULT : ConnectionDefinition.READ_ONLY,
                 status -> Mono.deferContextual(contextView -> {
-                    try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
-                        return callback.apply(status.getConnection());
-                    }
+                    PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty());
+                    return status.propagate(propagatedContext, () -> callback.apply(status.getConnection()));
                 })
             );
         }
@@ -998,10 +994,10 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
                     return Mono.just(d);
                 }
                 return Mono.deferContextual(contextView -> {
-                    try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
+                    return ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate(() -> {
                         storedQuery.bindParameters(new R2dbcParameterBinder(ctx, stmt, storedQuery), ctx.invocationContext, d.entity, d.previousValues);
-                    }
-                    return Mono.just(d);
+                        return Mono.just(d);
+                    });
                 });
             });
         }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
@@ -95,15 +95,16 @@ public final class DataIntroductionAdvice implements MethodInterceptor<Object, O
         CompletionStage<Object> completionStage = (CompletionStage<Object>) dataInterceptor.intercept(key, context);
         CompletableFuture<Object> completableFuture = new CompletableFuture<>();
         completionStage.whenComplete((value, throwable) -> {
-            try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
+            propagatedContext.propagate(() -> {
                 if (throwable == null) {
                     Class<Object> target = context.getReturnType().asArgument().getType();
-                    if (value == null) {
-                        value = conversionService.convert(new NullValue(), target).orElse(value);
+                    Object v = value;
+                    if (v == null) {
+                        v = conversionService.convert(new NullValue(), target).orElse(v);
                     } else {
-                        value = conversionService.convert(value, target).orElse(value);
+                        v = conversionService.convert(v, target).orElse(v);
                     }
-                    completableFuture.complete(value);
+                    completableFuture.complete(v);
                 } else {
                     Throwable finalThrowable = throwable;
                     if (finalThrowable instanceof CompletionException) {
@@ -111,7 +112,8 @@ public final class DataIntroductionAdvice implements MethodInterceptor<Object, O
                     }
                     completableFuture.completeExceptionally(finalThrowable);
                 }
-            }
+                return null;
+            });
         });
         return completableFuture;
     }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/ExecutorAsyncOperations.java
@@ -68,13 +68,14 @@ public class ExecutorAsyncOperations implements AsyncRepositoryOperations {
         CompletableFuture<T> cf = new CompletableFuture<>();
         PropagatedContext propagatedContext = PropagatedContext.getOrEmpty();
         CompletableFuture.supplyAsync(PropagatedContext.wrapCurrent(supplier), executor).whenComplete((value, throwable) -> {
-            try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
+            propagatedContext.propagate(() -> {
                 if (throwable != null) {
                     cf.completeExceptionally(throwable);
                 } else {
                     cf.complete(value);
                 }
-            }
+                return null;
+            });
         });
         return cf;
     }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractReactiveEntityOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/AbstractReactiveEntityOperations.java
@@ -108,12 +108,12 @@ public abstract class AbstractReactiveEntityOperations<Ctx extends OperationCont
                 return Mono.just(d);
             }
             return Mono.deferContextual(contextView -> {
-                try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
+                return ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate(() -> {
                     final DefaultEntityEventContext<T> event = new DefaultEntityEventContext<>(persistentEntity, d.entity);
                     d.vetoed = !fn.apply((EntityEventContext<Object>) event);
                     d.entity = event.getEntity();
                     return Mono.just(d);
-                }
+                });
             });
         });
         return false;
@@ -126,11 +126,11 @@ public abstract class AbstractReactiveEntityOperations<Ctx extends OperationCont
                 return Mono.just(d);
             }
             return Mono.deferContextual(contextView -> {
-                try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate()) {
+                return ReactorPropagation.findPropagatedContext(contextView).orElse(PropagatedContext.empty()).propagate(() -> {
                     final DefaultEntityEventContext<T> event = new DefaultEntityEventContext<>(persistentEntity, d.entity);
                     fn.accept((EntityEventContext<Object>) event);
                     return Mono.just(d);
-                }
+                });
             });
         });
     }

--- a/data-spring-jdbc/src/main/java/io/micronaut/data/spring/jdbc/SpringJdbcConnectionOperations.java
+++ b/data-spring-jdbc/src/main/java/io/micronaut/data/spring/jdbc/SpringJdbcConnectionOperations.java
@@ -70,11 +70,20 @@ public final class SpringJdbcConnectionOperations implements ConnectionOperation
         return new JdbcTemplate(dataSource).execute((ConnectionCallback<R>) connection -> callback.apply(createStatus(connection)));
     }
 
+    @Override
+    public boolean managesConnection(ConnectionStatus<Connection> connectionStatus) {
+        if (connectionStatus instanceof DefaultConnectionStatus<Connection> status) {
+            return status.isConnectionOf(this);
+        }
+        return false;
+    }
+
     private DefaultConnectionStatus<Connection> createStatus(Connection connection) {
         return new DefaultConnectionStatus<>(
             connection,
             ConnectionDefinition.DEFAULT,
-            true
+            true,
+            this
         );
     }
 

--- a/data-spring-jdbc/src/main/java/io/micronaut/data/spring/tx/AbstractSpringTransactionOperations.java
+++ b/data-spring-jdbc/src/main/java/io/micronaut/data/spring/tx/AbstractSpringTransactionOperations.java
@@ -23,6 +23,7 @@ import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.SynchronousTransactionManager;
 import io.micronaut.transaction.TransactionCallback;
 import io.micronaut.transaction.TransactionDefinition;
+import io.micronaut.transaction.TransactionOperations;
 import io.micronaut.transaction.TransactionStatus;
 import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.support.AbstractPropagatedStatusTransactionOperations;
@@ -35,6 +36,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.sql.Connection;
+import java.util.function.Supplier;
 
 /**
  * Adds Spring Transaction management capability to Micronaut Data.
@@ -60,33 +62,30 @@ public abstract class AbstractSpringTransactionOperations
     }
 
     @Override
+    public boolean managesTransaction(TransactionStatus<Connection> transactionStatus) {
+        if (transactionStatus instanceof SpringTransactionStatus springTransactionStatus) {
+            return springTransactionStatus.isConnectionOf(this);
+        }
+        return false;
+    }
+
+    @Override
     public TransactionStatus<Connection> getTransaction(TransactionDefinition definition) throws TransactionException {
         DefaultTransactionDefinition def = asSpringTxDefinition(definition);
         org.springframework.transaction.TransactionStatus transaction = transactionManager.getTransaction(def);
-        SpringTransactionStatus status = new SpringTransactionStatus(transaction, definition);
-        PropagatedContext propagatedContext = extendCurrentPropagatedContext(status);
-        status.propagatedScope = propagatedContext.propagate();
-        return status;
+        return new SpringTransactionStatus(transaction, definition, this);
     }
 
     @Override
     public void commit(TransactionStatus<Connection> status) throws TransactionException {
         SpringTransactionStatus springTransactionStatus = (SpringTransactionStatus) status;
-        try {
-            transactionManager.commit(springTransactionStatus.springStatus);
-        } finally {
-            springTransactionStatus.propagatedScope.close();
-        }
+        transactionManager.commit(springTransactionStatus.springStatus);
     }
 
     @Override
     public void rollback(TransactionStatus<Connection> status) throws TransactionException {
         SpringTransactionStatus springTransactionStatus = (SpringTransactionStatus) status;
-        try {
-            transactionManager.rollback(springTransactionStatus.springStatus);
-        } finally {
-            springTransactionStatus.propagatedScope.close();
-        }
+        transactionManager.rollback(springTransactionStatus.springStatus);
     }
 
     @Override
@@ -137,7 +136,7 @@ public abstract class AbstractSpringTransactionOperations
     private <R> R execute(TransactionCallback<Connection, R> callback,
                           org.springframework.transaction.TransactionStatus status,
                           TransactionDefinition transactionDefinition) {
-        SpringTransactionStatus txStatus = new SpringTransactionStatus(status, transactionDefinition);
+        SpringTransactionStatus txStatus = new SpringTransactionStatus(status, transactionDefinition, this);
         try {
             return callback.call(txStatus);
         } catch (RuntimeException | Error ex) {
@@ -154,11 +153,16 @@ public abstract class AbstractSpringTransactionOperations
 
         private final org.springframework.transaction.TransactionStatus springStatus;
         private final TransactionDefinition transactionDefinition;
-        private PropagatedContext.Scope propagatedScope;
+        private final TransactionOperations<Connection> transactionOperations;
 
-        SpringTransactionStatus(org.springframework.transaction.TransactionStatus springStatus, TransactionDefinition transactionDefinition) {
+        SpringTransactionStatus(org.springframework.transaction.TransactionStatus springStatus, TransactionDefinition transactionDefinition, TransactionOperations<Connection> transactionOperations) {
             this.springStatus = springStatus;
             this.transactionDefinition = transactionDefinition;
+            this.transactionOperations = transactionOperations;
+        }
+
+        boolean isConnectionOf(TransactionOperations<Connection> transactionOperations) {
+            return this.transactionOperations == transactionOperations;
         }
 
         @Override
@@ -196,6 +200,11 @@ public abstract class AbstractSpringTransactionOperations
         @Override
         public Connection getConnection() {
             return AbstractSpringTransactionOperations.this.getConnection();
+        }
+
+        @Override
+        public <V> V propagate(Supplier<V> supplier) {
+            return PropagatedContext.getOrEmpty().plus(this).propagate(supplier);
         }
 
         @Override

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateConnectionOperations.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateConnectionOperations.java
@@ -64,11 +64,20 @@ public final class SpringHibernateConnectionOperations implements ConnectionOper
         return new HibernateTemplate(sessionFactory).execute(session -> callback.apply(createStatus(session)));
     }
 
+    @Override
+    public boolean managesConnection(ConnectionStatus<Session> connectionStatus) {
+        if (connectionStatus instanceof DefaultConnectionStatus<Session> status) {
+            return status.isConnectionOf(this);
+        }
+        return false;
+    }
+
     private DefaultConnectionStatus<Session> createStatus(Session session) {
         return new DefaultConnectionStatus<>(
             session,
             ConnectionDefinition.DEFAULT,
-            true
+            true,
+            this
         );
     }
 

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
@@ -19,11 +19,13 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.data.spring.tx.AbstractSpringTransactionOperations;
 import io.micronaut.transaction.SynchronousTransactionManager;
 import io.micronaut.transaction.TransactionCallback;
 import io.micronaut.transaction.TransactionDefinition;
+import io.micronaut.transaction.TransactionOperations;
 import io.micronaut.transaction.TransactionStatus;
 import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.support.TransactionSynchronization;
@@ -34,6 +36,7 @@ import org.springframework.orm.hibernate5.HibernateTransactionManager;
 
 import java.sql.Connection;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Adds Spring Transaction management capability to Micronaut Data.
@@ -78,12 +81,12 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
 
     @Override
     public <R> R execute(TransactionDefinition definition, TransactionCallback<Session, R> callback) {
-        return transactionOperations.execute(definition, status -> callback.call(new SessionTransactionStatus(status, definition)));
+        return transactionOperations.execute(definition, status -> callback.call(new SessionTransactionStatus(status, definition, this)));
     }
 
     @Override
     public TransactionStatus<Session> getTransaction(TransactionDefinition definition) throws TransactionException {
-        return new SessionTransactionStatus(transactionOperations.getTransaction(definition), definition);
+        return new SessionTransactionStatus(transactionOperations.getTransaction(definition), definition, this);
     }
 
     @Override
@@ -96,6 +99,14 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
     public void rollback(TransactionStatus<Session> status) throws TransactionException {
         SessionTransactionStatus sessionTransactionStatus = (SessionTransactionStatus) status;
         transactionOperations.rollback(sessionTransactionStatus.status);
+    }
+
+    @Override
+    public boolean managesTransaction(TransactionStatus<Session> transactionStatus) {
+        if (transactionStatus instanceof SessionTransactionStatus sessionTransactionStatus) {
+            return sessionTransactionStatus.isConnectionOf(this);
+        }
+        return false;
     }
 
     private static final class SpringJdbcConnectionTransactionOperations extends AbstractSpringTransactionOperations {
@@ -130,10 +141,16 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
 
         private final TransactionStatus<Connection> status;
         private final TransactionDefinition definition;
+        private final TransactionOperations<?> transactionOperations;
 
-        SessionTransactionStatus(TransactionStatus<Connection> status, TransactionDefinition definition) {
+        SessionTransactionStatus(TransactionStatus<Connection> status, TransactionDefinition definition, TransactionOperations<?> transactionOperations) {
             this.status = status;
             this.definition = definition;
+            this.transactionOperations = transactionOperations;
+        }
+
+        boolean isConnectionOf(TransactionOperations<?> transactionOperations) {
+            return this.transactionOperations == transactionOperations;
         }
 
         @Override
@@ -149,6 +166,11 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
         @Override
         public ConnectionStatus<Session> getConnectionStatus() {
             throw new IllegalStateException("Connection status is not supported for Spring Hibernate TX manager!");
+        }
+
+        @Override
+        public <V> V propagate(Supplier<V> supplier) {
+            return PropagatedContext.getOrEmpty().plus(this).propagate(supplier);
         }
 
         @Override

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
@@ -169,11 +169,6 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
         }
 
         @Override
-        public <V> V propagate(Supplier<V> supplier) {
-            return PropagatedContext.getOrEmpty().plus(this).propagate(supplier);
-        }
-
-        @Override
         public boolean isNewTransaction() {
             return status.isNewTransaction();
         }
@@ -201,6 +196,21 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
         @Override
         public void registerSynchronization(TransactionSynchronization synchronization) {
             status.registerSynchronization(synchronization);
+        }
+
+        @Override
+        public <V> V propagate(PropagatedContext propagatedContext, Supplier<V> supplier) {
+            return status.propagate(propagatedContext, supplier);
+        }
+
+        @Override
+        public void propagate(Runnable runnable) {
+            status.propagate(runnable);
+        }
+
+        @Override
+        public <V> V propagate(Supplier<V> supplier) {
+            return status.propagate(supplier);
         }
     }
 }

--- a/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
+++ b/data-spring-jpa/src/main/java/io/micronaut/data/spring/jpa/hibernate/SpringHibernateTransactionOperations.java
@@ -65,8 +65,9 @@ public final class SpringHibernateTransactionOperations implements SynchronousTr
     }
 
     @Override
-    public Optional<? extends TransactionStatus<?>> findTransactionStatus() {
-        return transactionOperations.findTransactionStatus();
+    public Optional<TransactionStatus<Session>> findTransactionStatus() {
+        return transactionOperations.findTransactionStatus()
+            .map(status -> new SessionTransactionStatus(status, status.getTransactionDefinition(), this));
     }
 
     @Override

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractConnectableSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractConnectableSpec.groovy
@@ -175,41 +175,43 @@ abstract class AbstractConnectableSpec extends Specification implements TestProp
                 }
             })
 
-            connectionOperations.execute(ConnectionDefinition.DEFAULT, status2 -> {
-                status2.registerSynchronization(new ConnectionSynchronization() {
-                    @Override
-                    void executionComplete() {
-                        events.add("con2 executionComplete1")
-                    }
+            status.propagate {
+                connectionOperations.execute(ConnectionDefinition.DEFAULT, status2 -> {
+                    status2.registerSynchronization(new ConnectionSynchronization() {
+                        @Override
+                        void executionComplete() {
+                            events.add("con2 executionComplete1")
+                        }
 
-                    @Override
-                    void beforeClosed() {
-                        events.add("con2 beforeClosed1")
-                    }
+                        @Override
+                        void beforeClosed() {
+                            events.add("con2 beforeClosed1")
+                        }
 
-                    @Override
-                    void afterClosed() {
-                        events.add("con2 afterClosed1")
-                    }
+                        @Override
+                        void afterClosed() {
+                            events.add("con2 afterClosed1")
+                        }
+                    })
+
+                    status2.registerSynchronization(new ConnectionSynchronization() {
+                        @Override
+                        void executionComplete() {
+                            events.add("con2 executionComplete2")
+                        }
+
+                        @Override
+                        void beforeClosed() {
+                            events.add("con2 beforeClosed2")
+                        }
+
+                        @Override
+                        void afterClosed() {
+                            events.add("con2 afterClosed2")
+                        }
+                    })
                 })
-
-                status2.registerSynchronization(new ConnectionSynchronization() {
-                    @Override
-                    void executionComplete() {
-                        events.add("con2 executionComplete2")
-                    }
-
-                    @Override
-                    void beforeClosed() {
-                        events.add("con2 beforeClosed2")
-                    }
-
-                    @Override
-                    void afterClosed() {
-                        events.add("con2 afterClosed2")
-                    }
-                })
-            })
+            }
 
             synchronousConnectionManager.complete(status)
 

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractConnectableSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractConnectableSpec.groovy
@@ -48,7 +48,11 @@ abstract class AbstractConnectableSpec extends Specification implements TestProp
         when:
             def connectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.DEFAULT)
         then:
-            connectionOperations.findConnectionStatus().get() == connectionStatus
+            connectionOperations.findConnectionStatus().isEmpty()
+        and:
+            connectionStatus.propagate {
+                connectionOperations.findConnectionStatus().get() == connectionStatus
+            }
         when:
             synchronousConnectionManager.complete(connectionStatus)
         then:

--- a/data-tck/src/main/java/io/micronaut/data/tck/services/TxBookService.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/services/TxBookService.java
@@ -87,11 +87,14 @@ public class TxBookService extends AbstractBookService {
             throw new IllegalStateException("No Connection expected!");
         }
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        if (connectionOperations.findConnectionStatus().isPresent()) {
-            throw new IllegalStateException("Connection is not expected");
-        }
-        if (transactionManager.findTransactionStatus().isPresent()) {
-            throw new IllegalStateException("TX is not expected");
+        boolean isSpringTX = transactionManager.getClass().getName().toLowerCase().contains("spring");
+        if (!isSpringTX) {
+            if (connectionOperations.findConnectionStatus().isPresent()) {
+                throw new IllegalStateException("Connection is not expected");
+            }
+            if (transactionManager.findTransactionStatus().isPresent()) {
+                throw new IllegalStateException("TX is not expected");
+            }
         }
         transaction.propagate(() -> {
             if (connectionOperations.findConnectionStatus().isEmpty()) {

--- a/data-tck/src/main/java/io/micronaut/data/tck/services/TxBookService.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/services/TxBookService.java
@@ -29,11 +29,13 @@ public class TxBookService extends AbstractBookService {
             ConnectionStatus<Object> outerConnection = getConnection();
             TransactionDefinition definition = new DefaultTransactionDefinition(TransactionDefinition.Propagation.NESTED);
             TransactionStatus<Object> status = transactionManager.getTransaction(definition);
-            ConnectionStatus<Object> txConnection = getConnection();
-            if (!txConnection.equals(outerConnection)) {
-                throw new IllegalStateException("Connection is not the same as the outer connection");
-            }
-            bookRepository.save(newBook("MandatoryBook"));
+            status.propagate(() -> {
+                ConnectionStatus<Object> txConnection = getConnection();
+                if (!txConnection.equals(outerConnection)) {
+                    throw new IllegalStateException("Connection is not the same as the outer connection");
+                }
+                bookRepository.save(newBook("MandatoryBook"));
+            });
             transactionManager.commit(status);
             ConnectionStatus<Object> afterTxConnection = getConnection();
             if (!afterTxConnection.equals(outerConnection)) {
@@ -81,11 +83,25 @@ public class TxBookService extends AbstractBookService {
         if (transactionManager.findTransactionStatus().isPresent()) {
             throw new IllegalStateException("No TX expected!");
         }
-        TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        if (transactionManager.findTransactionStatus().isEmpty()) {
-            throw new IllegalStateException("TX expected");
+        if (connectionOperations.findConnectionStatus().isPresent()) {
+            throw new IllegalStateException("No Connection expected!");
         }
-        mandatoryTransaction();
+        TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
+        if (connectionOperations.findConnectionStatus().isPresent()) {
+            throw new IllegalStateException("Connection is not expected");
+        }
+        if (transactionManager.findTransactionStatus().isPresent()) {
+            throw new IllegalStateException("TX is not expected");
+        }
+        transaction.propagate(() -> {
+            if (connectionOperations.findConnectionStatus().isEmpty()) {
+                throw new IllegalStateException("Connection is expected");
+            }
+            if (transactionManager.findTransactionStatus().isEmpty()) {
+                throw new IllegalStateException("TX is expected");
+            }
+            mandatoryTransaction();
+        });
         transactionManager.commit(transaction);
     }
 
@@ -96,8 +112,10 @@ public class TxBookService extends AbstractBookService {
 
     public void bookAddedInNestedTransactionSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.of(TransactionDefinition.Propagation.NESTED));
-        bookRepository.save(newBook("Book1"));
-        transactionManager.commit(transaction);
+        transaction.propagate(() -> {
+            bookRepository.save(newBook("Book1"));
+            transactionManager.commit(transaction);
+        });
     }
 
     @Transactional(propagation = TransactionDefinition.Propagation.NESTED)
@@ -124,10 +142,12 @@ public class TxBookService extends AbstractBookService {
 
     public void bookAddedInNeverPropagationSync(Runnable noTxCheck) {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.of(TransactionDefinition.Propagation.NEVER));
-        bookRepository.save(newBook("MandatoryBook"));
-        // Spring TX manager will retain the connection and clean it up at the TX end
-        noTxCheck.run();
-        transactionManager.commit(transaction);
+        transaction.propagate(() -> {
+            bookRepository.save(newBook("MandatoryBook"));
+            // Spring TX manager will retain the connection and clean it up at the TX end
+            noTxCheck.run();
+            transactionManager.commit(transaction);
+        });
     }
 
     @jakarta.transaction.Transactional
@@ -138,7 +158,9 @@ public class TxBookService extends AbstractBookService {
     public void bookAddedInInnerNeverPropagationSync(Runnable noTxCheck) {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
         try {
-            bookAddedInNeverPropagationSync(noTxCheck);
+            transaction.propagate(() -> {
+                bookAddedInNeverPropagationSync(noTxCheck);
+            });
             transactionManager.commit(transaction);
         } catch (Exception e) {
             transactionManager.rollback(transaction);
@@ -174,7 +196,9 @@ public class TxBookService extends AbstractBookService {
 
     public void mandatoryTransactionSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.of(TransactionDefinition.Propagation.MANDATORY));
-        bookRepository.save(newBook("MandatoryBook"));
+        transaction.propagate(() -> {
+            bookRepository.save(newBook("MandatoryBook"));
+        });
         transactionManager.commit(transaction);
     }
 
@@ -195,7 +219,9 @@ public class TxBookService extends AbstractBookService {
 
     public void bookIsAddedInAnotherRequiresNewTxSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        addBookRequiresNewSync();
+        transaction.propagate(() -> {
+            addBookRequiresNewSync();
+        });
         transactionManager.commit(transaction);
     }
 
@@ -212,14 +238,16 @@ public class TxBookService extends AbstractBookService {
 
     public void bookIsAddedAndAnotherRequiresNewTxIsFailingSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        bookRepository.save(newBook("Book1"));
-        try {
-            transactionRequiresNewFailing();
-            transactionManager.commit(transaction);
-        } catch (Exception e) {
-            transactionManager.rollback(transaction);
-            throw e;
-        }
+        transaction.propagate(() -> {
+            bookRepository.save(newBook("Book1"));
+            try {
+                transactionRequiresNewFailing();
+                transactionManager.commit(transaction);
+            } catch (Exception e) {
+                transactionManager.rollback(transaction);
+                throw e;
+            }
+        });
     }
 
     @jakarta.transaction.Transactional
@@ -234,19 +262,23 @@ public class TxBookService extends AbstractBookService {
 
     public void innerTransactionHasSuppressedExceptionSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        transactionFailingSync();
-        bookRepository.save(newBook("Book1"));
+        transaction.propagate(() -> {
+            transactionFailingSync();
+            bookRepository.save(newBook("Book1"));
+        });
         transactionManager.commit(transaction);
     }
 
     public void innerTransactionHasSuppressedExceptionSync2() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
-        try {
-            transactionFailing();
-        } catch (Exception e) {
-            // Ignore
-        }
-        bookRepository.save(newBook("Book1"));
+        transaction.propagate(() -> {
+            try {
+                transactionFailing();
+            } catch (Exception e) {
+                // Ignore
+            }
+            bookRepository.save(newBook("Book1"));
+        });
         transactionManager.commit(transaction);
     }
 
@@ -285,7 +317,9 @@ public class TxBookService extends AbstractBookService {
 
     public void addBookRequiresNewSync() {
         TransactionStatus<Object> transaction = transactionManager.getTransaction(TransactionDefinition.of(TransactionDefinition.Propagation.REQUIRES_NEW));
-        bookRepository.save(newBook("Book1"));
+        transaction.propagate(() -> {
+            bookRepository.save(newBook("Book1"));
+        });
         transactionManager.commit(transaction);
     }
 

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionOperations.java
@@ -86,4 +86,14 @@ public interface TransactionOperations<T> {
     default <R> R executeWrite(@NonNull TransactionCallback<T, R> callback) {
         return execute(TransactionDefinition.DEFAULT, callback);
     }
+
+    /**
+     * Determine whether the given transaction status refers to a transaction
+     * managed by this {@link TransactionOperations} instance.
+     *
+     * @param transactionStatus The transaction status to verify
+     * @return true if the transaction is managed (i.e. created/supplied) by this operations instance
+     * @since 5.0
+     */
+    boolean managesTransaction(@NonNull TransactionStatus<T> transactionStatus);
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionOperations.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.transaction;
 
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Blocking;
 
@@ -52,8 +51,7 @@ public interface TransactionOperations<T> {
      * Find optional propagated transaction status.
      * @return The transaction status.
      */
-    @Experimental
-    Optional<? extends TransactionStatus<?>> findTransactionStatus();
+    Optional<TransactionStatus<T>> findTransactionStatus();
 
     /**
      * Execute a transaction within the context of the function.

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
@@ -17,9 +17,13 @@ package io.micronaut.transaction;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.exceptions.TransactionUsageException;
 import io.micronaut.transaction.support.TransactionSynchronization;
+
+import java.util.function.Supplier;
 
 /**
  * The transaction status.
@@ -29,7 +33,7 @@ import io.micronaut.transaction.support.TransactionSynchronization;
  * @author Denis Stepanov
  * @since 1.0.0
  */
-public interface TransactionStatus<T> extends TransactionExecution {
+public interface TransactionStatus<T> extends TransactionExecution, PropagatedContextElement {
 
     /**
      * @return The underlying transaction object if exists.
@@ -63,5 +67,44 @@ public interface TransactionStatus<T> extends TransactionExecution {
     default void registerSynchronization(@NonNull TransactionSynchronization synchronization) {
         throw new TransactionUsageException("Transaction synchronization is not supported!");
     }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param propagatedContext The propagated context
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(PropagatedContext propagatedContext, Supplier<V> supplier) {
+        return propagatedContext.plus(getConnectionStatus()).plus(this).propagate(supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(Supplier<V> supplier) {
+        return propagate(PropagatedContext.getOrEmpty(), supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param runnable The runnable
+     * @since 5.0
+     */
+    default void propagate(Runnable runnable) {
+        propagate(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
 }
 

--- a/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/TransactionStatus.java
@@ -90,7 +90,7 @@ public interface TransactionStatus<T> extends TransactionExecution, PropagatedCo
      * @since 5.0
      */
     default <V> V propagate(Supplier<V> supplier) {
-        return propagate(PropagatedContext.getOrEmpty(), supplier);
+        return PropagatedContext.getOrEmpty().plus(getConnectionStatus()).plus(this).propagate(supplier);
     }
 
     /**

--- a/data-tx/src/main/java/io/micronaut/transaction/async/AsyncTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/async/AsyncTransactionOperations.java
@@ -62,4 +62,14 @@ public interface AsyncTransactionOperations<C> {
     default @NonNull <T> CompletionStage<T> withTransaction(@NonNull Function<AsyncTransactionStatus<C>, CompletionStage<T>> handler) {
         return withTransaction(TransactionDefinition.DEFAULT, handler);
     }
+
+    /**
+     * Determine whether the given transaction status refers to a transaction
+     * managed by this {@link AsyncTransactionOperations} instance.
+     *
+     * @param transactionStatus The transaction status to verify
+     * @return true if the transaction is managed (i.e. created/supplied) by this operations instance
+     * @since 5.0
+     */
+    boolean managesTransaction(@NonNull AsyncTransactionStatus<C> transactionStatus);
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/async/AsyncTransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/async/AsyncTransactionStatus.java
@@ -16,7 +16,12 @@
 package io.micronaut.transaction.async;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
+import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.TransactionExecution;
+
+import java.util.function.Supplier;
 
 /**
  * Status object for async transactions.
@@ -25,10 +30,57 @@ import io.micronaut.transaction.TransactionExecution;
  * @author Denis Stepanov
  * @since 3.5.0
  */
-public interface AsyncTransactionStatus<T> extends TransactionExecution {
+public interface AsyncTransactionStatus<T> extends TransactionExecution, PropagatedContextElement {
+
+    /**
+     * @return The connection status.
+     */
+    @NonNull
+    ConnectionStatus<T> getConnectionStatus();
+
     /**
      * @return The current connection.
      */
     @NonNull
-    T getConnection();
+    default T getConnection() {
+        return getConnectionStatus().getConnection();
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param propagatedContext The propagated context
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(PropagatedContext propagatedContext, Supplier<V> supplier) {
+        return propagatedContext.plus(getConnectionStatus()).plus(this).propagate(supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(Supplier<V> supplier) {
+        return propagate(PropagatedContext.getOrEmpty(), supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param runnable The runnable
+     * @since 5.0
+     */
+    default void propagate(Runnable runnable) {
+        propagate(() -> {
+            runnable.run();
+            return null;
+        });
+    }
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/async/AsyncUsingReactiveTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/async/AsyncUsingReactiveTransactionOperations.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.TransactionDefinition;
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus;
 import io.micronaut.transaction.reactive.ReactorReactiveTransactionOperations;
@@ -50,12 +51,20 @@ public final class AsyncUsingReactiveTransactionOperations<C> implements AsyncTr
     }
 
     @Override
+    public boolean managesTransaction(AsyncTransactionStatus<C> transactionStatus) {
+        if (transactionStatus instanceof DefaultAsyncTransactionStatus<C> status) {
+            return status.asyncTransactionOperations == this;
+        }
+        return false;
+    }
+
+    @Override
     public Optional<? extends AsyncTransactionStatus<?>> findTransactionStatus() {
         return Optional.ofNullable(
             reactiveTransactionOperations.getTransactionStatus(
                 ReactorPropagation.addPropagatedContext(Context.empty(), PropagatedContext.getOrEmpty())
             )
-        ).map(DefaultAsyncTransactionStatus::new);
+        ).map(status -> new DefaultAsyncTransactionStatus<>(status, this));
     }
 
     @Override
@@ -63,11 +72,9 @@ public final class AsyncUsingReactiveTransactionOperations<C> implements AsyncTr
                                                   Function<AsyncTransactionStatus<C>, CompletionStage<T>> handler) {
         Mono<T> result = Mono.fromDirect(reactiveTransactionOperations.withTransaction(definition,
             status -> Mono.deferContextual(contextView -> Mono.fromCompletionStage(() -> {
-                try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView)
-                    .orElseGet(PropagatedContext::getOrEmpty)
-                    .propagate()) {
-                    return handler.apply(new DefaultAsyncTransactionStatus<>(status));
-                }
+                DefaultAsyncTransactionStatus<C> asyncStatus = new DefaultAsyncTransactionStatus<>(status, this);
+                PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty);
+                return asyncStatus.propagate(propagatedContext, () -> handler.apply(asyncStatus));
             }))));
         return onCompleteCompleteFuture(result);
     }
@@ -97,23 +104,25 @@ public final class AsyncUsingReactiveTransactionOperations<C> implements AsyncTr
 
             @Override
             public void onError(Throwable t) {
-                try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
-                    completableFuture.completeExceptionally(t);
-                }
+                propagatedContext.propagate(() -> completableFuture.completeExceptionally(t));
             }
 
             @Override
             public void onComplete() {
-                try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
-                    completableFuture.complete(result);
-                }
+                propagatedContext.propagate(() -> completableFuture.complete(result));
             }
         });
         return completableFuture;
     }
 
     private record DefaultAsyncTransactionStatus<T>(
-        ReactiveTransactionStatus<T> status) implements AsyncTransactionStatus<T> {
+        ReactiveTransactionStatus<T> status,
+        AsyncTransactionOperations<T> asyncTransactionOperations) implements AsyncTransactionStatus<T> {
+
+        @Override
+        public ConnectionStatus<T> getConnectionStatus() {
+            return status.getConnectionStatus();
+        }
 
         @Override
         public boolean isNewTransaction() {

--- a/data-tx/src/main/java/io/micronaut/transaction/async/AsyncUsingSyncTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/async/AsyncUsingSyncTransactionOperations.java
@@ -18,6 +18,7 @@ package io.micronaut.transaction.async;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.SynchronousTransactionManager;
 import io.micronaut.transaction.TransactionDefinition;
 import io.micronaut.transaction.TransactionStatus;
@@ -43,29 +44,38 @@ public final class AsyncUsingSyncTransactionOperations<C> implements AsyncTransa
     }
 
     @Override
+    public boolean managesTransaction(AsyncTransactionStatus<C> transactionStatus) {
+        if (transactionStatus instanceof DefaultAsyncTransactionStatus<C> status) {
+            return status.operations == this;
+        }
+        return false;
+    }
+
+    @Override
     public <T> CompletionStage<T> withTransaction(TransactionDefinition definition,
                                                   Function<AsyncTransactionStatus<C>, CompletionStage<T>> handler) {
         CompletableFuture<T> newResult = new CompletableFuture<>();
+        TransactionStatus<C> status = synchronousTransactionManager.getTransaction(definition);
+        CompletionStage<T> result;
         PropagatedContext propagatedContext = PropagatedContext.getOrEmpty();
-        try (PropagatedContext.Scope ignore = propagatedContext.propagate()) { // Propagate to clean up the scope
-            TransactionStatus<C> status = synchronousTransactionManager.getTransaction(definition);
-            CompletionStage<T> result;
-            try {
-                result = handler.apply(new DefaultAsyncTransactionStatus<>(status));
-            } catch (Throwable e) {
-                CompletableFuture<T> r = new CompletableFuture<>();
-                r.completeExceptionally(e);
-                result = r;
-            }
+        try {
+            DefaultAsyncTransactionStatus<C> txStatus = new DefaultAsyncTransactionStatus<>(status, this);
+            result = txStatus.propagate(propagatedContext.plus(status), () -> handler.apply(txStatus));
+        } catch (Throwable e) {
+            CompletableFuture<T> r = new CompletableFuture<>();
+            r.completeExceptionally(e);
+            result = r;
+        }
 
-            // Last step to complete the TX, we need to use `withState` to properly setup thread-locals for the TX manager
-            result.whenComplete((o, throwable) -> {
+        // Last step to complete the TX, we need to use `withState` to properly setup thread-locals for the TX manager
+        result.whenComplete((o, throwable) -> {
+            propagatedContext.propagate(() -> {
                 if (throwable == null) {
                     try {
                         synchronousTransactionManager.commit(status);
                     } catch (Throwable e) {
                         newResult.completeExceptionally(e);
-                        return;
+                        return null;
                     }
                     newResult.complete(o);
                 } else {
@@ -76,13 +86,20 @@ public final class AsyncUsingSyncTransactionOperations<C> implements AsyncTransa
                     }
                     newResult.completeExceptionally(throwable);
                 }
+                return null;
             });
-        }
+        });
         return newResult;
     }
 
     private record DefaultAsyncTransactionStatus<T>(
-        TransactionStatus<T> status) implements AsyncTransactionStatus<T> {
+        TransactionStatus<T> status,
+        AsyncTransactionOperations<T> operations) implements AsyncTransactionStatus<T> {
+
+        @Override
+        public ConnectionStatus<T> getConnectionStatus() {
+            return status.getConnectionStatus();
+        }
 
         @Override
         public boolean isNewTransaction() {

--- a/data-tx/src/main/java/io/micronaut/transaction/impl/DefaultTransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/impl/DefaultTransactionStatus.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.TransactionDefinition;
+import io.micronaut.transaction.TransactionOperations;
 import io.micronaut.transaction.support.TransactionSynchronization;
 
 /**
@@ -34,29 +35,40 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
 
     protected final ConnectionStatus<C> connectionStatus;
     private final TransactionDefinition definition;
+    private final TransactionOperations<C> transactionOperations;
     @Nullable
     private Object transaction;
     @Nullable
     private Object savepoint;
 
     private DefaultTransactionStatus(ConnectionStatus<C> connectionStatus,
-                                     TransactionDefinition definition) {
+                                     TransactionDefinition definition,
+                                     TransactionOperations<C> transactionOperations) {
         this.connectionStatus = connectionStatus;
         this.definition = definition;
+        this.transactionOperations = transactionOperations;
     }
 
     public static <C> DefaultTransactionStatus<C> newTx(ConnectionStatus<C> connectionStatus,
-                                                        TransactionDefinition definition) {
-        return new NewTransactionStatus<>(connectionStatus, definition);
+                                                        TransactionDefinition definition,
+                                                        TransactionOperations<C> transactionOperations) {
+        return new NewTransactionStatus<>(connectionStatus, definition, transactionOperations);
     }
 
     public static <C> DefaultTransactionStatus<C> noTx(ConnectionStatus<C> connectionStatus,
-                                                       TransactionDefinition definition) {
-        return new NoTxTransactionStatus<>(connectionStatus, definition);
+                                                       TransactionDefinition definition,
+                                                       TransactionOperations<C> transactionOperations) {
+        return new NoTxTransactionStatus<>(connectionStatus, definition, transactionOperations);
     }
 
-    public static <C> DefaultTransactionStatus<C> existingTx(ConnectionStatus<C> connectionStatus, DefaultTransactionStatus<C> existingTransaction) {
-        return new ExistingTransactionStatus<>(connectionStatus, existingTransaction);
+    public static <C> DefaultTransactionStatus<C> existingTx(ConnectionStatus<C> connectionStatus,
+                                                             DefaultTransactionStatus<C> existingTransaction,
+                                                             TransactionOperations<C> transactionOperations) {
+        return new ExistingTransactionStatus<>(connectionStatus, existingTransaction, transactionOperations);
+    }
+
+    public boolean isTransactionOf(TransactionOperations<C> transactionOperations) {
+        return this.transactionOperations ==  transactionOperations;
     }
 
     @Override
@@ -116,8 +128,9 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
     private static final class NewTransactionStatus<C> extends DefaultTransactionStatus<C> {
 
         public NewTransactionStatus(ConnectionStatus<C> connectionStatus,
-                                    TransactionDefinition definition) {
-            super(connectionStatus, definition);
+                                    TransactionDefinition definition,
+                                    TransactionOperations<C> transactionOperations) {
+            super(connectionStatus, definition, transactionOperations);
         }
 
         @Override
@@ -130,8 +143,9 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
     private static final class NoTxTransactionStatus<C> extends DefaultTransactionStatus<C> {
 
         public NoTxTransactionStatus(ConnectionStatus<C> connectionStatus,
-                                     TransactionDefinition definition) {
-            super(connectionStatus, definition);
+                                     TransactionDefinition definition,
+                                     TransactionOperations<C> transactionOperations) {
+            super(connectionStatus, definition, transactionOperations);
         }
 
         @Override
@@ -146,8 +160,9 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
         private final DefaultTransactionStatus<C> existingTransaction;
 
         public ExistingTransactionStatus(ConnectionStatus<C> connectionStatus,
-                                         DefaultTransactionStatus<C> existingTransaction) {
-            super(connectionStatus, existingTransaction.getTransactionDefinition());
+                                         DefaultTransactionStatus<C> existingTransaction,
+                                         TransactionOperations<C> transactionOperations) {
+            super(connectionStatus, existingTransaction.getTransactionDefinition(), transactionOperations);
             this.existingTransaction = existingTransaction;
         }
 

--- a/data-tx/src/main/java/io/micronaut/transaction/reactive/ReactiveTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/reactive/ReactiveTransactionOperations.java
@@ -49,6 +49,16 @@ public interface ReactiveTransactionOperations<C> {
     }
 
     /**
+     * Determine whether the given transaction status refers to a transaction
+     * managed by this {@link ReactiveTransactionOperations} instance.
+     *
+     * @param transactionStatus The transaction status to verify
+     * @return true if the transaction is managed (i.e. created/supplied) by this operations instance
+     * @since 5.0
+     */
+    boolean managesTransaction(@NonNull ReactiveTransactionStatus<C> transactionStatus);
+
+    /**
      * A transactional callback interface.
      *
      * @param <C> The connection type
@@ -63,4 +73,5 @@ public interface ReactiveTransactionOperations<C> {
          */
         Publisher<T> doInTransaction(ReactiveTransactionStatus<C> status);
     }
+
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/reactive/ReactiveTransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/reactive/ReactiveTransactionStatus.java
@@ -16,8 +16,12 @@
 package io.micronaut.transaction.reactive;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.transaction.TransactionExecution;
+
+import java.util.function.Supplier;
 
 /**
  * Status object for reactive transactions.
@@ -26,7 +30,7 @@ import io.micronaut.transaction.TransactionExecution;
  * @author graemerocher
  * @since 2.2.0
  */
-public interface ReactiveTransactionStatus<T> extends TransactionExecution {
+public interface ReactiveTransactionStatus<T> extends TransactionExecution, PropagatedContextElement {
 
     /**
      * @return The current connection.
@@ -40,5 +44,43 @@ public interface ReactiveTransactionStatus<T> extends TransactionExecution {
      */
     @NonNull
     ConnectionStatus<T> getConnectionStatus();
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param propagatedContext The propagated context
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(PropagatedContext propagatedContext, Supplier<V> supplier) {
+        return propagatedContext.plus(getConnectionStatus()).plus(this).propagate(supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param supplier The supplier
+     * @param <V>      The value type
+     * @return The value
+     * @since 5.0
+     */
+    default <V> V propagate(Supplier<V> supplier) {
+        return propagate(PropagatedContext.getOrEmpty(), supplier);
+    }
+
+    /**
+     * Propagated the current {@link io.micronaut.core.propagation.PropagatedContext} with added connection status.
+     *
+     * @param runnable The runnable
+     * @since 5.0
+     */
+    default void propagate(Runnable runnable) {
+        propagate(() -> {
+            runnable.run();
+            return null;
+        });
+    }
 
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
@@ -43,8 +43,8 @@ public abstract class AbstractDefaultTransactionOperations<C> extends AbstractTr
     }
 
     @Override
-    protected DefaultTransactionStatus<C> createExistingTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition, DefaultTransactionStatus<C> existingTransaction) {
-        return DefaultTransactionStatus.existingTx(connectionStatus, existingTransaction, this);
+    protected DefaultTransactionStatus<C> createExistingTransactionStatus(TransactionDefinition definition, DefaultTransactionStatus<C> existingTransaction) {
+        return DefaultTransactionStatus.existingTx(existingTransaction.getConnectionStatus(), existingTransaction, this);
     }
 
     @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
@@ -39,17 +39,17 @@ public abstract class AbstractDefaultTransactionOperations<C> extends AbstractTr
 
     @Override
     protected DefaultTransactionStatus<C> createNewTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
-        return DefaultTransactionStatus.newTx(connectionStatus, definition);
+        return DefaultTransactionStatus.newTx(connectionStatus, definition, this);
     }
 
     @Override
     protected DefaultTransactionStatus<C> createExistingTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition, DefaultTransactionStatus<C> existingTransaction) {
-        return DefaultTransactionStatus.existingTx(connectionStatus, existingTransaction);
+        return DefaultTransactionStatus.existingTx(connectionStatus, existingTransaction, this);
     }
 
     @Override
     protected DefaultTransactionStatus<C> createNoTxTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
-        return DefaultTransactionStatus.noTx(connectionStatus, definition);
+        return DefaultTransactionStatus.noTx(connectionStatus, definition, this);
     }
 
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractPropagatedStatusTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractPropagatedStatusTransactionOperations.java
@@ -45,7 +45,11 @@ public abstract class AbstractPropagatedStatusTransactionOperations<T extends Tr
     protected abstract <R> R doExecute(TransactionDefinition definition, TransactionCallback<C, R> callback);
 
     @Override
-    public final Optional<T> findTransactionStatus() {
+    public final Optional<TransactionStatus<C>> findTransactionStatus() {
+        return findTransactionStatusInternal().map(status -> status);
+    }
+
+    public final Optional<T> findTransactionStatusInternal() {
         return PropagatedContext.getOrEmpty()
             .findAll(TransactionStatus.class)
             .filter(this::managesTransaction)

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractPropagatedStatusTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractPropagatedStatusTransactionOperations.java
@@ -17,7 +17,6 @@ package io.micronaut.transaction.support;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.transaction.TransactionCallback;
 import io.micronaut.transaction.TransactionDefinition;
 import io.micronaut.transaction.TransactionOperations;
@@ -47,45 +46,23 @@ public abstract class AbstractPropagatedStatusTransactionOperations<T extends Tr
 
     @Override
     public final Optional<T> findTransactionStatus() {
-        return findTransactionPropagatedContextElement()
-            .map(PropagatedTransactionStatusElement::status)
-            .map(status -> (T) status);
-    }
-
-    private Optional<PropagatedTransactionStatusElement> findTransactionPropagatedContextElement() {
         return PropagatedContext.getOrEmpty()
-            .findAll(PropagatedTransactionStatusElement.class)
-            .filter(element -> element.transactionOperations == this)
-            .findFirst();
+            .findAll(TransactionStatus.class)
+            .filter(this::managesTransaction)
+            .findFirst()
+            .map(status -> (T) status);
     }
 
     @Override
     public final <R> R execute(@NonNull TransactionDefinition definition,
                                @NonNull TransactionCallback<C, R> callback) {
-        return doExecute(definition, status -> {
-            try (PropagatedContext.Scope ignore = extendCurrentPropagatedContext(status)
-                .propagate()) {
+        return doExecute(definition, status -> status.propagate(() -> {
+            try {
                 return callback.call(status);
+            } catch (Exception e) {
+                return ExceptionUtil.sneakyThrow(e);
             }
-        });
-    }
-
-    /**
-     * Extends the propagated context with the transaction status.
-     *
-     * @param status The transaction status
-     * @return new propagated context
-     */
-    @NonNull
-    protected PropagatedContext extendCurrentPropagatedContext(TransactionStatus<C> status) {
-        return PropagatedContext.getOrEmpty()
-            .plus(new PropagatedTransactionStatusElement<>(AbstractPropagatedStatusTransactionOperations.this, status));
-    }
-
-    private record PropagatedTransactionStatusElement<T extends TransactionStatus<?>>(
-        TransactionOperations<?> transactionOperations,
-        TransactionStatus<?> status
-    ) implements PropagatedContextElement {
+        }));
     }
 
 }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
@@ -75,7 +75,7 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     @Override
     public boolean managesTransaction(ReactiveTransactionStatus<C> transactionStatus) {
         if (transactionStatus instanceof DefaultReactiveTransactionStatus<C> status) {
-            return status.isTransactionOf(this);
+            return status.reactiveTransactionOperations == this;
         }
         return false;
     }
@@ -410,10 +410,6 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
             this.isNew = isNew;
             this.transactionDefinition = transactionDefinition;
             this.reactiveTransactionOperations = reactiveTransactionOperations;
-        }
-
-        boolean isTransactionOf(@NonNull ReactiveTransactionOperations<C> reactiveTransactionOperations) {
-            return this.reactiveTransactionOperations == reactiveTransactionOperations;
         }
 
         @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractReactorTransactionOperations.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.async.propagation.ReactorPropagation;
-import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.data.connection.ConnectionStatus;
 import io.micronaut.data.connection.reactive.ReactiveConnectionStatus;
 import io.micronaut.data.connection.reactive.ReactiveConnectionSynchronization;
@@ -74,10 +73,18 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
                                                            @NonNull TransactionDefinition transactionDefinition);
 
     @Override
+    public boolean managesTransaction(ReactiveTransactionStatus<C> transactionStatus) {
+        if (transactionStatus instanceof DefaultReactiveTransactionStatus<C> status) {
+            return status.isTransactionOf(this);
+        }
+        return false;
+    }
+
+    @Override
     public final Optional<ReactiveTransactionStatus<C>> findTransactionStatus(ContextView contextView) {
-        return ReactorPropagation.findAllContextElements(contextView, ReactiveTransactionPropagatedContext.class)
-            .filter(e -> e.transactionOperations == this)
-            .map(e -> (ReactiveTransactionStatus<C>) e.status)
+        return ReactorPropagation.findAllContextElements(contextView, ReactiveTransactionStatus.class)
+            .filter(this::managesTransaction)
+            .map(e -> (ReactiveTransactionStatus<C>) e)
             .findFirst();
     }
 
@@ -136,7 +143,7 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
 
     private <T> Flux<T> openNewConnectionAndTx(TransactionDefinition definition, TransactionalCallback<C, T> handler) {
         return connectionOperations.withConnectionFlux(definition.getConnectionDefinition(), connectionStatus -> {
-                DefaultReactiveTransactionStatus<C> txStatus = new DefaultReactiveTransactionStatus<>(connectionStatus, true, definition);
+                DefaultReactiveTransactionStatus<C> txStatus = new DefaultReactiveTransactionStatus<>(connectionStatus, true, definition, this);
                 return executeTransactionFlux(txStatus, handler);
             }
         );
@@ -172,7 +179,7 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     private <T> Mono<T> openNewConnectionAndTxMono(TransactionDefinition definition, Function<ReactiveTransactionStatus<C>, Mono<T>> handler) {
         return connectionOperations.withConnectionMono(definition.getConnectionDefinition(), connectionStatus ->
             executeTransactionMono(
-                new DefaultReactiveTransactionStatus<>(connectionStatus, true, definition),
+                new DefaultReactiveTransactionStatus<>(connectionStatus, true, definition, this),
                 handler
             )
         );
@@ -271,7 +278,7 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
                                               @NonNull Function<ReactiveTransactionStatus<C>, Mono<R>> handler) {
         try {
             return Mono.just(status)
-                .flatMap(handler::apply)
+                .flatMap(handler)
                 .contextWrite(context -> addTxStatus(context, status));
         } catch (Exception e) {
             return Mono.error(new TransactionSystemException("Error invoking doInTransaction handler: " + e.getMessage(), e));
@@ -279,21 +286,7 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     }
 
     private ReactiveTransactionStatus<C> existingTransaction(ReactiveTransactionStatus<C> existing, TransactionDefinition transactionDefinition) {
-        return new ReactiveTransactionStatus<>() {
-            @Override
-            public C getConnection() {
-                return existing.getConnection();
-            }
-
-            @Override
-            public ConnectionStatus<C> getConnectionStatus() {
-                return existing.getConnectionStatus();
-            }
-
-            @Override
-            public boolean isNewTransaction() {
-                return false;
-            }
+        return new DefaultReactiveTransactionStatus<>(existing.getConnectionStatus(), false, transactionDefinition, this) {
 
             @Override
             public void setRollbackOnly() {
@@ -310,10 +303,6 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
                 return existing.isCompleted();
             }
 
-            @Override
-            public TransactionDefinition getTransactionDefinition() {
-                return transactionDefinition;
-            }
         };
     }
 
@@ -332,20 +321,20 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
     @NonNull
     private Publisher<Void> doCommit(@NonNull DefaultReactiveTransactionStatus<C> status) {
         Flux<Void> op;
-		try {
-			if (status.isRollbackOnly()) {
-				op = Flux.from(rollbackTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
-			} else {
-				op = Flux.from(commitTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
-			}
-		} catch (Exception e) {
-			// Sometimes an exception can be thrown creating the publishers for rollback or commit.
-			// An example of this, is if the connection has been closed prematurely by the DBMS.
-			// We should ensure we always return a Publisher to allow downstream consumers to properly
-			// detect and handle these type of errors.
-			op = Flux.error(e);
-		}
-		return op.as(flux -> doFinish(flux, status));
+        try {
+            if (status.isRollbackOnly()) {
+                op = Flux.from(rollbackTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
+            } else {
+                op = Flux.from(commitTransaction(status.getConnectionStatus(), status.getTransactionDefinition()));
+            }
+        } catch (Exception e) {
+            // Sometimes an exception can be thrown creating the publishers for rollback or commit.
+            // An example of this, is if the connection has been closed prematurely by the DBMS.
+            // We should ensure we always return a Publisher to allow downstream consumers to properly
+            // detect and handle these type of errors.
+            op = Flux.error(e);
+        }
+        return op.as(flux -> doFinish(flux, status));
     }
 
     @NonNull
@@ -354,20 +343,20 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
             LOG.warn("Rolling back transaction on error: " + throwable.getMessage(), throwable);
         }
         Flux<Void> abort;
-		try {
-			TransactionDefinition definition = status.getTransactionDefinition();
-			if (definition.rollbackOn(throwable)) {
-				abort = Flux.from(rollbackTransaction(status.getConnectionStatus(), definition));
-			} else {
-				abort = Flux.error(throwable);
-			}
-		} catch (Exception e) {
-			// Sometimes an exception can be thrown creating the publishers for rollback or commit.
-			// An example of this, is if the connection has been closed prematurely by the DBMS.
-			// We should ensure we always return a Publisher to allow downstream consumers to properly
-			// detect and handle these type of errors.
-			abort = Flux.error(e);
-		}
+        try {
+            TransactionDefinition definition = status.getTransactionDefinition();
+            if (definition.rollbackOn(throwable)) {
+                abort = Flux.from(rollbackTransaction(status.getConnectionStatus(), definition));
+            } else {
+                abort = Flux.error(throwable);
+            }
+        } catch (Exception e) {
+            // Sometimes an exception can be thrown creating the publishers for rollback or commit.
+            // An example of this, is if the connection has been closed prematurely by the DBMS.
+            // We should ensure we always return a Publisher to allow downstream consumers to properly
+            // detect and handle these type of errors.
+            abort = Flux.error(e);
+        }
         return abort.onErrorResume((rollbackError) -> {
             if (rollbackError != throwable && LOG.isWarnEnabled()) {
                 LOG.warn("Error occurred during transaction rollback: " + rollbackError.getMessage(), rollbackError);
@@ -385,10 +374,9 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
 
     @NonNull
     private Context addTxStatus(@NonNull Context context, @NonNull ReactiveTransactionStatus<C> status) {
-        return ReactorPropagation.addContextElement(
-            context,
-            new ReactiveTransactionPropagatedContext<>(this, status)
-        );
+        context = ReactorPropagation.addContextElement(context, status.getConnectionStatus());
+        context = ReactorPropagation.addContextElement(context, status);
+        return context;
     }
 
     @NonNull
@@ -401,30 +389,31 @@ public abstract class AbstractReactorTransactionOperations<C> implements Reactor
         return new TransactionUsageException("Found an existing transaction but propagation behaviour doesn't support it: " + propagationBehavior);
     }
 
-    private record ReactiveTransactionPropagatedContext<C>(
-        ReactiveTransactionOperations<?> transactionOperations,
-        ReactiveTransactionStatus<C> status)
-        implements PropagatedContextElement {
-    }
-
     /**
      * Represents the current reactive transaction status.
      *
      * @param <C> The connection type
      */
-    protected static final class DefaultReactiveTransactionStatus<C> implements ReactiveTransactionStatus<C> {
+    protected static class DefaultReactiveTransactionStatus<C> implements ReactiveTransactionStatus<C> {
         private final ConnectionStatus<C> connectionStatus;
         private final boolean isNew;
         private final TransactionDefinition transactionDefinition;
+        private final ReactiveTransactionOperations<C> reactiveTransactionOperations;
         private boolean rollbackOnly;
         private boolean completed;
 
         public DefaultReactiveTransactionStatus(ConnectionStatus<C> connectionStatus,
                                                 boolean isNew,
-                                                TransactionDefinition transactionDefinition) {
+                                                TransactionDefinition transactionDefinition,
+                                                ReactiveTransactionOperations<C> reactiveTransactionOperations) {
             this.connectionStatus = connectionStatus;
             this.isNew = isNew;
             this.transactionDefinition = transactionDefinition;
+            this.reactiveTransactionOperations = reactiveTransactionOperations;
+        }
+
+        boolean isTransactionOf(@NonNull ReactiveTransactionOperations<C> reactiveTransactionOperations) {
+            return this.reactiveTransactionOperations == reactiveTransactionOperations;
         }
 
         @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
@@ -127,7 +127,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     }
 
     private <R> R doExecuteWithoutSynchronousConnectionManager(TransactionDefinition definition, TransactionCallback<C, R> callback) {
-        Optional<T> existingTransactionOptional = findTransactionStatus();
+        Optional<T> existingTransactionOptional = findTransactionStatusInternal();
         if (existingTransactionOptional.isEmpty()) {
             return connectionOperations.execute(
                 txConnectionDefinition(definition),
@@ -163,7 +163,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         if (synchronousConnectionManager == null) {
             throw new TransactionUsageException("Synchronous connection manager not supported!");
         }
-        final T existingTransaction = findTransactionStatus().orElse(null);
+        final T existingTransaction = findTransactionStatusInternal().orElse(null);
         if (existingTransaction == null) {
             ConnectionStatus<C> connectionStatus = connectionOperations.findConnectionStatus().orElse(null);
             if (connectionStatus == null) {

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Abstract transaction operations.
@@ -107,13 +106,11 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     /**
      * Create transaction status with existing transaction.
      *
-     * @param connectionStatus    The connection status
      * @param definition          The transaction definition
      * @param existingTransaction The existing transaction
      * @return new transaction status
      */
-    protected abstract T createExistingTransactionStatus(@NonNull ConnectionStatus<C> connectionStatus,
-                                                         @NonNull TransactionDefinition definition,
+    protected abstract T createExistingTransactionStatus(@NonNull TransactionDefinition definition,
                                                          @NonNull T existingTransaction);
 
     @Override
@@ -123,30 +120,79 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
 
     @Override
     protected final <R> R doExecute(@NonNull TransactionDefinition definition, @NonNull TransactionCallback<C, R> callback) {
-        ConnectionStatus<C> connectionStatus = connectionOperations.findConnectionStatus().orElse(null);
-        if (connectionStatus == null) {
-            return connectionOperations.execute(
-                txConnectionDefinition(definition),
-                status -> doExecute(status, definition, callback)
-            );
+        if (synchronousConnectionManager == null) {
+            return doExecuteWithoutSynchronousConnectionManager(definition, callback);
         }
-        return doExecute(connectionStatus, definition, callback);
+        return executeTransactional(getTransaction(definition), callback, definition);
     }
 
-    private <R> R doExecute(ConnectionStatus<C> connectionStatus, TransactionDefinition definition, TransactionCallback<C, R> callback) {
-        T existingTransaction = findTransactionStatus().orElse(null);
-        if (existingTransaction != null) {
-            return executeWithExistingTransaction(
-                definition,
-                existingTransaction,
-                callback
+    private <R> R doExecuteWithoutSynchronousConnectionManager(TransactionDefinition definition, TransactionCallback<C, R> callback) {
+        Optional<T> existingTransactionOptional = findTransactionStatus();
+        if (existingTransactionOptional.isEmpty()) {
+            return connectionOperations.execute(
+                txConnectionDefinition(definition),
+                connectionStatus -> executeTransactional(createAndBeginTransaction(definition, connectionStatus), callback, definition)
             );
         }
-        return executeNew(
-            connectionStatus,
-            definition,
-            callback
-        );
+        T existingTransaction = existingTransactionOptional.get();
+        checkNeverTransactionPropagation(definition);
+        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW) {
+            doSuspend(existingTransaction);
+            return connectionOperations.execute(
+                ConnectionDefinition.REQUIRES_NEW,
+                connectionStatus -> {
+                    T newTransaction = createAndBeginTransaction(definition, connectionStatus);
+                    newTransaction.registerInvocationSynchronization(new TransactionSynchronization() {
+                        @Override
+                        public void afterCompletion(Status status) {
+                            doResume(existingTransaction);
+                        }
+                    });
+                    return executeTransactional(newTransaction, callback, definition);
+                }
+            );
+        }
+        T existingTransactionStatus = createExistingTransactionStatus(definition, existingTransaction);
+        return executeTransactional(existingTransactionStatus, callback, definition);
+    }
+
+    @NonNull
+    @Override
+    public T getTransaction(TransactionDefinition definition) throws TransactionException {
+        if (synchronousConnectionManager == null) {
+            throw new TransactionUsageException("Synchronous connection manager not supported!");
+        }
+        final T existingTransaction = findTransactionStatus().orElse(null);
+        if (existingTransaction == null) {
+            ConnectionStatus<C> connectionStatus = connectionOperations.findConnectionStatus().orElse(null);
+            if (connectionStatus == null) {
+                ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(txConnectionDefinition(definition));
+                T transactionStatus = createAndBeginTransaction(definition, newConnectionStatus);
+                transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCompletion(Status status) {
+                        synchronousConnectionManager.complete(newConnectionStatus);
+                    }
+                });
+                return transactionStatus;
+            }
+            return createAndBeginTransaction(definition, connectionStatus);
+        }
+        checkNeverTransactionPropagation(definition);
+        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW) {
+            doSuspend(existingTransaction);
+            ConnectionStatus<C> newConnection = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
+            T newTransaction = createAndBeginTransaction(definition, newConnection);
+            newTransaction.registerInvocationSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(Status status) {
+                    doResume(existingTransaction);
+                    synchronousConnectionManager.complete(newConnection);
+                }
+            });
+            return newTransaction;
+        }
+        return createExistingTransactionStatus(definition, existingTransaction);
     }
 
     /**
@@ -234,46 +280,6 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         return new NestedTransactionNotSupportedException("Transaction manager does not allow nested transactions");
     }
 
-    private <R> R executeNew(ConnectionStatus<C> connectionStatus,
-                             TransactionDefinition definition,
-                             TransactionCallback<C, R> callback) {
-
-        return switch (definition.getPropagationBehavior()) {
-            case REQUIRED, REQUIRES_NEW, NESTED -> // Nested propagation applies only for the existing TX
-                executeWithNewTransaction(connectionStatus, definition, callback);
-            case SUPPORTS, NEVER, NOT_SUPPORTED ->
-                executeWithoutTransaction(connectionStatus, callback);
-            case MANDATORY -> throw newMandatoryTx();
-        };
-    }
-
-    private <R> R executeWithExistingTransaction(TransactionDefinition definition,
-                                                 T existingTransaction,
-                                                 TransactionCallback<C, R> callback) {
-
-        return switch (definition.getPropagationBehavior()) {
-            case REQUIRED, SUPPORTS, MANDATORY, NESTED ->
-                openConnectionAndExecuteTransaction(definition, existingTransaction, callback);
-            case REQUIRES_NEW -> suspend(existingTransaction, () -> connectionOperations.execute(
-                txConnectionDefinition(definition),
-                status -> executeWithNewTransaction(
-                    status,
-                    definition,
-                    callback
-                )
-            ));
-            case NOT_SUPPORTED -> suspend(existingTransaction, () -> connectionOperations.execute(
-                ConnectionDefinition.REQUIRES_NEW,
-                status -> executeWithoutTransaction(
-                    status,
-                    callback
-                )
-            ));
-            case NEVER ->
-                throw new TransactionUsageException("Existing transaction found for transaction marked with propagation 'never'");
-        };
-    }
-
     /**
      * Do suspend the transaction.
      *
@@ -290,52 +296,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     protected void doResume(T transaction) {
     }
 
-    /**
-     * Do suspend the transaction.
-     *
-     * @param transaction The transaction
-     * @param callback    The callback
-     * @param <R>         The result type
-     * @return The callback result
-     */
-    protected <R> R suspend(T transaction, Supplier<R> callback) {
-        return callback.get();
-    }
-
-    private <R> R openConnectionAndExecuteTransaction(TransactionDefinition definition,
-                                                      T existingTransaction,
-                                                      TransactionCallback<C, R> callback) {
-        ConnectionDefinition txConnectionDefinition = txConnectionDefinition(definition);
-        return connectionOperations.execute(txConnectionDefinition,
-            status -> executeTransactional(
-                createExistingTransactionStatus(
-                    status,
-                    definition,
-                    existingTransaction
-                ),
-                callback,
-                definition
-            )
-        );
-    }
-
-    private <R> R executeWithNewTransaction(@NonNull ConnectionStatus<C> connectionStatus,
-                                            @NonNull TransactionDefinition definition,
-                                            @NonNull TransactionCallback<C, R> callback) {
-
-        return executeTransactional(
-            createNewTransactionStatus(connectionStatus, definition),
-            callback,
-            definition
-        );
-    }
-
-    private <R> R executeWithoutTransaction(@NonNull ConnectionStatus<C> connectionStatus, TransactionCallback<C, R> callback) {
-        return callback.apply(createNoTxTransactionStatus(connectionStatus, TransactionDefinition.DEFAULT));
-    }
-
     private <R> R executeTransactional(T transaction, TransactionCallback<C, R> callback, TransactionDefinition definition) {
-        begin(transaction);
         R result;
         try {
             result = callback.apply(transaction);
@@ -462,111 +423,26 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         tx.triggerAfterCompletion(TransactionSynchronization.Status.ROLLED_BACK);
     }
 
-    @NonNull
-    @Override
-    public TransactionStatus<C> getTransaction(TransactionDefinition definition) throws TransactionException {
-        if (synchronousConnectionManager == null) {
-            throw new TransactionUsageException("Synchronous connection manager not supported!");
-        }
-        ConnectionStatus<C> connectionStatus = connectionOperations.findConnectionStatus().orElse(null);
-        Optional<T> existingTransactionStatus = findTransactionStatus();
-        if (existingTransactionStatus.isPresent()) {
-            T existingTransaction = existingTransactionStatus.get();
-            return switch (definition.getPropagationBehavior()) {
-                case REQUIRED, SUPPORTS, MANDATORY, NESTED ->
-                    reuseTransaction(definition, connectionStatus, existingTransaction);
-                case REQUIRES_NEW -> suspendAndOpenNewTransaction(definition, existingTransaction);
-                case NOT_SUPPORTED -> suspendAndOpenNewConnection(definition, existingTransaction);
-                case NEVER ->
-                    throw new TransactionUsageException("Existing transaction found for transaction marked with propagation 'never'");
-            };
-        } else {
-            if (connectionStatus != null) {
-                return switch (definition.getPropagationBehavior()) {
-                    case REQUIRED, REQUIRES_NEW, NESTED -> openNewTransaction(connectionStatus, definition); // Nested propagation applies only for the existing TX
-                    case SUPPORTS, NEVER, NOT_SUPPORTED ->
-                        withNoTransactionStatus(connectionStatus, definition);
-                    case MANDATORY -> throw newMandatoryTx();
-                };
-            }
-            return switch (definition.getPropagationBehavior()) {
-                case REQUIRED, REQUIRES_NEW, NESTED -> openNewConnectionAndTransaction(definition); // Nested propagation applies only for the existing TX
-                case SUPPORTS, NEVER, NOT_SUPPORTED ->
-                    withNoTransactionStatus(connectionStatus, definition);
-                case MANDATORY -> throw newMandatoryTx();
-            };
+    private void checkNeverTransactionPropagation(TransactionDefinition definition) {
+        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.NEVER) {
+            throw new TransactionUsageException("Existing transaction found for transaction marked with propagation 'never'");
         }
     }
 
-    @NonNull
-    private T reuseTransaction(TransactionDefinition definition, ConnectionStatus<C> connectionStatus, T existingTransaction) {
-        T transactionStatus = createExistingTransactionStatus(
-            connectionStatus,
-            definition,
-            existingTransaction
-        );
-        begin(transactionStatus);
-        return transactionStatus;
+    private T createAndBeginTransaction(@NonNull TransactionDefinition definition, @NonNull ConnectionStatus<C> connectionStatus) {
+        T transaction = createTransaction(definition, connectionStatus);
+        begin(transaction);
+        return transaction;
     }
 
-    @NonNull
-    private T suspendAndOpenNewTransaction(TransactionDefinition definition, T existingTransaction) {
-        doSuspend(existingTransaction);
-        ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
-        T transactionStatus = createNewTransactionStatus(newConnectionStatus, definition);
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                doResume(existingTransaction);
-                synchronousConnectionManager.complete(newConnectionStatus);
-            }
-        });
-        begin(transactionStatus);
-        return transactionStatus;
-    }
-
-    @NonNull
-    private T suspendAndOpenNewConnection(TransactionDefinition definition, T existingTransaction) {
-        doSuspend(existingTransaction);
-        ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
-        T transactionStatus = createNoTxTransactionStatus(newConnectionStatus, definition);
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                doResume(existingTransaction);
-                synchronousConnectionManager.complete(newConnectionStatus);
-            }
-        });
-        begin(transactionStatus);
-        return transactionStatus;
-    }
-
-    @NonNull
-    private T openNewConnectionAndTransaction(TransactionDefinition definition) {
-        ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
-        T transactionStatus = createNewTransactionStatus(newConnectionStatus, definition);
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                synchronousConnectionManager.complete(newConnectionStatus);
-            }
-        });
-        begin(transactionStatus);
-        return transactionStatus;
-    }
-
-    @NonNull
-    private T openNewTransaction(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
-        T transactionStatus = createNewTransactionStatus(connectionStatus, definition);
-        begin(transactionStatus);
-        return transactionStatus;
-    }
-
-    @NonNull
-    private T withNoTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
-        T transactionStatus = createNoTxTransactionStatus(connectionStatus, definition);
-        begin(transactionStatus);
-        return transactionStatus;
+    private T createTransaction(@NonNull TransactionDefinition definition, @NonNull ConnectionStatus<C> connectionStatus) {
+        return switch (definition.getPropagationBehavior()) {
+            case REQUIRED, REQUIRES_NEW, NESTED ->
+                createNewTransactionStatus(connectionStatus, definition); // Nested propagation applies only for the existing TX
+            case SUPPORTS, NOT_SUPPORTED, NEVER ->
+                createNoTxTransactionStatus(connectionStatus, definition);
+            case MANDATORY -> throw newMandatoryTx();
+        };
     }
 
     @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
@@ -18,7 +18,6 @@ package io.micronaut.transaction.support;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.data.connection.ConnectionDefinition;
 import io.micronaut.data.connection.ConnectionOperations;
 import io.micronaut.data.connection.ConnectionStatus;
@@ -33,6 +32,7 @@ import io.micronaut.transaction.exceptions.NestedTransactionNotSupportedExceptio
 import io.micronaut.transaction.exceptions.TransactionException;
 import io.micronaut.transaction.exceptions.TransactionUsageException;
 import io.micronaut.transaction.exceptions.UnexpectedRollbackException;
+import io.micronaut.transaction.impl.DefaultTransactionStatus;
 import io.micronaut.transaction.impl.InternalTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +64,14 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
                                          @Nullable SynchronousConnectionManager<C> synchronousConnectionManager) {
         this.connectionOperations = connectionOperations;
         this.synchronousConnectionManager = synchronousConnectionManager;
+    }
+
+    @Override
+    public boolean managesTransaction(TransactionStatus<C> transactionStatus) {
+        if (transactionStatus instanceof DefaultTransactionStatus<C> status) {
+            return status.isTransactionOf(this);
+        }
+        return false;
     }
 
     /**
@@ -497,13 +505,6 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
             definition,
             existingTransaction
         );
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                scope.close();
-            }
-        });
         begin(transactionStatus);
         return transactionStatus;
     }
@@ -513,12 +514,10 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         doSuspend(existingTransaction);
         ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
         T transactionStatus = createNewTransactionStatus(newConnectionStatus, definition);
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
         transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCompletion(Status status) {
                 doResume(existingTransaction);
-                scope.close();
                 synchronousConnectionManager.complete(newConnectionStatus);
             }
         });
@@ -531,12 +530,10 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         doSuspend(existingTransaction);
         ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
         T transactionStatus = createNoTxTransactionStatus(newConnectionStatus, definition);
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
         transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCompletion(Status status) {
                 doResume(existingTransaction);
-                scope.close();
                 synchronousConnectionManager.complete(newConnectionStatus);
             }
         });
@@ -548,11 +545,9 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     private T openNewConnectionAndTransaction(TransactionDefinition definition) {
         ConnectionStatus<C> newConnectionStatus = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
         T transactionStatus = createNewTransactionStatus(newConnectionStatus, definition);
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
         transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCompletion(Status status) {
-                scope.close();
                 synchronousConnectionManager.complete(newConnectionStatus);
             }
         });
@@ -563,13 +558,6 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     @NonNull
     private T openNewTransaction(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
         T transactionStatus = createNewTransactionStatus(connectionStatus, definition);
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                scope.close();
-            }
-        });
         begin(transactionStatus);
         return transactionStatus;
     }
@@ -577,13 +565,6 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
     @NonNull
     private T withNoTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition) {
         T transactionStatus = createNoTxTransactionStatus(connectionStatus, definition);
-        PropagatedContext.Scope scope = extendCurrentPropagatedContext(transactionStatus).propagate();
-        transactionStatus.registerInvocationSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(Status status) {
-                scope.close();
-            }
-        });
         begin(transactionStatus);
         return transactionStatus;
     }

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
@@ -136,7 +136,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
         }
         T existingTransaction = existingTransactionOptional.get();
         checkNeverTransactionPropagation(definition);
-        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW) {
+        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW ||  definition.getPropagationBehavior() == TransactionDefinition.Propagation.NOT_SUPPORTED) {
             doSuspend(existingTransaction);
             return connectionOperations.execute(
                 ConnectionDefinition.REQUIRES_NEW,
@@ -153,6 +153,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
             );
         }
         T existingTransactionStatus = createExistingTransactionStatus(definition, existingTransaction);
+        begin(existingTransactionStatus);
         return executeTransactional(existingTransactionStatus, callback, definition);
     }
 
@@ -179,7 +180,7 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
             return createAndBeginTransaction(definition, connectionStatus);
         }
         checkNeverTransactionPropagation(definition);
-        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW) {
+        if (definition.getPropagationBehavior() == TransactionDefinition.Propagation.REQUIRES_NEW || definition.getPropagationBehavior() == TransactionDefinition.Propagation.NOT_SUPPORTED) {
             doSuspend(existingTransaction);
             ConnectionStatus<C> newConnection = synchronousConnectionManager.getConnection(ConnectionDefinition.REQUIRES_NEW);
             T newTransaction = createAndBeginTransaction(definition, newConnection);
@@ -192,7 +193,9 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
             });
             return newTransaction;
         }
-        return createExistingTransactionStatus(definition, existingTransaction);
+        T existingTransactionStatus = createExistingTransactionStatus(definition, existingTransaction);
+        begin(existingTransactionStatus);
+        return existingTransactionStatus;
     }
 
     /**

--- a/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
@@ -71,9 +71,9 @@ public final class SynchronousTransactionOperationsFromReactiveTransactionOperat
     @Override
     public <R> R execute(TransactionDefinition definition, TransactionCallback<T, R> callback) {
         Mono<R> result = reactiveTransactionOperations.withTransactionMono(definition, status -> Mono.deferContextual(contextView -> {
-            try (PropagatedContext.Scope ignore = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty).propagate()) {
-                return Mono.justOrEmpty(callback.apply(new DefaultTransactionStatus<>(status)));
-            }
+            DefaultTransactionStatus<T> transactionStatus = new DefaultTransactionStatus<>(status, this);
+            PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty);
+            return Mono.justOrEmpty(transactionStatus.propagate(propagatedContext, () -> callback.apply(transactionStatus)));
         }).subscribeOn(scheduler)).contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, PropagatedContext.getOrEmpty()));
         return result.onErrorMap(e -> {
             if (e instanceof UndeclaredThrowableException) {
@@ -89,12 +89,26 @@ public final class SynchronousTransactionOperationsFromReactiveTransactionOperat
             "and only supports 'execute', 'executeRead' and 'executeWrite' methods.");
     }
 
+    @Override
+    public boolean managesTransaction(TransactionStatus<T> transactionStatus) {
+        if (transactionStatus instanceof DefaultTransactionStatus<T> status) {
+            return status.isTransactionOf(this);
+        }
+        return false;
+    }
+
     private final class DefaultTransactionStatus<K> implements TransactionStatus<K> {
 
         private final ReactiveTransactionStatus<K> transactionStatus;
+        private final TransactionOperations<K> transactionOperations;
 
-        private DefaultTransactionStatus(ReactiveTransactionStatus<K> transactionStatus) {
+        private DefaultTransactionStatus(ReactiveTransactionStatus<K> transactionStatus, TransactionOperations<K> transactionOperations) {
             this.transactionStatus = transactionStatus;
+            this.transactionOperations = transactionOperations;
+        }
+
+        public boolean isTransactionOf(TransactionOperations<K> transactionOperations) {
+            return this.transactionOperations ==  transactionOperations;
         }
 
         @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/sync/SynchronousTransactionOperationsFromReactiveTransactionOperations.java
@@ -64,7 +64,7 @@ public final class SynchronousTransactionOperationsFromReactiveTransactionOperat
     }
 
     @Override
-    public Optional<? extends TransactionStatus<?>> findTransactionStatus() {
+    public Optional<TransactionStatus<T>> findTransactionStatus() {
         return Optional.empty();
     }
 

--- a/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/test/DefaultTestTransactionExecutionListener.java
@@ -80,7 +80,9 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
     @Override
     public Object interceptTest(TestMethodInvocationContext<Object> methodInvocationContext) throws Throwable {
         if (transactionMode == TransactionMode.SINGLE_TRANSACTION) {
-            return TestMethodInterceptor.super.interceptTest(methodInvocationContext);
+            if (tx != null) {
+                return propagate(methodInvocationContext);
+            }
         }
         // Not all testing frameworks supports intercepting the invocation
         TestContext testContext = methodInvocationContext.getTestContext();
@@ -104,10 +106,22 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
         }
     }
 
+    private Object propagate(TestMethodInvocationContext<Object> methodInvocationContext) {
+        return tx.propagate(() -> {
+            try {
+                return TestMethodInterceptor.super.interceptAfterEach(methodInvocationContext);
+            } catch (Throwable e) {
+                return ExceptionUtil.sneakyThrow(e);
+            }
+        });
+    }
+
     @Override
     public Object interceptBeforeEach(TestMethodInvocationContext<Object> methodInvocationContext) throws Throwable {
         if (transactionMode == TransactionMode.SINGLE_TRANSACTION) {
-            return TestMethodInterceptor.super.interceptBeforeEach(methodInvocationContext);
+            if (tx != null) {
+                return propagate(methodInvocationContext);
+            }
         }
         // Not all testing frameworks supports intercepting the invocation
         TestContext testContext = methodInvocationContext.getTestContext();
@@ -130,6 +144,9 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
     @Override
     public Object interceptAfterEach(TestMethodInvocationContext<Object> methodInvocationContext) throws Throwable {
         if (transactionMode == TransactionMode.SINGLE_TRANSACTION) {
+            if (tx != null) {
+                return propagate(methodInvocationContext);
+            }
             return TestMethodInterceptor.super.interceptAfterEach(methodInvocationContext);
         }
         // Not all testing frameworks supports intercepting the invocation
@@ -142,7 +159,7 @@ public class DefaultTestTransactionExecutionListener implements TestExecutionLis
                 try {
                     return TestMethodInterceptor.super.interceptAfterEach(methodInvocationContext);
                 } catch (Throwable e) {
-                    throw new UncheckedException(e);
+                    return ExceptionUtil.sneakyThrow(e);
                 }
             });
         } catch (UncheckedException e) {

--- a/doc-examples/hibernate-example-kotlin-ksp/src/test/kotlin/example/HibernateTotalSizeIssueTest.kt
+++ b/doc-examples/hibernate-example-kotlin-ksp/src/test/kotlin/example/HibernateTotalSizeIssueTest.kt
@@ -2,6 +2,7 @@ package example
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.micronaut.data.connection.ConnectionOperations
 import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.Sort.Order
@@ -10,14 +11,17 @@ import io.micronaut.data.runtime.criteria.where
 import io.micronaut.test.annotation.Sql
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import jakarta.persistence.criteria.JoinType
+import org.hibernate.Session
 
 @Sql("classpath:init.sql")
 @MicronautTest
 class HibernateTotalSizeIssueTest(
-    private val authorRepository: AuthorRepository
+    private val authorRepository: AuthorRepository,
+    private val connectionOperations: ConnectionOperations<Session>
 ) : StringSpec({
 
-    "test totalSize should match the number of authors" {
+    "test totalSize should match the number of authors" { connectionOperations.executeWrite {
+
         val criteria = where<Author> {
             val genresJoin = root.joinList<Author, Genre>("genres", JoinType.LEFT)
 
@@ -68,5 +72,5 @@ class HibernateTotalSizeIssueTest(
         page.content.size shouldBe 1
         page.content[0].name shouldBe "Stephen King"
         page.content[0].genres.map { it.name }.sorted() shouldBe listOf("Horror", "Thriller")
-    }
+    } }
 })

--- a/doc-examples/mongo-reactive-example-kotlin/src/main/kotlin/example/PersonSuspendRepositoryService.kt
+++ b/doc-examples/mongo-reactive-example-kotlin/src/main/kotlin/example/PersonSuspendRepositoryService.kt
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory
 import java.lang.Thread.currentThread
 import java.util.*
 import jakarta.transaction.Transactional
+import kotlinx.coroutines.currentCoroutineContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
@@ -54,7 +55,7 @@ open class PersonSuspendRepositoryService(
 
     @io.micronaut.transaction.annotation.Transactional("custom")
     open suspend fun deleteAllForCustomDb2(): TransactionExecution {
-        val txStatus: TransactionExecution = getCustomTxStatus(coroutineContext)!!
+        val txStatus: TransactionExecution = getCustomTxStatus(currentCoroutineContext())!!
         if (txStatus.isCompleted || !txStatus.isNewTransaction) {
             throw RuntimeException()
         }
@@ -64,7 +65,7 @@ open class PersonSuspendRepositoryService(
 
     @io.micronaut.transaction.annotation.Transactional("custom")
     open suspend fun saveForCustomDb2(p: Parent): TransactionExecution {
-        val txStatus: TransactionExecution = getCustomTxStatus(coroutineContext)!!
+        val txStatus: TransactionExecution = getCustomTxStatus(currentCoroutineContext())!!
         if (txStatus.isCompleted || !txStatus.isNewTransaction) {
             throw RuntimeException()
         }
@@ -74,7 +75,7 @@ open class PersonSuspendRepositoryService(
 
     @Transactional
     open suspend fun saveTwo(p1: Parent, p2: Parent) {
-        val current: TransactionExecution = getTxStatus(coroutineContext)!!
+        val current: TransactionExecution = getTxStatus(currentCoroutineContext())!!
         if (!current.isNewTransaction && current.isCompleted) {
             throw IllegalStateException()
         }
@@ -90,7 +91,7 @@ open class PersonSuspendRepositoryService(
 
     @Transactional(Transactional.TxType.MANDATORY)
     open suspend fun saveOneMandatory(p: Parent): TransactionExecution {
-        val txStatus: TransactionExecution = getTxStatus(coroutineContext)!!
+        val txStatus: TransactionExecution = getTxStatus(currentCoroutineContext())!!
         if (txStatus.isNewTransaction && txStatus.isCompleted) {
             throw IllegalStateException()
         }

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,6 +1,42 @@
 This section documents breaking changes between Micronaut versions
 
-== 4.0.0
+== 5.0
+
+=== Interactions with synchronous transaction and connection manager
+
+Creating a new transaction with `io.micronaut.transaction.SynchronousTransactionManager` or a connection with `io.micronaut.data.connection.SynchronousConnectionManager` no longer places the resulting status into the current `PropagatedContext` automatically.
+Code that subsequently looks up the active transaction or connection (for example via `TransactionOperations#findTransactionStatus` or `ConnectionOperations#findConnectionStatus`) must now explicitly propagate the status when manual transaction or connection demarcation is used.
+Use `TransactionStatus#propagate` or `ConnectionStatus#propagate` to wrap the code section that should observe the newly created context element.
+
+[source,java]
+----
+TransactionStatus<Object> status = transactionManager.getTransaction(TransactionDefinition.DEFAULT);
+
+// No propagation: downstream code cannot observe the transaction
+Optional<TransactionStatus<Object>> missing = transactionOperations.findTransactionStatus(); // empty
+
+// Use TransactionStatus#propagate so that downstream lookups succeed
+status.propagate(() -> {
+    TransactionStatus<Object> present = transactionOperations.getTransactionStatus();
+    bookRepository.saveWithMandatoryTransaction(newBook);
+});
+
+ConnectionStatus<Connection> connection = connectionManager.getConnection(ConnectionDefinition.DEFAULT);
+
+// Without propagate the connection is invisible to ConnectionOperations
+Optional<ConnectionStatus<Connection>> absent = connectionOperations.findConnectionStatus(); // empty
+
+// Use ConnectionStatus#propagate to make the connection available to participating components
+connection.propagate(() -> {
+    ConnectionStatus<Connection> current = connectionOperations.getConnectionStatus();
+    Connection jdbc = current.getConnection();
+    // perform work with the managed connection
+});
+----
+
+NOTE: These changes are required for Micronaut 5 to support propagating context with scoped values.
+
+== 4.0
 
 === Repositories validation
 
@@ -36,5 +72,3 @@ The new implementation has a newly added connection management, allowing to shar
 === Async and Reactive repositories
 
 Async and reactive repositories are no longer throw `EmptyResultException` if the entity is not found.
-
-


### PR DESCRIPTION
- `getTransaction(..)` / `getConnection` no longer bind the propagated context element to the thread - replaced by `txStatus.propagate({...})`
-  remove any usages of try-resource propagation that should be removed in v5 to support scoped values
- refactoring of tx/connection operations to reduce execution stack
- API improvements