### PR TITLE
feature/issue-3619-kotlin-coroutine-null-value

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
@@ -98,7 +98,7 @@ public final class DataIntroductionAdvice implements MethodInterceptor<Object, O
             try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
                 if (throwable == null) {
                     Class<Object> target = context.getReturnType().asArgument().getType();
-                    if (value == null) {
+                    if (value == null && target.getName().equals("kotlinx.coroutines.flow.Flow")) {
                         value = conversionService.convert(new NullValue(), target).orElse(value);
                     } else {
                         value = conversionService.convert(value, target).orElse(value);


### PR DESCRIPTION
Issue #3619 

Only convert `new NullValue()` when target is `kotlinx.coroutines.flow.Flow` in `DataIntroductionAdvice::interceptCompletionStage` to resolve issue with returning non-null string of `NullValue[]`