### PR TITLE
Error message when Embeddable has a missing field name rather than th…

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2Embedded2Spec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/H2Embedded2Spec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.data.jdbc.h2
 
 import groovy.transform.EqualsAndHashCode
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.data.exceptions.DataAccessException
 import org.jspecify.annotations.Nullable
 import io.micronaut.data.annotation.Embeddable
 import io.micronaut.data.annotation.Id
@@ -29,6 +30,8 @@ import jakarta.persistence.Entity
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.sql.DataSource
+
 import static io.micronaut.data.model.query.builder.sql.Dialect.H2
 
 @MicronautTest
@@ -39,24 +42,45 @@ class H2Embedded2Spec extends Specification {
     @Shared
     FooRepo repo
 
+    @Inject
+    @Shared
+    BazRepo bazRepo
+
     def filledInnerCanBeRetrieved() {
         when:
-            var saved = repo.save(new Foo(0, new Bar("1", "2")))
-            var found = repo.findById(saved.id).get()
+        var saved = repo.save(new Foo(0, new Bar("1", "2")))
+        var found = repo.findById(saved.id).get()
         then:
-            found.bar == new Bar("1", "2")
+        found.bar == new Bar("1", "2")
     }
 
     void partiallyFilledInnerCanBeRetrieved() {
         when:
-            var saved = repo.save(new Foo(0, new Bar("1", null)))
-            var found = repo.findById(saved.id).get()
+        var saved = repo.save(new Foo(0, new Bar("1", null)))
+        var found = repo.findById(saved.id).get()
         then:
-            found.bar == new Bar("1", null)
+        found.bar == new Bar("1", null)
     }
 
-}
+    void nullEmbeddedFieldProducesErrorMessageWithDottedPath() {
+        when: "the entity is loaded"
+        bazRepo.save(new BazEntity(1, new BazFields("2024-01-01", null)))
+        bazRepo.findById(1)
 
+        then: "exception message contains the full dotted path to the null field"
+        def ex = thrown(DataAccessException)
+        ex.message.contains("bazFields.createdBy")
+    }
+
+    void allNullEmbeddedColumnsThrowsForNonNullableEmbeddedProperty() {
+        when: "the entity is loaded"
+        bazRepo.save(new BazEntity(999, new BazFields(null, null)))
+        bazRepo.findById(999)
+
+        then: "materialization fails because the embedded property is not nullable"
+        thrown(DataAccessException)
+    }
+}
 @JdbcRepository(dialect = H2)
 interface FooRepo extends CrudRepository<Foo, Integer> {
 }
@@ -93,5 +117,42 @@ class Foo {
     Foo(int id, @Nullable Bar bar) {
         this.id = id
         this.bar = bar
+    }
+}
+
+@JdbcRepository(dialect = H2)
+interface BazRepo extends CrudRepository<BazEntity, Integer> {
+}
+
+@EqualsAndHashCode
+@Embeddable
+@Introspected
+class BazFields {
+
+    @Nullable
+    String createdOn
+    @Nullable
+    String createdBy
+
+    BazFields(String createdOn, String createdBy) {
+        this.createdOn = createdOn
+        this.createdBy = createdBy
+    }
+}
+
+@EqualsAndHashCode
+@Entity
+@Introspected
+class BazEntity {
+
+    @Id
+    int id
+
+    @Embedded
+    BazFields bazFields
+
+    BazEntity(int id, BazFields bazFields) {
+        this.id = id
+        this.bazFields = bazFields
     }
 }

--- a/data-model/src/main/java/io/micronaut/data/exceptions/MissingPropertyValueException.java
+++ b/data-model/src/main/java/io/micronaut/data/exceptions/MissingPropertyValueException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.exceptions;
+
+/**
+ * Exception thrown when a null value for a non-null constructor argument is detected.
+ * The {@code path} field holds dotted property path identifying the exact field that
+ * was null.
+ *
+ * @author Daksh R Jain
+ * @since 5.0.0
+ */
+public class MissingPropertyValueException extends DataAccessException {
+
+    private final String path;
+
+    public MissingPropertyValueException(String path, String entityName) {
+        super("Null value read for non-null constructor argument [" + path + "] of type: " + entityName);
+        this.path = path;
+    }
+
+    public MissingPropertyValueException(String path, String entityName, Throwable cause) {
+        super("Null value read for non-null constructor argument [" + path + "] of type: " + entityName, cause);
+        this.path = path;
+    }
+
+    /**
+     * Getter for path field.
+     *
+     * @return the dotted property path identifying the exact field that was null.
+     */
+    public String getPath() {
+        return this.path;
+    }
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.data.runtime.mapper.sql;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.data.exceptions.MissingPropertyValueException;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanProperty;
@@ -503,11 +504,17 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             } else {
                 int len = constructorArguments.length;
                 @Nullable Object[] args = new Object[len];
+                String firstNullFieldName = null;
                 for (int i = 0; i < len; i++) {
                     RuntimePersistentProperty<K> prop = constructorArguments[i];
                     if (prop instanceof RuntimeAssociation<K> entityAssociation) {
                         if (prop instanceof Embedded embedded) {
-                            args[i] = readEntity(rs, ctx.embedded(embedded), null, null);
+                            try {
+                                args[i] = readEntity(rs, ctx.embedded(embedded), null, null);
+                            } catch (MissingPropertyValueException e) {
+                                String propertyPath = prop.getName() + "." +  e.getPath();
+                                throw new MissingPropertyValueException(propertyPath, persistentEntity.getName(), e);
+                            }
                         } else {
                             final Relation.Kind kind = entityAssociation.getKind();
                             final boolean isInverse = parent != null && ctx.association != null && ctx.association.getOwner() == entityAssociation.getAssociatedEntity();
@@ -550,7 +557,11 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                             if (!prop.isOptional() && !nullableEmbedded) {
                                 AnnotationMetadata entityAnnotationMetadata = ctx.persistentEntity.getAnnotationMetadata();
                                 if (entityAnnotationMetadata.hasAnnotation(Embeddable.class) || entityAnnotationMetadata.hasAnnotation(EmbeddedId.class)) {
-                                    return null;
+                                    if (firstNullFieldName == null) {
+                                        firstNullFieldName = prop.getName();
+                                    }
+                                    args[i] = null;
+                                    continue;
                                 }
                                 throw new DataAccessException("Null value read for non-null constructor argument [" + prop.getName() + "] of type: " + persistentEntity.getName());
                             } else {
@@ -561,7 +572,15 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                         args[i] = convert(prop, v);
                     }
                 }
-                if (nullableEmbedded && args.length > 0 && isAllNulls(args)) {
+                boolean isAllNulls = isAllNulls(args);
+                if (firstNullFieldName != null) {
+                    if (isAllNulls) {
+                        return null;
+                    } else {
+                        throw new MissingPropertyValueException(firstNullFieldName, persistentEntity.getName());
+                    }
+                }
+                if (nullableEmbedded && args.length > 0 && isAllNulls) {
                     return null;
                 } else {
                     entity = introspection.instantiate(args);
@@ -605,8 +624,14 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                 BeanProperty<K, Object> property = rpp.getProperty();
                 if (rpp instanceof RuntimeAssociation<K> entityAssociation) {
                     if (rpp instanceof Embedded embedded) {
-                        Object value = readEntity(rs, ctx.embedded(embedded), parent == null ? entity : parent, null);
-                        entity = setProperty(property, entity, value);
+                        try {
+                            Object value = readEntity(rs, ctx.embedded(embedded), parent == null ? entity : parent, null);
+                            entity = setProperty(property, entity, value);
+                        } catch (MissingPropertyValueException e) {
+                            String propertyPath = rpp.getName() + "." + e.getPath();
+                            throw new MissingPropertyValueException(propertyPath, persistentEntity.getName(), e);
+                        }
+
                     } else {
                         final boolean isInverse = parent != null && entityAssociation.getKind().isSingleEnded() && ctx.association != null && ctx.association.getOwner() == entityAssociation.getAssociatedEntity();
                         // Before setting property value, check if mappedBy is not different from the property name


### PR DESCRIPTION
Closes: #3254 

Adding a custom exception whenever an embedded null field is detected and throwing the error that displays the exact field name which is null and not the embedded object name itself.