### PR TITLE
Complete the truncated Javadoc on @ReadOnly

### DIFF
--- a/data-tx/src/main/java/io/micronaut/transaction/annotation/ReadOnly.java
+++ b/data-tx/src/main/java/io/micronaut/transaction/annotation/ReadOnly.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Target;
 
 /**
  * Stereotype annotation for demarcating a read-only transaction. Since the
- * {@code jakarta.transaction.Transactional}
+ * {@code jakarta.transaction.Transactional} annotation does not support a
+ * {@code readOnly} attribute, this annotation acts as a shortcut for
+ * {@link Transactional @Transactional(readOnly = true)}.
  *
  * @author graemerocher
  * @since 1.0.0


### PR DESCRIPTION
## Summary

Resolves #1062.

The class-level Javadoc on `io.micronaut.transaction.annotation.ReadOnly` ends mid-sentence:

```java
/**
 * Stereotype annotation for demarcating a read-only transaction. Since the
 * {@code jakarta.transaction.Transactional}
 *
 * @author graemerocher
 * @since 1.0.0
 */
```

This PR extends the second sentence to spell out the rationale: `jakarta.transaction.Transactional` does not expose a `readOnly` attribute, so this annotation is provided as a shortcut for `@Transactional(readOnly = true)` (which matches the meta-annotation already on the class).

## Diff

```diff
 /**
  * Stereotype annotation for demarcating a read-only transaction. Since the
- * {@code jakarta.transaction.Transactional}
+ * {@code jakarta.transaction.Transactional} annotation does not support a
+ * {@code readOnly} attribute, this annotation acts as a shortcut for
+ * {@link Transactional @Transactional(readOnly = true)}.
  *
  * @author graemerocher
  * @since 1.0.0
  */
```

## Test plan

- [x] `./gradlew :micronaut-data-tx:compileJava` → BUILD SUCCESSFUL
- [x] `./gradlew :micronaut-data-tx:javadoc` → BUILD SUCCESSFUL (no new warnings; preexisting warnings on unrelated classes are unchanged)

Happy to tweak the wording if maintainers prefer a different phrasing.