### PR TITLE
Fix NESTED propagation not creating JDBC savepoints (#3334)

### DIFF
--- a/data-tx-jdbc/src/test/groovy/io/micronaut/transaction/jdbc/NestedTransactionSpec.groovy
+++ b/data-tx-jdbc/src/test/groovy/io/micronaut/transaction/jdbc/NestedTransactionSpec.groovy
@@ -1,0 +1,184 @@
+package io.micronaut.transaction.jdbc
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.transaction.TransactionDefinition
+import io.micronaut.transaction.TransactionOperations
+import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.Specification
+
+import javax.sql.DataSource
+import java.sql.Connection
+
+@MicronautTest(transactional = false)
+@Property(name = "datasources.default.name", value = "mydb")
+@Issue('https://github.com/micronaut-projects/micronaut-data/issues/3334')
+class NestedTransactionSpec extends Specification {
+
+    @Inject
+    TransactionOperations<Connection> transactionManager
+
+    @Inject
+    DataSource dataSource
+
+    private static final TransactionDefinition NESTED =
+        TransactionDefinition.of(TransactionDefinition.Propagation.NESTED)
+
+    void setup() {
+        transactionManager.executeWrite({ status ->
+            def connection = dataSource.getConnection()
+            connection.prepareStatement("drop table test_nested if exists").execute()
+            connection.prepareStatement(
+                "create table test_nested (id bigint not null auto_increment, name varchar(255), primary key (id))"
+            ).execute()
+            return null
+        })
+    }
+
+    void "nested transaction rolls back without affecting outer transaction"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            try {
+                transactionManager.execute(NESTED, { nestedStatus ->
+                    insertRow("B")
+                    throw new RuntimeException("nested failure")
+                })
+            } catch (RuntimeException ignored) {
+                // Outer transaction catches and continues
+            }
+            return null
+        })
+
+        then:
+        getNames() == ["A"]
+    }
+
+    void "nested transaction commits independently"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            transactionManager.execute(NESTED, { nestedStatus ->
+                insertRow("B")
+                return null
+            })
+            return null
+        })
+
+        then:
+        getNames().sort() == ["A", "B"]
+    }
+
+    void "multiple nested transactions with selective rollback"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            transactionManager.execute(NESTED, { nestedStatus ->
+                insertRow("B")
+                return null
+            })
+            try {
+                transactionManager.execute(NESTED, { nestedStatus ->
+                    insertRow("C")
+                    throw new RuntimeException("second nested failure")
+                })
+            } catch (RuntimeException ignored) {
+                // Catch the second nested failure
+            }
+            return null
+        })
+
+        then:
+        getNames().sort() == ["A", "B"]
+    }
+
+    void "nested with setRollbackOnly rolls back only the savepoint"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            transactionManager.execute(NESTED, { nestedStatus ->
+                insertRow("B")
+                nestedStatus.setRollbackOnly()
+                return null
+            })
+            return null
+        })
+
+        then:
+        getNames() == ["A"]
+    }
+
+    void "NESTED without existing transaction starts a new transaction"() {
+        when:
+        transactionManager.execute(NESTED, { status ->
+            insertRow("A")
+            return null
+        })
+
+        then:
+        getNames() == ["A"]
+    }
+
+    void "uncaught nested exception rolls back both nested and outer"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            transactionManager.execute(NESTED, { nestedStatus ->
+                insertRow("B")
+                throw new RuntimeException("uncaught nested failure")
+            })
+            return null
+        })
+
+        then:
+        thrown(RuntimeException)
+        getNames() == []
+    }
+
+    void "nested within nested creates independent savepoints"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            transactionManager.execute(NESTED, { outerNested ->
+                insertRow("B")
+                try {
+                    transactionManager.execute(NESTED, { innerNested ->
+                        insertRow("C")
+                        throw new RuntimeException("inner nested failure")
+                    })
+                } catch (RuntimeException ignored) {
+                    // Only the innermost nested rolls back
+                }
+                return null
+            })
+            return null
+        })
+
+        then:
+        getNames().sort() == ["A", "B"]
+    }
+
+    private void insertRow(String name) {
+        def connection = dataSource.getConnection()
+        try (def ps = connection.prepareStatement("insert into test_nested (name) values(?)")) {
+            ps.setString(1, name)
+            ps.execute()
+        }
+    }
+
+    private List<String> getNames() {
+        return transactionManager.executeRead({ status ->
+            def connection = dataSource.getConnection()
+            try (def ps = connection.prepareStatement("select name from test_nested order by name")) {
+                try (def rs = ps.executeQuery()) {
+                    def names = []
+                    while (rs.next()) {
+                        names << rs.getString("name")
+                    }
+                    return names
+                }
+            }
+        })
+    }
+}

--- a/data-tx-jdbc/src/test/groovy/io/micronaut/transaction/jdbc/NestedTransactionSpec.groovy
+++ b/data-tx-jdbc/src/test/groovy/io/micronaut/transaction/jdbc/NestedTransactionSpec.groovy
@@ -4,6 +4,8 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.TransactionDefinition
 import io.micronaut.transaction.TransactionOperations
+import io.micronaut.transaction.impl.InternalTransaction
+import io.micronaut.transaction.support.TransactionSynchronization
 import jakarta.inject.Inject
 import spock.lang.Issue
 import spock.lang.Specification
@@ -157,6 +159,32 @@ class NestedTransactionSpec extends Specification {
 
         then:
         getNames().sort() == ["A", "B"]
+    }
+
+    void "beforeCommit failure in nested transaction preserves outer transaction"() {
+        when:
+        transactionManager.executeWrite({ status ->
+            insertRow("A")
+            try {
+                transactionManager.execute(NESTED, { nestedStatus ->
+                    insertRow("B")
+                    ((InternalTransaction) nestedStatus).registerInvocationSynchronization(
+                        new TransactionSynchronization() {
+                            @Override
+                            void beforeCommit(boolean readOnly) {
+                                throw new RuntimeException("simulated beforeCommit failure")
+                            }
+                        }
+                    )
+                    return null
+                })
+            } catch (RuntimeException ignored) {
+            }
+            return null
+        })
+
+        then:
+        getNames() == ["A"]
     }
 
     private void insertRow(String name) {

--- a/data-tx/src/main/java/io/micronaut/transaction/impl/DefaultTransactionStatus.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/impl/DefaultTransactionStatus.java
@@ -55,8 +55,10 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
         return new NoTxTransactionStatus<>(connectionStatus, definition);
     }
 
-    public static <C> DefaultTransactionStatus<C> existingTx(ConnectionStatus<C> connectionStatus, DefaultTransactionStatus<C> existingTransaction) {
-        return new ExistingTransactionStatus<>(connectionStatus, existingTransaction);
+    public static <C> DefaultTransactionStatus<C> existingTx(ConnectionStatus<C> connectionStatus,
+                                                                TransactionDefinition definition,
+                                                                DefaultTransactionStatus<C> existingTransaction) {
+        return new ExistingTransactionStatus<>(connectionStatus, definition, existingTransaction);
     }
 
     @Override
@@ -171,8 +173,9 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
         private final DefaultTransactionStatus<C> existingTransaction;
 
         public ExistingTransactionStatus(ConnectionStatus<C> connectionStatus,
+                                         TransactionDefinition definition,
                                          DefaultTransactionStatus<C> existingTransaction) {
-            super(connectionStatus, existingTransaction.getTransactionDefinition());
+            super(connectionStatus, definition);
             this.existingTransaction = existingTransaction;
         }
 
@@ -184,7 +187,13 @@ public abstract sealed class DefaultTransactionStatus<C> extends AbstractInterna
         @Override
         public void setRollbackOnly() {
             super.setRollbackOnly();
-            existingTransaction.setGlobalRollbackOnly();
+            // Nested transactions use savepoints for isolation: rollback-only should
+            // only affect the savepoint, not doom the outer transaction. For all other
+            // propagation types (REQUIRED, SUPPORTS, MANDATORY) the inner block shares
+            // the outer transaction, so rollback-only must propagate.
+            if (!isNestedTransaction()) {
+                existingTransaction.setGlobalRollbackOnly();
+            }
         }
 
         @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractDefaultTransactionOperations.java
@@ -44,7 +44,7 @@ public abstract class AbstractDefaultTransactionOperations<C> extends AbstractTr
 
     @Override
     protected DefaultTransactionStatus<C> createExistingTransactionStatus(ConnectionStatus<C> connectionStatus, TransactionDefinition definition, DefaultTransactionStatus<C> existingTransaction) {
-        return DefaultTransactionStatus.existingTx(connectionStatus, existingTransaction);
+        return DefaultTransactionStatus.existingTx(connectionStatus, definition, existingTransaction);
     }
 
     @Override

--- a/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/support/AbstractTransactionOperations.java
@@ -388,11 +388,11 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
                 }
 
             } catch (UnexpectedRollbackException ex) {
-                // can only be caused by doCommit
+                // can only be caused by doCommit or doNestedCommit
                 tx.triggerAfterCompletion(TransactionSynchronization.Status.ROLLED_BACK);
                 throw ex;
             } catch (TransactionException ex) {
-                // can only be caused by doCommit
+                // can only be caused by doCommit or doNestedCommit
                 if (isRollbackOnCommitFailure()) {
                     doRollbackOnCommitException(tx, ex);
                 } else {
@@ -451,7 +451,16 @@ public abstract class AbstractTransactionOperations<T extends InternalTransactio
             if (logger.isDebugEnabled()) {
                 logger.debug("Initiating transaction rollback after commit exception", ex);
             }
-            doRollback(tx);
+            // Mirror rollbackInternal's dispatch: nested transactions must roll back
+            // to their savepoint (not the entire connection), and non-new/non-nested
+            // transactions should only mark rollback-only on the outer transaction.
+            if (tx.isNewTransaction()) {
+                doRollback(tx);
+            } else if (tx.isNestedTransaction()) {
+                doNestedRollback(tx);
+            } else {
+                tx.setRollbackOnly();
+            }
         } catch (RuntimeException | Error rbex) {
             logger.error("Commit exception overridden by rollback exception", ex);
             tx.triggerAfterCompletion(TransactionSynchronization.Status.UNKNOWN);

--- a/data-tx/src/test/java/io/micronaut/transaction/impl/DefaultTransactionStatusTest.java
+++ b/data-tx/src/test/java/io/micronaut/transaction/impl/DefaultTransactionStatusTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.transaction.impl;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.connection.ConnectionDefinition;
+import io.micronaut.data.connection.ConnectionStatus;
+import io.micronaut.data.connection.ConnectionSynchronization;
+import io.micronaut.transaction.TransactionDefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultTransactionStatusTest {
+
+    private static final TransactionDefinition NESTED_DEFINITION =
+        TransactionDefinition.of(TransactionDefinition.Propagation.NESTED);
+
+    @Test
+    void existingTxWithNestedDefinitionReportsIsNestedTransaction() {
+        DefaultTransactionStatus<Object> outerTx = newOuterTx();
+
+        DefaultTransactionStatus<Object> nestedTx = DefaultTransactionStatus.existingTx(
+            stubConnectionStatus(), NESTED_DEFINITION, outerTx
+        );
+
+        assertTrue(nestedTx.isNestedTransaction(),
+            "ExistingTransactionStatus created with NESTED definition must report isNestedTransaction() == true");
+        assertFalse(nestedTx.isNewTransaction());
+        assertEquals(TransactionDefinition.Propagation.NESTED,
+            nestedTx.getTransactionDefinition().getPropagationBehavior());
+    }
+
+    @Test
+    void existingTxWithRequiredDefinitionDoesNotReportNested() {
+        DefaultTransactionStatus<Object> outerTx = newOuterTx();
+
+        DefaultTransactionStatus<Object> existingTx = DefaultTransactionStatus.existingTx(
+            stubConnectionStatus(), TransactionDefinition.DEFAULT, outerTx
+        );
+
+        assertFalse(existingTx.isNestedTransaction());
+        assertFalse(existingTx.isNewTransaction());
+    }
+
+    @Test
+    void nestedTransactionPreservesOwnDefinitionNotParents() {
+        // Verify the incoming definition is stored, not the parent's.
+        // This is the core assertion for issue #3334: before the fix,
+        // ExistingTransactionStatus copied the outer transaction's definition.
+        DefaultTransactionStatus<Object> outerTx = newOuterTx();
+
+        DefaultTransactionStatus<Object> nestedTx = DefaultTransactionStatus.existingTx(
+            stubConnectionStatus(), NESTED_DEFINITION, outerTx
+        );
+
+        assertEquals(TransactionDefinition.Propagation.REQUIRED,
+            outerTx.getTransactionDefinition().getPropagationBehavior(),
+            "Outer tx should still have REQUIRED");
+        assertEquals(TransactionDefinition.Propagation.NESTED,
+            nestedTx.getTransactionDefinition().getPropagationBehavior(),
+            "Nested tx must have NESTED, not the outer's REQUIRED");
+    }
+
+    @Test
+    void nestedSetRollbackOnlyDoesNotPropagateToParent() {
+        // NESTED uses savepoints for isolation: setRollbackOnly should only
+        // affect the savepoint, not doom the outer transaction.
+        DefaultTransactionStatus<Object> outerTx = newOuterTx();
+
+        DefaultTransactionStatus<Object> nestedTx = DefaultTransactionStatus.existingTx(
+            stubConnectionStatus(), NESTED_DEFINITION, outerTx
+        );
+
+        nestedTx.setRollbackOnly();
+
+        assertTrue(nestedTx.isLocalRollbackOnly(),
+            "Nested tx should be marked as local rollback-only");
+        assertFalse(outerTx.isGlobalRollbackOnly(),
+            "Outer tx must NOT be marked as global rollback-only when nested tx sets rollback-only");
+    }
+
+    @Test
+    void nonNestedExistingTxSetRollbackOnlyPropagatesToParent() {
+        // For REQUIRED/SUPPORTS/MANDATORY, the inner block shares the outer
+        // transaction, so rollback-only must propagate.
+        DefaultTransactionStatus<Object> outerTx = newOuterTx();
+
+        DefaultTransactionStatus<Object> existingTx = DefaultTransactionStatus.existingTx(
+            stubConnectionStatus(), TransactionDefinition.DEFAULT, outerTx
+        );
+
+        existingTx.setRollbackOnly();
+
+        assertTrue(existingTx.isLocalRollbackOnly());
+        assertTrue(outerTx.isGlobalRollbackOnly(),
+            "Outer tx SHOULD be marked as global rollback-only for non-nested existing tx");
+    }
+
+    private static DefaultTransactionStatus<Object> newOuterTx() {
+        return DefaultTransactionStatus.newTx(stubConnectionStatus(), TransactionDefinition.DEFAULT);
+    }
+
+    private static ConnectionStatus<Object> stubConnectionStatus() {
+        return new ConnectionStatus<>() {
+            @Override
+            public boolean isNew() {
+                return false;
+            }
+
+            @NonNull
+            @Override
+            public Object getConnection() {
+                throw new UnsupportedOperationException("stub");
+            }
+
+            @NonNull
+            @Override
+            public ConnectionDefinition getDefinition() {
+                return ConnectionDefinition.DEFAULT;
+            }
+
+            @Override
+            public void registerSynchronization(@NonNull ConnectionSynchronization synchronization) {
+            }
+        };
+    }
+}

--- a/data-tx/src/test/java/io/micronaut/transaction/support/DoRollbackOnCommitExceptionTest.java
+++ b/data-tx/src/test/java/io/micronaut/transaction/support/DoRollbackOnCommitExceptionTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.transaction.support;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.data.connection.ConnectionDefinition;
+import io.micronaut.data.connection.ConnectionOperations;
+import io.micronaut.data.connection.ConnectionStatus;
+import io.micronaut.data.connection.ConnectionSynchronization;
+import io.micronaut.transaction.TransactionDefinition;
+import io.micronaut.transaction.exceptions.TransactionSystemException;
+import io.micronaut.transaction.exceptions.UnexpectedRollbackException;
+import io.micronaut.transaction.impl.DefaultTransactionStatus;
+import io.micronaut.transaction.impl.InternalTransaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that doRollbackOnCommitException dispatches to the correct
+ * rollback method based on transaction type: doRollback for new,
+ * doNestedRollback for nested, setRollbackOnly for existing non-nested.
+ */
+class DoRollbackOnCommitExceptionTest {
+
+    private static final TransactionDefinition NESTED_DEFINITION =
+        TransactionDefinition.of(TransactionDefinition.Propagation.NESTED);
+
+    private RecordingTransactionManager txManager;
+
+    @BeforeEach
+    void setUp() {
+        txManager = new RecordingTransactionManager();
+    }
+
+    @Test
+    void nestedBeforeCommitFailureDispatchesToDoNestedRollback() {
+        txManager.executeWrite(outerStatus -> {
+            try {
+                txManager.execute(
+                    NESTED_DEFINITION, nestedStatus -> {
+                    registerThrowingBeforeCommit(nestedStatus);
+                    return null;
+                });
+            } catch (RuntimeException ignored) {
+            }
+            return null;
+        });
+
+        assertEquals(
+            List.of("doBegin", "doNestedBegin", "doNestedRollback", "doCommit"),
+            txManager.calls
+        );
+    }
+
+    @Test
+    void nestedCommitFailureDispatchesToDoNestedRollback() {
+        txManager.failNestedCommit = true;
+
+        txManager.executeWrite(outerStatus -> {
+            try {
+                txManager.execute(NESTED_DEFINITION, nestedStatus -> null);
+            } catch (TransactionSystemException ignored) {
+            }
+            return null;
+        });
+
+        assertEquals(
+            List.of("doBegin", "doNestedBegin", "doNestedCommit", "doNestedRollback", "doCommit"),
+            txManager.calls
+        );
+    }
+
+    @Test
+    void newTransactionBeforeCommitFailureDispatchesToDoRollback() {
+        try {
+            txManager.executeWrite(status -> {
+                registerThrowingBeforeCommit(status);
+                return null;
+            });
+        } catch (RuntimeException ignored) {
+        }
+
+        assertEquals(List.of("doBegin", "doRollback"), txManager.calls);
+    }
+
+    @Test
+    void existingNonNestedBeforeCommitFailureDispatchesToSetRollbackOnly() {
+        try {
+            txManager.executeWrite(outerStatus -> {
+                try {
+                    txManager.execute(
+                        TransactionDefinition.DEFAULT, // REQUIRED — joins outer
+                        existingStatus -> {
+                        registerThrowingBeforeCommit(existingStatus);
+                        return null;
+                    });
+                } catch (RuntimeException ignored) {
+                }
+                return null;
+            });
+        } catch (UnexpectedRollbackException ignored) {
+            // Outer commit detects globalRollbackOnly set by inner setRollbackOnly
+        }
+
+        // With the fix: doRollbackOnCommitException calls setRollbackOnly (not
+        // doRollback) on the inner tx, which propagates globalRollbackOnly to the
+        // outer. The outer then rolls back via doRollback. Only one doRollback.
+        // With the bug: doRollback would appear twice — once spuriously from
+        // doRollbackOnCommitException on the inner tx, once from the outer rollback.
+        assertEquals(
+            List.of("doBegin", "doRollback"),
+            txManager.calls
+        );
+    }
+
+    private static void registerThrowingBeforeCommit(Object status) {
+        ((InternalTransaction<?>) status).registerInvocationSynchronization(
+            new TransactionSynchronization() {
+                @Override
+                public void beforeCommit(boolean readOnly) {
+                    throw new RuntimeException("simulated beforeCommit failure");
+                }
+            }
+        );
+    }
+
+    /**
+     * Transaction manager that records which doXxx methods are called.
+     */
+    static class RecordingTransactionManager extends AbstractDefaultTransactionOperations<String> {
+
+        final List<String> calls = new ArrayList<>();
+        boolean failNestedCommit;
+
+        RecordingTransactionManager() {
+            super(new StackConnectionOperations(), null);
+        }
+
+        @NonNull
+        @Override
+        public String getConnection() {
+            return "stub";
+        }
+
+        @Override
+        protected void doBegin(DefaultTransactionStatus<String> tx) {
+            calls.add("doBegin");
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus<String> tx) {
+            calls.add("doCommit");
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus<String> tx) {
+            calls.add("doRollback");
+        }
+
+        @Override
+        protected void doNestedBegin(DefaultTransactionStatus<String> tx) {
+            calls.add("doNestedBegin");
+        }
+
+        @Override
+        protected void doNestedCommit(DefaultTransactionStatus<String> tx) {
+            calls.add("doNestedCommit");
+            if (failNestedCommit) {
+                throw new TransactionSystemException("simulated commit failure");
+            }
+        }
+
+        @Override
+        protected void doNestedRollback(DefaultTransactionStatus<String> tx) {
+            calls.add("doNestedRollback");
+        }
+    }
+
+    /**
+     * Minimal ConnectionOperations that tracks a stack of connections
+     * to support nested execute() calls.
+     */
+    static class StackConnectionOperations implements ConnectionOperations<String> {
+
+        private final Deque<ConnectionStatus<String>> stack = new ArrayDeque<>();
+
+        @Override
+        public Optional<ConnectionStatus<String>> findConnectionStatus() {
+            return Optional.ofNullable(stack.peek());
+        }
+
+        @Override
+        public <R> R execute(@NonNull ConnectionDefinition definition,
+                             @NonNull Function<ConnectionStatus<String>, R> callback) {
+            ConnectionStatus<String> status = new StubConnectionStatus();
+            stack.push(status);
+            try {
+                return callback.apply(status);
+            } finally {
+                stack.pop();
+            }
+        }
+    }
+
+    static class StubConnectionStatus implements ConnectionStatus<String> {
+        @Override
+        public boolean isNew() {
+            return true;
+        }
+
+        @NonNull
+        @Override
+        public String getConnection() {
+            return "stub";
+        }
+
+        @NonNull
+        @Override
+        public ConnectionDefinition getDefinition() {
+            return ConnectionDefinition.DEFAULT;
+        }
+
+        @Override
+        public void registerSynchronization(@NonNull ConnectionSynchronization synchronization) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

  - `ExistingTransactionStatus` was copying the outer transaction's definition instead of preserving the incoming NESTED definition, so `isNestedTransaction()` never returned true and savepoints were never
  created
  - `doRollbackOnCommitException()` unconditionally called `doRollback()` instead of dispatching by transaction type, destroying the outer transaction when a nested commit-time callback failed
  - `setRollbackOnly()` on a nested transaction propagated to the outer transaction, defeating savepoint isolation

  ## How to review

  The diff is ~630 lines across 6 files, but only ~30 lines are production code — the rest are tests. The two commits are designed to be reviewed in order:

  1. **Fix NESTED propagation not creating JDBC savepoints** — The core bug. Read the commit message for the full explanation, then review the three small changes in
  `DefaultTransactionStatus.java` and the one-line forwarding change in `AbstractDefaultTransactionOperations.java`.

  2. **Fix doRollbackOnCommitException dispatching to wrong rollback method** — A pre-existing bug that became reachable after commit 1. The fix is a single `if/else if/else` in
  `AbstractTransactionOperations.java` mirroring `rollbackInternal`'s existing dispatch.