### PR TITLE
Fix Data classloader matching for mapped entities

### DIFF
--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
@@ -27,7 +27,9 @@ import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * The Micronaut Data codec registry.
@@ -39,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 final class DataCodecRegistry implements CodecRegistry {
 
     @Nullable
-    private final Collection<Class<?>> entities;
+    private final Set<String> entityNames;
     private final DataSerdeRegistry dataSerdeRegistry;
     private final RuntimeEntityRegistry runtimeEntityRegistry;
     private final Map<Class, Codec> codecs = new ConcurrentHashMap<>();
@@ -54,7 +56,9 @@ final class DataCodecRegistry implements CodecRegistry {
     DataCodecRegistry(@Nullable Collection<Class<?>> entities,
                       DataSerdeRegistry dataSerdeRegistry,
                       RuntimeEntityRegistry runtimeEntityRegistry) {
-        this.entities = entities;
+        this.entityNames = entities == null ? null : entities.stream()
+            .map(Class::getName)
+            .collect(Collectors.toUnmodifiableSet());
         this.dataSerdeRegistry = dataSerdeRegistry;
         this.runtimeEntityRegistry = runtimeEntityRegistry;
     }
@@ -71,7 +75,7 @@ final class DataCodecRegistry implements CodecRegistry {
         if (codec != null) {
             return codec;
         }
-        if (clazz.isEnum() || entities != null && !entities.contains(clazz)) {
+        if (clazz.isEnum() || (entityNames != null && !entityNames.contains(clazz.getName()))) {
             return null;
         }
         if (BeanIntrospector.SHARED.findIntrospection(clazz).isPresent()) {

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
@@ -16,17 +16,20 @@
 package io.micronaut.data.mongodb.serde;
 
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
+import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.data.annotation.Embeddable;
 import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.model.runtime.RuntimeEntityRegistry;
 import io.micronaut.data.model.runtime.RuntimePersistentEntity;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -75,10 +78,11 @@ final class DataCodecRegistry implements CodecRegistry {
         if (codec != null) {
             return codec;
         }
-        if (clazz.isEnum() || (entityNames != null && !entityNames.contains(clazz.getName()))) {
+        Optional<BeanIntrospection<T>> introspection = BeanIntrospector.SHARED.findIntrospection(clazz);
+        if (clazz.isEnum() || isExcluded(clazz, introspection)) {
             return null;
         }
-        if (BeanIntrospector.SHARED.findIntrospection(clazz).isPresent()) {
+        if (introspection.isPresent()) {
             RuntimePersistentEntity<T> entity = runtimeEntityRegistry.getEntity(clazz);
             if (entity.isAnnotationPresent(MappedEntity.class)) {
                 codec = new MappedEntityCodec<>(dataSerdeRegistry, entity, clazz, registry);
@@ -90,6 +94,17 @@ final class DataCodecRegistry implements CodecRegistry {
             return codec;
         }
         return null;
+    }
+
+    private <T> boolean isExcluded(Class<T> clazz, Optional<BeanIntrospection<T>> introspection) {
+        if (entityNames == null || entityNames.contains(clazz.getName())) {
+            return false;
+        }
+        return introspection
+            .map(BeanIntrospection::getAnnotationMetadata)
+            .map(annotationMetadata -> !annotationMetadata.hasStereotype(MappedEntity.class)
+                && !annotationMetadata.hasStereotype(Embeddable.class))
+            .orElse(true);
     }
 
 }

--- a/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
+++ b/data-mongodb/src/main/java/io/micronaut/data/mongodb/serde/DataCodecRegistry.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -78,7 +79,7 @@ final class DataCodecRegistry implements CodecRegistry {
         if (codec != null) {
             return codec;
         }
-        Optional<BeanIntrospection<T>> introspection = BeanIntrospector.SHARED.findIntrospection(clazz);
+        Optional<BeanIntrospection<T>> introspection = findIntrospection(clazz);
         if (clazz.isEnum() || isExcluded(clazz, introspection)) {
             return null;
         }
@@ -105,6 +106,32 @@ final class DataCodecRegistry implements CodecRegistry {
             .map(annotationMetadata -> !annotationMetadata.hasStereotype(MappedEntity.class)
                 && !annotationMetadata.hasStereotype(Embeddable.class))
             .orElse(true);
+    }
+
+    private <T> Optional<BeanIntrospection<T>> findIntrospection(Class<T> type) {
+        ClassLoader classLoader = type.getClassLoader();
+        if (classLoader == null) {
+            classLoader = runtimeEntityRegistry.getApplicationContext().getClassLoader();
+        }
+        ClassLoader introspectionClassLoader = classLoader;
+        return withContextClassLoader(
+            introspectionClassLoader,
+            () -> BeanIntrospector.forClassLoader(introspectionClassLoader).findIntrospection(type)
+        );
+    }
+
+    private static <T> T withContextClassLoader(ClassLoader classLoader, Supplier<T> action) {
+        Thread thread = Thread.currentThread();
+        ClassLoader previous = thread.getContextClassLoader();
+        if (previous == classLoader) {
+            return action.get();
+        }
+        thread.setContextClassLoader(classLoader);
+        try {
+            return action.get();
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
     }
 
 }

--- a/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
@@ -66,6 +66,10 @@ class DataCodecRegistrySpec extends Specification {
                 return super.loadClass(name, resolve)
             }
         }
-        return classLoader.loadClass(entityClass.name)
+        try {
+            return classLoader.loadClass(entityClass.name)
+        } finally {
+            classLoader.close()
+        }
     }
 }

--- a/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.mongodb.serde
+
+import com.mongodb.MongoClientSettings
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.document.mongodb.entities.ComplexValue
+import io.micronaut.data.model.runtime.RuntimeEntityRegistry
+import spock.lang.Specification
+
+class DataCodecRegistrySpec extends Specification {
+
+    void "data codec registry accepts matching entity names loaded by a different classloader"() {
+        given:
+        Class<?> scannedEntity = reloadEntityClass(ComplexValue)
+
+        expect:
+        scannedEntity.name == ComplexValue.name
+        scannedEntity != ComplexValue
+
+        when:
+        def context = ApplicationContext.run()
+        def dataCodecRegistry = new DataCodecRegistry(
+                [scannedEntity],
+                context.getBean(DataSerdeRegistry),
+                context.getBean(RuntimeEntityRegistry)
+        )
+        def codec = dataCodecRegistry.get(ComplexValue, MongoClientSettings.defaultCodecRegistry)
+
+        then:
+        codec != null
+        codec.encoderClass == ComplexValue
+
+        cleanup:
+        context?.close()
+    }
+
+    private static Class<?> reloadEntityClass(Class<?> entityClass) {
+        URL location = entityClass.getProtectionDomain().getCodeSource().getLocation()
+        def classLoader = new URLClassLoader(new URL[] { location }, entityClass.classLoader) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name == entityClass.name) {
+                    Class<?> loaded = findLoadedClass(name)
+                    if (loaded == null) {
+                        loaded = findClass(name)
+                    }
+                    if (resolve) {
+                        resolveClass(loaded)
+                    }
+                    return loaded
+                }
+                return super.loadClass(name, resolve)
+            }
+        }
+        return classLoader.loadClass(entityClass.name)
+    }
+}

--- a/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
+++ b/data-mongodb/src/test/groovy/io/micronaut/data/mongodb/serde/DataCodecRegistrySpec.groovy
@@ -17,6 +17,8 @@ package io.micronaut.data.mongodb.serde
 
 import com.mongodb.MongoClientSettings
 import io.micronaut.context.ApplicationContext
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.document.mongodb.entities.ComplexValue
 import io.micronaut.data.model.runtime.RuntimeEntityRegistry
 import spock.lang.Specification
@@ -48,6 +50,24 @@ class DataCodecRegistrySpec extends Specification {
         context?.close()
     }
 
+    void "data codec registry accepts mapped entities when scan result is empty"() {
+        when:
+        def context = ApplicationContext.run()
+        def dataCodecRegistry = new DataCodecRegistry(
+                [],
+                context.getBean(DataSerdeRegistry),
+                context.getBean(RuntimeEntityRegistry)
+        )
+        def codec = dataCodecRegistry.get(EmptyScanEntity, MongoClientSettings.defaultCodecRegistry)
+
+        then:
+        codec != null
+        codec.encoderClass == EmptyScanEntity
+
+        cleanup:
+        context?.close()
+    }
+
     private static Class<?> reloadEntityClass(Class<?> entityClass) {
         URL location = entityClass.getProtectionDomain().getCodeSource().getLocation()
         def classLoader = new URLClassLoader(new URL[] { location }, entityClass.classLoader) {
@@ -71,5 +91,12 @@ class DataCodecRegistrySpec extends Specification {
         } finally {
             classLoader.close()
         }
+    }
+
+    @MappedEntity
+    static class EmptyScanEntity {
+        @Id
+        String id
+        String name
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/intercept/AbstractQueryInterceptor.java
@@ -23,7 +23,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.beans.BeanIntrospection;
-import io.micronaut.core.beans.BeanWrapper;
+import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -809,8 +809,8 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
      */
     @NonNull
     protected Object instantiateEntity(@NonNull Class<?> rootEntity, @NonNull Map<String, Object> parameterValues) {
-        PersistentEntity entity = operations.getEntity(rootEntity);
-        BeanIntrospection<?> introspection = BeanIntrospection.getIntrospection(rootEntity);
+        RuntimePersistentEntity<?> entity = operations.getEntity(rootEntity);
+        BeanIntrospection<?> introspection = entity.getIntrospection();
         Argument<?>[] constructorArguments = introspection.getConstructorArguments();
         Object instance;
         if (ArrayUtils.isNotEmpty(constructorArguments)) {
@@ -840,18 +840,17 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
             instance = introspection.instantiate();
         }
 
-        BeanWrapper<Object> wrapper = BeanWrapper.getWrapper(instance);
         Collection<? extends PersistentProperty> persistentProperties = entity.getPersistentProperties();
         if (entity.hasIdentity()) {
-            setProperty(wrapper, entity.getIdentity(), parameterValues);
+            setProperty(introspection, instance, entity.getIdentity(), parameterValues);
         }
         if (entity.hasCompositeIdentity()) {
             for (PersistentProperty compositeIdentity : entity.getCompositeIdentity()) {
-                setProperty(wrapper, compositeIdentity, parameterValues);
+                setProperty(introspection, instance, compositeIdentity, parameterValues);
             }
         }
         for (PersistentProperty prop : persistentProperties) {
-            setProperty(wrapper, prop, parameterValues);
+            setProperty(introspection, instance, prop, parameterValues);
         }
         return instance;
     }
@@ -1101,14 +1100,15 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
     }
 
     /**
-     * Sets the property value for given persistent property of the {@link BeanWrapper} if property
+     * Sets the property value for given persistent property of the {@link BeanIntrospection} if property
      * present in given parameter values and property not readonly or generated.
      *
-     * @param wrapper the bean wrapper
+     * @param introspection the bean introspection
+     * @param instance the bean instance
      * @param prop the persistent property
      * @param parameterValues the parameter value map
      */
-    private static void setProperty(BeanWrapper<Object> wrapper, PersistentProperty prop, Map<String, Object> parameterValues) {
+    private static void setProperty(BeanIntrospection<?> introspection, Object instance, PersistentProperty prop, Map<String, Object> parameterValues) {
         if (!prop.isReadOnly() && !prop.isGenerated()) {
             String propName = prop.getName();
             if (parameterValues.containsKey(propName)) {
@@ -1117,14 +1117,25 @@ public abstract class AbstractQueryInterceptor<T, R> implements DataInterceptor<
                 if (v == null && !prop.isOptional()) {
                     throw new IllegalArgumentException("Argument [" + propName + "] cannot be null");
                 }
-                wrapper.setProperty(propName, v);
+                setBeanProperty(introspection, instance, propName, v);
             } else if (prop.isRequired()) {
-                final Optional<Object> p = wrapper.getProperty(propName, Object.class);
-                if (p.isEmpty()) {
+                if (!hasPropertyValue(introspection, instance, propName)) {
                     throw new IllegalArgumentException("Argument [" + propName + "] cannot be null");
                 }
             }
         }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void setBeanProperty(BeanIntrospection introspection, Object instance, String propName, Object value) {
+        introspection.getProperty(propName)
+            .ifPresent(property -> ((BeanProperty) property).convertAndSet(instance, value));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static boolean hasPropertyValue(BeanIntrospection introspection, Object instance, String propName) {
+        Optional<BeanProperty> property = introspection.getProperty(propName);
+        return property.isPresent() && property.get().get(instance) != null;
     }
 
     private record StoredQueryKey(RepositoryMethodKey methodKey, StoredQuery.OperationType operationType) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
@@ -17,9 +17,10 @@ package io.micronaut.data.runtime.support;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextProvider;
-import org.jspecify.annotations.NonNull;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.data.annotation.event.PostLoad;
@@ -39,6 +40,7 @@ import io.micronaut.data.model.runtime.convert.AttributeConverter;
 import io.micronaut.data.runtime.event.EntityEventRegistry;
 
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
@@ -128,7 +130,7 @@ final class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, Appli
     @NonNull
     @Override
     public <T> RuntimePersistentEntity<T> newEntity(@NonNull Class<T> type) {
-        return new RuntimePersistentEntity<>(type) {
+        return new RuntimePersistentEntity<>(resolveIntrospection(type)) {
             final boolean hasPrePersistEventListeners = eventRegistry.supports((RuntimePersistentEntity) this, PrePersist.class);
             final boolean hasPreRemoveEventListeners = eventRegistry.supports((RuntimePersistentEntity) this, PreRemove.class);
             final boolean hasPreUpdateEventListeners = eventRegistry.supports((RuntimePersistentEntity) this, PreUpdate.class);
@@ -182,6 +184,35 @@ final class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, Appli
                 return hasPostPersistEventListeners;
             }
         };
+    }
+
+    private <T> BeanIntrospection<T> resolveIntrospection(Class<T> type) {
+        ClassLoader classLoader = type.getClassLoader();
+        if (classLoader == null) {
+            classLoader = applicationContext.getClassLoader();
+        }
+        if (classLoader == null) {
+            return BeanIntrospection.getIntrospection(type);
+        }
+        ClassLoader introspectionClassLoader = classLoader;
+        return withContextClassLoader(
+                introspectionClassLoader,
+                () -> BeanIntrospector.forClassLoader(introspectionClassLoader).getIntrospection(type)
+        );
+    }
+
+    private static <T> T withContextClassLoader(ClassLoader classLoader, java.util.function.Supplier<T> action) {
+        Thread thread = Thread.currentThread();
+        ClassLoader previous = thread.getContextClassLoader();
+        if (previous == classLoader) {
+            return action.get();
+        }
+        thread.setContextClassLoader(classLoader);
+        try {
+            return action.get();
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
     }
 
     @Override

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistry.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * A registry for entities looking up instances of {@link RuntimeEntityRegistry}.
@@ -191,9 +192,6 @@ final class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, Appli
         if (classLoader == null) {
             classLoader = applicationContext.getClassLoader();
         }
-        if (classLoader == null) {
-            return BeanIntrospection.getIntrospection(type);
-        }
         ClassLoader introspectionClassLoader = classLoader;
         return withContextClassLoader(
                 introspectionClassLoader,
@@ -201,7 +199,7 @@ final class DefaultRuntimeEntityRegistry implements RuntimeEntityRegistry, Appli
         );
     }
 
-    private static <T> T withContextClassLoader(ClassLoader classLoader, java.util.function.Supplier<T> action) {
+    private static <T> T withContextClassLoader(ClassLoader classLoader, Supplier<T> action) {
         Thread thread = Thread.currentThread();
         ClassLoader previous = thread.getContextClassLoader();
         if (previous == classLoader) {

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistrySpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistrySpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.support
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.model.runtime.RuntimeEntityRegistry
+import spock.lang.Specification
+
+class DefaultRuntimeEntityRegistrySpec extends Specification {
+
+    private static final String MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER = "micronaut.introspections.use.context.classloader"
+
+    void "runtime entity registry resolves introspection from the entity classloader"() {
+        given:
+        Class<?> reloadedEntity = reloadEntityClass(ClassLoaderOnlyEntity)
+        ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader
+        String previousIntrospectionClassLoaderProperty = System.getProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)
+        ApplicationContext context = null
+
+        when:
+        System.setProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER, "true")
+        Thread.currentThread().contextClassLoader = DefaultRuntimeEntityRegistrySpec.classLoader
+        context = ApplicationContext.run()
+        def entity = context.getBean(RuntimeEntityRegistry).getEntity(reloadedEntity)
+
+        then:
+        reloadedEntity.name == ClassLoaderOnlyEntity.name
+        reloadedEntity != ClassLoaderOnlyEntity
+        entity.introspection.beanType.is(reloadedEntity)
+
+        cleanup:
+        context?.close()
+        Thread.currentThread().contextClassLoader = previousClassLoader
+        restoreSystemProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER, previousIntrospectionClassLoaderProperty)
+        closeClassLoader(reloadedEntity.classLoader)
+    }
+
+    private static Class<?> reloadEntityClass(Class<?> entityClass) {
+        URL location = entityClass.getProtectionDomain().getCodeSource().getLocation()
+        def classLoader = new URLClassLoader(new URL[] { location }, entityClass.getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (shouldLoadChildFirst(name, entityClass)) {
+                    Class<?> loaded = findLoadedClass(name)
+                    if (loaded == null) {
+                        loaded = findClass(name)
+                    }
+                    if (resolve) {
+                        resolveClass(loaded)
+                    }
+                    return loaded
+                }
+                return super.loadClass(name, resolve)
+            }
+        }
+        return classLoader.loadClass(entityClass.name)
+    }
+
+    private static boolean shouldLoadChildFirst(String name, Class<?> entityClass) {
+        String entityName = entityClass.name
+        String packageName = entityClass.packageName
+        String simpleName = entityName.substring(packageName.length() + 1)
+        String generatedPrefix = packageName + '.$' + simpleName
+        return name == entityName || name.startsWith(entityName + '$') || name.startsWith(generatedPrefix + '$')
+    }
+
+    private static void restoreSystemProperty(String name, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(name)
+        } else {
+            System.setProperty(name, previousValue)
+        }
+    }
+
+    private static void closeClassLoader(ClassLoader classLoader) {
+        if (classLoader instanceof Closeable) {
+            classLoader.close()
+        }
+    }
+
+    @MappedEntity
+    static class ClassLoaderOnlyEntity {
+        @Id
+        Long id
+        String name
+    }
+}

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistrySpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/support/DefaultRuntimeEntityRegistrySpec.groovy
@@ -16,24 +16,25 @@
 package io.micronaut.data.runtime.support
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.aop.MethodInvocationContext
+import io.micronaut.core.convert.ConversionService
 import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.intercept.RepositoryMethodKey
 import io.micronaut.data.model.runtime.RuntimeEntityRegistry
+import io.micronaut.data.operations.RepositoryOperations
+import io.micronaut.data.runtime.intercept.AbstractQueryInterceptor
 import spock.lang.Specification
 
 class DefaultRuntimeEntityRegistrySpec extends Specification {
-
-    private static final String MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER = "micronaut.introspections.use.context.classloader"
 
     void "runtime entity registry resolves introspection from the entity classloader"() {
         given:
         Class<?> reloadedEntity = reloadEntityClass(ClassLoaderOnlyEntity)
         ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader
-        String previousIntrospectionClassLoaderProperty = System.getProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER)
         ApplicationContext context = null
 
         when:
-        System.setProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER, "true")
         Thread.currentThread().contextClassLoader = DefaultRuntimeEntityRegistrySpec.classLoader
         context = ApplicationContext.run()
         def entity = context.getBean(RuntimeEntityRegistry).getEntity(reloadedEntity)
@@ -46,7 +47,34 @@ class DefaultRuntimeEntityRegistrySpec extends Specification {
         cleanup:
         context?.close()
         Thread.currentThread().contextClassLoader = previousClassLoader
-        restoreSystemProperty(MICRONAUT_INTROSPECTIONS_USE_CONTEXT_CLASSLOADER, previousIntrospectionClassLoaderProperty)
+        closeClassLoader(reloadedEntity.classLoader)
+    }
+
+    void "query interceptor instantiates entity using runtime entity introspection"() {
+        given:
+        Class<?> reloadedEntity = reloadEntityClass(ClassLoaderOnlyEntity)
+        ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader
+        ApplicationContext context = null
+
+        when:
+        Thread.currentThread().contextClassLoader = DefaultRuntimeEntityRegistrySpec.classLoader
+        context = ApplicationContext.run()
+        def entity = context.getBean(RuntimeEntityRegistry).getEntity(reloadedEntity)
+        def operations = Stub(RepositoryOperations) {
+            getApplicationContext() >> context
+            getConversionService() >> ConversionService.SHARED
+            getEntity(reloadedEntity) >> entity
+        }
+        def instance = new TestQueryInterceptor(operations).instantiate(reloadedEntity, [id: 1L, name: "R2DBC"])
+
+        then:
+        instance.class.is(reloadedEntity)
+        entity.introspection.getRequiredProperty("id", Long).get(instance) == 1L
+        entity.introspection.getRequiredProperty("name", String).get(instance) == "R2DBC"
+
+        cleanup:
+        context?.close()
+        Thread.currentThread().contextClassLoader = previousClassLoader
         closeClassLoader(reloadedEntity.classLoader)
     }
 
@@ -79,14 +107,6 @@ class DefaultRuntimeEntityRegistrySpec extends Specification {
         return name == entityName || name.startsWith(entityName + '$') || name.startsWith(generatedPrefix + '$')
     }
 
-    private static void restoreSystemProperty(String name, String previousValue) {
-        if (previousValue == null) {
-            System.clearProperty(name)
-        } else {
-            System.setProperty(name, previousValue)
-        }
-    }
-
     private static void closeClassLoader(ClassLoader classLoader) {
         if (classLoader instanceof Closeable) {
             classLoader.close()
@@ -98,5 +118,21 @@ class DefaultRuntimeEntityRegistrySpec extends Specification {
         @Id
         Long id
         String name
+    }
+
+    private static final class TestQueryInterceptor extends AbstractQueryInterceptor<Object, Object> {
+
+        TestQueryInterceptor(RepositoryOperations operations) {
+            super(operations)
+        }
+
+        Object instantiate(Class<?> rootEntity, Map<String, Object> parameterValues) {
+            instantiateEntity(rootEntity, parameterValues)
+        }
+
+        @Override
+        Object intercept(RepositoryMethodKey methodKey, MethodInvocationContext<Object, Object> context) {
+            throw new UnsupportedOperationException()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Store MongoDB scan results as entity class names so codec resolution works when scanned entities and runtime entities are loaded by different classloaders.
- Allow the MongoDB codec registry to create codecs for introspected `@MappedEntity` and `@Embeddable` types when classpath scan results are empty.
- Resolve `RuntimePersistentEntity` introspections with the entity classloader, temporarily installing that loader as the thread context classloader while loading the introspection.
- Use the already-resolved `RuntimePersistentEntity` introspection when repository save/insert interceptors instantiate an entity from method parameters.

## Rationale

Applications can load user classes and generated introspection references from an application or test classloader while Micronaut Data runtime code is loaded from a parent/shared classloader. In that arrangement, comparing entity `Class` instances by identity or resolving runtime entity metadata through the wrong introspector can miss or bind the wrong introspection for the same class name.

The MongoDB codec registry change avoids rejecting valid mapped entities simply because scan results came from a different loader. The runtime entity registry change makes repository operations build metadata from the introspection that belongs to the actual entity class being handled. The save/insert interceptor change keeps that same classloader-aware introspection in use when a repository method accepts scalar parameters and Micronaut Data constructs the entity instance internally; otherwise the interceptor can fall back to a global `BeanIntrospection.getIntrospection(...)` lookup and fail for generated class loaded entities even though `@Serdeable` has correctly produced an introspection.

This keeps framework behavior correct without requiring guide/application workarounds such as adding explicit `@Introspected` to `@Serdeable` entities or changing datasource configuration.

## Validation

- `./gradlew --no-daemon --rerun-tasks :micronaut-data-runtime:test --tests io.micronaut.data.runtime.support.DefaultRuntimeEntityRegistrySpec`
- `./gradlew --no-daemon :micronaut-data-runtime:test --tests io.micronaut.data.runtime.support.DefaultRuntimeEntityRegistrySpec :micronaut-data-mongodb:test --tests io.micronaut.data.mongodb.serde.DataCodecRegistrySpec`