### PR TITLE
Fix existence-aware SQL readers to preserve configured conversion service

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameExistenceAwareResultSetReader.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameExistenceAwareResultSetReader.java
@@ -19,11 +19,13 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.runtime.mapper.AbstractDelegatingResultReader;
+import io.micronaut.data.runtime.mapper.ResultReader;
 import org.jspecify.annotations.Nullable;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -39,7 +41,11 @@ public class ColumnNameExistenceAwareResultSetReader extends AbstractDelegatingR
     private Set<String> knownColumns;
 
     public ColumnNameExistenceAwareResultSetReader() {
-        super(new ColumnNameResultSetReader());
+        this(new ColumnNameResultSetReader());
+    }
+
+    public ColumnNameExistenceAwareResultSetReader(ResultReader<ResultSet, String> delegate) {
+        super(delegate);
     }
 
     @Override
@@ -62,13 +68,13 @@ public class ColumnNameExistenceAwareResultSetReader extends AbstractDelegatingR
                     if (columnLabel == null) {
                         continue;
                     }
-                    knownColumns.add(columnLabel.toLowerCase());
+                    knownColumns.add(columnLabel.toLowerCase(Locale.ENGLISH));
                 }
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }
         }
-        return knownColumns.contains(name.toLowerCase());
+        return knownColumns.contains(name.toLowerCase(Locale.ENGLISH));
     }
 
 }

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameExistenceAwareResultSetReader.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameExistenceAwareResultSetReader.java
@@ -40,10 +40,6 @@ public class ColumnNameExistenceAwareResultSetReader extends AbstractDelegatingR
     @Nullable
     private Set<String> knownColumns;
 
-    public ColumnNameExistenceAwareResultSetReader() {
-        this(new ColumnNameResultSetReader());
-    }
-
     public ColumnNameExistenceAwareResultSetReader(ResultReader<ResultSet, String> delegate) {
         super(delegate);
     }

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -249,7 +249,7 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
 
     @Override
     protected ResultReader<ResultSet, String> createColumnNameResultSetReaderWithColumnExistenceAware() {
-        return new ColumnNameExistenceAwareResultSetReader();
+        return new ColumnNameExistenceAwareResultSetReader(columnNameResultSetReader);
     }
 
     @NonNull

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/ColumnNameExistenceAwareResultSetReaderSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/ColumnNameExistenceAwareResultSetReaderSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.jdbc.mapper.ColumnNameExistenceAwareResultSetReader
+import io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader
+import io.micronaut.data.model.DataType
+import io.micronaut.data.runtime.convert.DataConversionService
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.DriverManager
+import java.time.LocalDateTime
+
+class ColumnNameExistenceAwareResultSetReaderSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "existence aware reader uses configured delegate conversion service"() {
+        given:
+        def conversionService = context.getBean(DataConversionService)
+        def reader = new ColumnNameExistenceAwareResultSetReader(new ColumnNameResultSetReader(conversionService))
+        def connection = DriverManager.getConnection("jdbc:h2:mem:readerconversion;DB_CLOSE_DELAY=-1")
+        def statement = connection.createStatement()
+        def resultSet = statement.executeQuery("SELECT TIMESTAMP '2024-01-02 03:04:05' AS last_updated")
+
+        expect:
+        resultSet.next()
+        def timestamp = reader.readDynamic(resultSet, "last_updated", DataType.TIMESTAMP)
+        reader.convertRequired(timestamp, LocalDateTime) == LocalDateTime.of(2024, 1, 2, 3, 4, 5)
+
+        cleanup:
+        resultSet?.close()
+        statement?.close()
+        connection?.close()
+    }
+}

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameExistenceAwareR2dbcResultSetReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameExistenceAwareR2dbcResultSetReader.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.model.DataType;
 import io.micronaut.data.runtime.mapper.AbstractDelegatingResultReader;
+import io.micronaut.data.runtime.mapper.ResultReader;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
@@ -41,7 +42,11 @@ public class ColumnNameExistenceAwareR2dbcResultSetReader extends AbstractDelega
     private Set<String> knownColumns;
 
     public ColumnNameExistenceAwareR2dbcResultSetReader() {
-        super(new ColumnNameR2dbcResultReader());
+        this(new ColumnNameR2dbcResultReader());
+    }
+
+    public ColumnNameExistenceAwareR2dbcResultSetReader(ResultReader<Row, String> delegate) {
+        super(delegate);
     }
 
     @Nullable

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameExistenceAwareR2dbcResultSetReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameExistenceAwareR2dbcResultSetReader.java
@@ -41,10 +41,6 @@ public class ColumnNameExistenceAwareR2dbcResultSetReader extends AbstractDelega
     @Nullable
     private Set<String> knownColumns;
 
-    public ColumnNameExistenceAwareR2dbcResultSetReader() {
-        this(new ColumnNameR2dbcResultReader());
-    }
-
     public ColumnNameExistenceAwareR2dbcResultSetReader(ResultReader<Row, String> delegate) {
         super(delegate);
     }

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
@@ -250,7 +250,7 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
 
     @Override
     protected ResultReader<Row, String> createColumnNameResultSetReaderWithColumnExistenceAware() {
-        return new ColumnNameExistenceAwareR2dbcResultSetReader();
+        return new ColumnNameExistenceAwareR2dbcResultSetReader(columnNameResultSetReader);
     }
 
     @Override

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ColumnNameExistenceAwareR2dbcResultSetReaderSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ColumnNameExistenceAwareR2dbcResultSetReaderSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.model.DataType
+import io.micronaut.data.r2dbc.mapper.ColumnNameExistenceAwareR2dbcResultSetReader
+import io.micronaut.data.r2dbc.mapper.ColumnNameR2dbcResultReader
+import io.micronaut.data.runtime.convert.DataConversionService
+import io.r2dbc.spi.ColumnMetadata
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.RowMetadata
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ColumnNameExistenceAwareR2dbcResultSetReaderSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    void "existence aware reader uses configured delegate conversion service"() {
+        given:
+        def localDateTime = LocalDateTime.of(2024, 1, 2, 3, 4, 5)
+        def instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant()
+        def conversionService = context.getBean(DataConversionService)
+        def reader = new ColumnNameExistenceAwareR2dbcResultSetReader(new ColumnNameR2dbcResultReader(conversionService))
+        Row row = Mock()
+        RowMetadata rowMetadata = Mock()
+        ColumnMetadata columnMetadata = Mock()
+
+        when:
+        def value = reader.readDynamic(row, "last_updated", DataType.TIMESTAMP)
+
+        then:
+        value == instant
+        reader.readDynamic(row, "missing_column", DataType.TIMESTAMP) == null
+
+        1 * row.getMetadata() >> rowMetadata
+        1 * rowMetadata.getColumnMetadatas() >> [columnMetadata]
+        1 * columnMetadata.getName() >> "last_updated"
+        1 * row.get("last_updated") >> localDateTime
+        0 * row.get("missing_column")
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ColumnNameExistenceAwareR2dbcResultSetReaderSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ColumnNameExistenceAwareR2dbcResultSetReaderSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
ColumnNameExistenceAwareResultSetReader and the R2DBC equivalent were creating their own default column-name readers internally. That bypassed the repository operations' configured DataConversionService and could break result mapping for values that require Micronaut Data conversions, for example timestamp values mapped to LocalDateTime.

Allow the existence-aware readers to wrap the configured delegate reader and have JDBC/R2DBC repository operations pass their existing column-name reader. The wrappers now only add missing-column handling while preserving normal read and conversion behavior.