### PR TITLE
Skip javadoc for AbstractJakartaDataTest

### DIFF
--- a/data-tck/build.gradle
+++ b/data-tck/build.gradle
@@ -30,3 +30,7 @@ dependencies {
     compileOnly projects.micronautDataJdbc
     compileOnly mn.micronaut.inject.groovy
 }
+
+tasks.withType(Javadoc).configureEach {
+    exclude("io/micronaut/data/tck/tests/AbstractJakartaDataTest.java")
+}


### PR DESCRIPTION
Without this change javadoc is failing with the error

> /dev/projects/micronaut-data/data-tck/build/aggregation/javadoc/io/micronaut/data/tck/tests/AbstractJakartaDataTest.java:27: error: cannot find symbol
import io.micronaut.data.tck.entities._Train;
                                     ^
  symbol:   class _Train
  location: package io.micronaut.data.tck.entities