### PR TITLE
Fix root entity resolution for inherited JPA specification executor methods

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -76,8 +76,6 @@ import io.micronaut.data.processor.visitors.finders.MethodMatcher;
 import io.micronaut.data.processor.visitors.finders.RawQueryMethodMatcher;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
 import io.micronaut.data.repository.GenericRepository;
-import io.micronaut.data.repository.jpa.JpaSpecificationExecutor;
-import io.micronaut.data.repository.jpa.async.AsyncJpaSpecificationExecutor;
 import io.micronaut.data.repository.jpa.criteria.CriteriaDeleteBuilder;
 import io.micronaut.data.repository.jpa.criteria.CriteriaQueryBuilder;
 import io.micronaut.data.repository.jpa.criteria.CriteriaUpdateBuilder;
@@ -85,8 +83,6 @@ import io.micronaut.data.repository.jpa.criteria.DeleteSpecification;
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification;
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification;
-import io.micronaut.data.repository.jpa.reactive.ReactiveStreamsJpaSpecificationExecutor;
-import io.micronaut.data.repository.jpa.reactive.ReactorJpaSpecificationExecutor;
 import io.micronaut.inject.annotation.EvaluatedExpressionReferenceCounter;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -131,6 +127,10 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
     public static final String SPRING_REPO = "org.springframework.data.repository.Repository";
     public static final String JAKARTA_DATA_REPO = "jakarta.data.repository.DataRepository";
+    private static final String JPA_SPECIFICATION_EXECUTOR = "io.micronaut.data.repository.jpa.JpaSpecificationExecutor";
+    private static final String ASYNC_JPA_SPECIFICATION_EXECUTOR = "io.micronaut.data.repository.jpa.async.AsyncJpaSpecificationExecutor";
+    private static final String REACTIVE_STREAMS_JPA_SPECIFICATION_EXECUTOR = "io.micronaut.data.repository.jpa.reactive.ReactiveStreamsJpaSpecificationExecutor";
+    private static final String REACTOR_JPA_SPECIFICATION_EXECUTOR = "io.micronaut.data.repository.jpa.reactive.ReactorJpaSpecificationExecutor";
     private static final boolean IS_DOCUMENT_ANNOTATION_PROCESSOR = ClassUtils.isPresent("io.micronaut.data.document.processor.mapper.MappedEntityMapper", RepositoryTypeElementVisitor.class.getClassLoader());
     private static final Map<String, String> COMMON_TYPE_ROLES;
     private static final List<Map.Entry<String, String>> COMMON_ANNOTATION_ROLES;
@@ -1028,19 +1028,19 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
         if (entity != null) {
             return entity;
         }
-        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, JpaSpecificationExecutor.class, "T");
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, JPA_SPECIFICATION_EXECUTOR, "T");
         if (entity != null) {
             return entity;
         }
-        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, AsyncJpaSpecificationExecutor.class, "T");
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, ASYNC_JPA_SPECIFICATION_EXECUTOR, "T");
         if (entity != null) {
             return entity;
         }
-        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, ReactiveStreamsJpaSpecificationExecutor.class, "T");
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, REACTIVE_STREAMS_JPA_SPECIFICATION_EXECUTOR, "T");
         if (entity != null) {
             return entity;
         }
-        return resolveEntityForCurrentClass(repositoryClass, entityResolver, ReactorJpaSpecificationExecutor.class, "T");
+        return resolveEntityForCurrentClass(repositoryClass, entityResolver, REACTOR_JPA_SPECIFICATION_EXECUTOR, "T");
     }
 
     @Nullable

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitor.java
@@ -76,6 +76,8 @@ import io.micronaut.data.processor.visitors.finders.MethodMatcher;
 import io.micronaut.data.processor.visitors.finders.RawQueryMethodMatcher;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
 import io.micronaut.data.repository.GenericRepository;
+import io.micronaut.data.repository.jpa.JpaSpecificationExecutor;
+import io.micronaut.data.repository.jpa.async.AsyncJpaSpecificationExecutor;
 import io.micronaut.data.repository.jpa.criteria.CriteriaDeleteBuilder;
 import io.micronaut.data.repository.jpa.criteria.CriteriaQueryBuilder;
 import io.micronaut.data.repository.jpa.criteria.CriteriaUpdateBuilder;
@@ -83,6 +85,8 @@ import io.micronaut.data.repository.jpa.criteria.DeleteSpecification;
 import io.micronaut.data.repository.jpa.criteria.PredicateSpecification;
 import io.micronaut.data.repository.jpa.criteria.QuerySpecification;
 import io.micronaut.data.repository.jpa.criteria.UpdateSpecification;
+import io.micronaut.data.repository.jpa.reactive.ReactiveStreamsJpaSpecificationExecutor;
+import io.micronaut.data.repository.jpa.reactive.ReactorJpaSpecificationExecutor;
 import io.micronaut.inject.annotation.EvaluatedExpressionReferenceCounter;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -1012,23 +1016,64 @@ public class RepositoryTypeElementVisitor implements TypeElementVisitor<Reposito
 
     @Nullable
     private SourcePersistentEntity resolveEntityForCurrentClass(ClassElement repositoryClass, Function<ClassElement, SourcePersistentEntity> entityResolver) {
-        Map<String, ClassElement> typeArguments = repositoryClass.getTypeArguments(GenericRepository.class);
-        String argName = "E";
+        SourcePersistentEntity entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, GenericRepository.class, "E");
+        if (entity != null) {
+            return entity;
+        }
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, SPRING_REPO, "T");
+        if (entity != null) {
+            return entity;
+        }
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, JAKARTA_DATA_REPO, "T");
+        if (entity != null) {
+            return entity;
+        }
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, JpaSpecificationExecutor.class, "T");
+        if (entity != null) {
+            return entity;
+        }
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, AsyncJpaSpecificationExecutor.class, "T");
+        if (entity != null) {
+            return entity;
+        }
+        entity = resolveEntityForCurrentClass(repositoryClass, entityResolver, ReactiveStreamsJpaSpecificationExecutor.class, "T");
+        if (entity != null) {
+            return entity;
+        }
+        return resolveEntityForCurrentClass(repositoryClass, entityResolver, ReactorJpaSpecificationExecutor.class, "T");
+    }
+
+    @Nullable
+    private SourcePersistentEntity resolveEntityForCurrentClass(ClassElement repositoryClass,
+                                                               Function<ClassElement, SourcePersistentEntity> entityResolver,
+                                                               Class<?> repositoryType,
+                                                               String argName) {
+        return resolveEntityFromTypeArguments(repositoryClass.getTypeArguments(repositoryType), entityResolver, argName);
+    }
+
+    @Nullable
+    private SourcePersistentEntity resolveEntityForCurrentClass(ClassElement repositoryClass,
+                                                               Function<ClassElement, SourcePersistentEntity> entityResolver,
+                                                               String repositoryType,
+                                                               String argName) {
+        return resolveEntityFromTypeArguments(repositoryClass.getTypeArguments(repositoryType), entityResolver, argName);
+    }
+
+    @Nullable
+    private SourcePersistentEntity resolveEntityFromTypeArguments(Map<String, ClassElement> typeArguments,
+                                                                  Function<ClassElement, SourcePersistentEntity> entityResolver,
+                                                                  String argName) {
         if (typeArguments.isEmpty()) {
-            argName = "T";
-            typeArguments = repositoryClass.getTypeArguments(SPRING_REPO);
+            return null;
         }
-        if (typeArguments.isEmpty()) {
-            argName = "T";
-            typeArguments = repositoryClass.getTypeArguments(JAKARTA_DATA_REPO);
+        ClassElement classElement = typeArguments.get(argName);
+        if (classElement == null) {
+            classElement = typeArguments.values().iterator().next();
         }
-        if (!typeArguments.isEmpty()) {
-            ClassElement ce = typeArguments.get(argName);
-            if (ce != null) {
-                return entityResolver.apply(ce);
-            }
+        if (classElement == null) {
+            return null;
         }
-        return null;
+        return entityResolver.apply(classElement);
     }
 
     private void annotateEntityRepresentationIfPresent(ClassElement repositoryClass, Function<ClassElement, SourcePersistentEntity> entityResolver) {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitorSpec.groovy
@@ -34,11 +34,13 @@ import io.micronaut.inject.ExecutableMethod
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import spock.lang.Shared
 import spock.lang.Unroll
 
 import javax.annotation.processing.SupportedAnnotationTypes
+import java.util.concurrent.CompletableFuture
 
 import static io.micronaut.data.processor.visitors.TestUtils.getQueryParameterNames
 
@@ -211,6 +213,56 @@ interface BookRepository extends JpaSpecificationExecutor<Person> {
         ExecutableMethod<?, ?> findAll = beanDefinition.getRequiredMethod("findAll", CriteriaQueryBuilder)
 
         then:
+        findAll.getValue(DataMethod, "rootEntity", Class).get() == Person
+    }
+
+    void "test inherited async specification methods without generic repository root"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.BookRepository' + BeanDefinitionVisitor.PROXY_SUFFIX, """
+package test;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.model.entities.Person;
+import io.micronaut.data.repository.jpa.async.AsyncJpaSpecificationExecutor;
+
+@Repository
+interface BookRepository extends AsyncJpaSpecificationExecutor<Person> {
+}
+""")
+
+        expect:
+        !beanDefinition.isAbstract()
+
+        when:
+        ExecutableMethod<?, ?> findAll = beanDefinition.getRequiredMethod("findAll", QuerySpecification)
+
+        then:
+        findAll.getReturnType().type == CompletableFuture
+        findAll.getValue(DataMethod, "rootEntity", Class).get() == Person
+    }
+
+    void "test inherited reactive streams specification methods without generic repository root"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.BookRepository' + BeanDefinitionVisitor.PROXY_SUFFIX, """
+package test;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.model.entities.Person;
+import io.micronaut.data.repository.jpa.reactive.ReactiveStreamsJpaSpecificationExecutor;
+
+@Repository
+interface BookRepository extends ReactiveStreamsJpaSpecificationExecutor<Person> {
+}
+""")
+
+        expect:
+        !beanDefinition.isAbstract()
+
+        when:
+        ExecutableMethod<?, ?> findAll = beanDefinition.getRequiredMethod("findAll", QuerySpecification)
+
+        then:
+        findAll.getReturnType().type == Publisher
         findAll.getValue(DataMethod, "rootEntity", Class).get() == Person
     }
 

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/RepositoryTypeElementVisitorSpec.groovy
@@ -27,11 +27,14 @@ import io.micronaut.data.model.Pageable
 import io.micronaut.data.model.PersistentEntity
 import io.micronaut.data.model.entities.Person
 import io.micronaut.data.model.query.builder.jpa.JpaQueryBuilder
+import io.micronaut.data.repository.jpa.criteria.CriteriaQueryBuilder
+import io.micronaut.data.repository.jpa.criteria.QuerySpecification
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import reactor.core.publisher.Flux
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -160,6 +163,55 @@ interface MyInterface {
         then:
             def e = thrown(RuntimeException)
             e.message.contains "Repository is required to be processed by the data-document-processor. Make sure it's included as a dependency to the annotation processor classpath!"
+    }
+
+    void "test inherited reactive specification methods without generic repository root"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.BookRepository' + BeanDefinitionVisitor.PROXY_SUFFIX, """
+package test;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.repository.jpa.reactive.ReactorJpaSpecificationExecutor;
+import io.micronaut.data.model.entities.Person;
+
+@Repository
+interface BookRepository extends ReactorJpaSpecificationExecutor<Person> {
+}
+""")
+
+        expect:
+        !beanDefinition.isAbstract()
+
+        when:
+        ExecutableMethod<?, ?> findAll = beanDefinition.getRequiredMethod("findAll", QuerySpecification)
+
+        then:
+        findAll.getReturnType().type == Flux
+        findAll.getValue(DataMethod, "rootEntity", Class).get() == Person
+    }
+
+    void "test inherited specification builder methods without generic repository root"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.BookRepository' + BeanDefinitionVisitor.PROXY_SUFFIX, """
+package test;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.model.entities.Person;
+import io.micronaut.data.repository.jpa.JpaSpecificationExecutor;
+
+@Repository
+interface BookRepository extends JpaSpecificationExecutor<Person> {
+}
+""")
+
+        expect:
+        !beanDefinition.isAbstract()
+
+        when:
+        ExecutableMethod<?, ?> findAll = beanDefinition.getRequiredMethod("findAll", CriteriaQueryBuilder)
+
+        then:
+        findAll.getValue(DataMethod, "rootEntity", Class).get() == Person
     }
 
     @Override


### PR DESCRIPTION
Having such repository 
```
@Repository
public interface BookRepository extends ReactorJpaSpecificationExecutor<Book> {
}
```
worked in Micronaut 4 and now in Micronaut 5 it throws error:
```
java.lang.NullPointerException: Persistent entity is required
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at io.micronaut.data.processor.visitors.MethodMatchContext.getRootEntity(MethodMatchContext.java:140)
	at io.micronaut.data.processor.visitors.RepositoryTypeElementVisitor.processMethodInfo(RepositoryTypeElementVisitor.java:574)
	at io.micronaut.data.processor.visitors.RepositoryTypeElementVisitor.visitRepositoryMethod(RepositoryTypeElementVisitor.java:409)
	at io.micronaut.data.processor.visitors.RepositoryTypeElementVisitor.lambda$visitClass$2(RepositoryTypeElementVisitor.java:312)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.micronaut.data.processor.visitors.RepositoryTypeElementVisitor.visitClass(RepositoryTypeElementVisitor.java:312)
	at io.micronaut.annotation.processing.TypeElementVisitorProcessor.visitClass(TypeElementVisitorProcessor.java:369)
	at io.micronaut.annotation.processing.TypeElementVisitorProcessor.process(TypeElementVisitorProcessor.java:307)
	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:956)
	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.java:872)
	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1188)
	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1301)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1262)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:938)
...
```
The fix is to extract entity type from `ReactorJpaSpecificationExecutor<Entity>` and other executors.