### PR TITLE
feature/issue-3619-kotlin-coroutine-null-value-5.0.x into 5.0.x

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/DataIntroductionAdvice.java
@@ -99,7 +99,7 @@ public final class DataIntroductionAdvice implements MethodInterceptor<Object, O
                 if (throwable == null) {
                     Class<Object> target = context.getReturnType().asArgument().getType();
                     Object v = value;
-                    if (v == null) {
+                    if (v == null && target.getName().equals("kotlinx.coroutines.flow.Flow")) {
                         v = conversionService.convert(new NullValue(), target).orElse(v);
                     } else {
                         v = conversionService.convert(v, target).orElse(v);

--- a/doc-examples/r2dbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
+++ b/doc-examples/r2dbc-example-kotlin/src/main/kotlin/example/BookRepository.kt
@@ -20,6 +20,8 @@ interface BookRepository : CoroutineCrudRepository<Book, Long> {
     @Join("author")
     override fun findAll(): Flow<Book>
 
+    suspend fun findTitleById(id: Long): String?
+
     // tag::mandatory[]
     @Transactional(Transactional.TxType.MANDATORY)
     override suspend fun <S : Book> save(entity: S): S

--- a/doc-examples/r2dbc-example-kotlin/src/test/kotlin/example/NullValueCoroutinesTest.kt
+++ b/doc-examples/r2dbc-example-kotlin/src/test/kotlin/example/NullValueCoroutinesTest.kt
@@ -1,0 +1,44 @@
+package example
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.transaction.kotlin.CoroutineTransactionOperations
+import io.r2dbc.spi.Connection
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@MicronautTest(transactional = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NullValueCoroutinesTest : AbstractTest(false) {
+
+    @Inject
+    lateinit var bookRepository: BookRepository
+
+    @Inject
+    lateinit var transactionOperations: CoroutineTransactionOperations<Connection>
+
+    @AfterEach
+    fun cleanupData(): Unit = runBlocking {
+        transactionOperations.execute {
+            bookRepository.deleteAll()
+        }
+    }
+
+    @Test
+    fun `'suspend fun' nullable 'String' return type, record not present, null returned when fetching property by entity ID`() = runBlocking {
+        val book = bookRepository.findTitleById(-1L)
+        assert(book == null)
+    }
+
+    @Test
+    fun `'suspend fun' nullable 'String' return type, record present, value returned when fetching property by entity ID`() = runBlocking {
+        transactionOperations.execute {
+            val author = Author("Huxley")
+            val savedBook = bookRepository.save(Book("Island", 384, author))
+            val bookTitle = bookRepository.findTitleById(savedBook.id!!)
+            assert(bookTitle == "Island")
+        }
+    }
+}


### PR DESCRIPTION
Issue #3619

Target `5.0.x`

`DataIntroductionAdvice::interceptCompletionStage` only convert as `new NullValue()` when target is `kotlinx.coroutines.flow.Flow` to avoid non-null string value of `NullValue[]` being returned