### PR TITLE
Fix DTO projection metadata generic matching

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/one2many/OneToManyDtoProjectionSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/one2many/OneToManyDtoProjectionSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.data.annotation.GeneratedValue
 import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Projection
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Relation
 import io.micronaut.data.jdbc.annotation.JdbcRepository
@@ -48,6 +49,22 @@ class OneToManyDtoProjectionSpec extends Specification implements H2TestProperty
         complete.lastName == "del Amo"
         complete.phones == ["111-111-1111"]
     }
+
+    void "explicit projection list property with same name as entity association keeps DTO element type"() {
+        given:
+        DtoContact contact = contactRepository.save(new DtoContact(firstName: "Sergio", lastName: "del Amo", phones: []))
+        phoneRepository.save(new DtoPhone(phone: "222-222-2222", contact: contact))
+
+        when:
+        DtoContactComplete complete = contactRepository.findCompleteProjectionById(contact.id).orElse(null)
+
+        then:
+        complete != null
+        complete.id == contact.id
+        complete.firstName == "Sergio"
+        complete.lastName == "del Amo"
+        complete.phones == ["222-222-2222"]
+    }
 }
 
 @JdbcRepository(dialect = Dialect.H2)
@@ -61,6 +78,19 @@ interface DtoContactRepository extends CrudRepository<DtoContact, Long> {
         group by c.id
         """)
     Optional<DtoContactComplete> findCompleteById(Long id)
+
+    @Projection("id")
+    @Projection("firstName")
+    @Projection("lastName")
+    @Projection("phones")
+    @Query("""
+        select c.id, c.first_name, c.last_name, group_concat(p.phone) as phones
+        from dto_contact c
+        left outer join dto_phone p on c.id = p.contact_id
+        where c.id = :id
+        group by c.id
+        """)
+    Optional<DtoContactComplete> findCompleteProjectionById(Long id)
 }
 
 @JdbcRepository(dialect = Dialect.H2)

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/one2many/OneToManyDtoProjectionSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/one2many/OneToManyDtoProjectionSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.data.jdbc.h2.one2many
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Relation
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.jdbc.h2.H2DBProperties
+import io.micronaut.data.jdbc.h2.H2TestPropertyProvider
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@H2DBProperties
+class OneToManyDtoProjectionSpec extends Specification implements H2TestPropertyProvider {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(getProperties())
+
+    @Shared
+    @Inject
+    DtoContactRepository contactRepository = applicationContext.getBean(DtoContactRepository)
+
+    @Shared
+    @Inject
+    DtoPhoneRepository phoneRepository = applicationContext.getBean(DtoPhoneRepository)
+
+    void "DTO list property with same name as entity association keeps DTO element type"() {
+        given:
+        DtoContact contact = contactRepository.save(new DtoContact(firstName: "Sergio", lastName: "del Amo", phones: []))
+        phoneRepository.save(new DtoPhone(phone: "111-111-1111", contact: contact))
+
+        when:
+        DtoContactComplete complete = contactRepository.findCompleteById(contact.id).orElse(null)
+
+        then:
+        complete != null
+        complete.id == contact.id
+        complete.firstName == "Sergio"
+        complete.lastName == "del Amo"
+        complete.phones == ["111-111-1111"]
+    }
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface DtoContactRepository extends CrudRepository<DtoContact, Long> {
+
+    @Query("""
+        select c.id, c.first_name, c.last_name, group_concat(p.phone) as phones
+        from dto_contact c
+        left outer join dto_phone p on c.id = p.contact_id
+        where c.id = :id
+        group by c.id
+        """)
+    Optional<DtoContactComplete> findCompleteById(Long id)
+}
+
+@JdbcRepository(dialect = Dialect.H2)
+interface DtoPhoneRepository extends CrudRepository<DtoPhone, Long> {
+}
+
+@MappedEntity("dto_contact")
+class DtoContact {
+    @Id
+    @GeneratedValue
+    Long id
+    String firstName
+    String lastName
+    @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = "contact")
+    List<DtoPhone> phones
+}
+
+@MappedEntity("dto_phone")
+class DtoPhone {
+    @Id
+    @GeneratedValue
+    Long id
+    String phone
+    @Relation(value = Relation.Kind.MANY_TO_ONE)
+    DtoContact contact
+}
+
+@Introspected
+class DtoContactComplete {
+    Long id
+    String firstName
+    String lastName
+    List<String> phones
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
@@ -24,11 +24,10 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.beans.BeanIntrospection;
-import io.micronaut.core.beans.exceptions.IntrospectionException;
-import io.micronaut.data.runtime.mapper.sql.SqlJsonColumnReader;
-import org.jspecify.annotations.NonNull;
 import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.MappedProperty;
@@ -64,6 +63,7 @@ import io.micronaut.data.runtime.date.DateTimeProvider;
 import io.micronaut.data.runtime.mapper.QueryStatement;
 import io.micronaut.data.runtime.mapper.ResultReader;
 import io.micronaut.data.runtime.mapper.sql.JsonQueryResultMapper;
+import io.micronaut.data.runtime.mapper.sql.SqlJsonColumnReader;
 import io.micronaut.data.runtime.mapper.sql.SqlJsonValueMapper;
 import io.micronaut.data.runtime.mapper.sql.SqlResultEntityTypeMapper;
 import io.micronaut.data.runtime.mapper.sql.SqlTypeMapper;
@@ -78,6 +78,7 @@ import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.json.JsonMapper;
 import jakarta.persistence.Tuple;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -949,7 +950,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
                 name = projection.stringValue().orElse(name);
             }
             RuntimePersistentProperty<E> entityProperty = persistentEntity.getPropertyByName(name);
-            if (entityProperty == null || !ReflectionUtils.getWrapperType(entityProperty.getType()).equals(ReflectionUtils.getWrapperType(p.getType()))) {
+            if (entityProperty == null || !isSamePropertyType(entityProperty.getProperty().asArgument(), p.asArgument())) {
                 return p;
             }
             return new BeanPropertyWithAnnotationMetadata<>(
@@ -957,6 +958,23 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
                 new AnnotationMetadataHierarchy(p.getAnnotationMetadata(), entityProperty.getAnnotationMetadata())
             );
         }).toList();
+    }
+
+    private static boolean isSamePropertyType(Argument<?> entityArgument, Argument<?> dtoArgument) {
+        if (!ReflectionUtils.getWrapperType(entityArgument.getType()).equals(ReflectionUtils.getWrapperType(dtoArgument.getType()))) {
+            return false;
+        }
+        Argument<?>[] entityTypeParameters = entityArgument.getTypeParameters();
+        Argument<?>[] dtoTypeParameters = dtoArgument.getTypeParameters();
+        if (entityTypeParameters.length != dtoTypeParameters.length) {
+            return false;
+        }
+        for (int i = 0; i < entityTypeParameters.length; i++) {
+            if (!isSamePropertyType(entityTypeParameters[i], dtoTypeParameters[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private String resolveEnvPlaceholderValues(String value) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/operations/internal/sql/AbstractSqlRepositoryOperations.java
@@ -892,10 +892,14 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS, Exc extends Except
                 BeanProperty<R, Object> entityProperty = (BeanProperty<R, Object>) propertyByName.getProperty();
                 MutableAnnotationMetadata mutableAnnotationMetadata = new MutableAnnotationMetadata();
                 mutableAnnotationMetadata.addAnnotation(Projection.class.getName(), projectionAnnotationValue.getValues());
+                AnnotationMetadata propertyAnnotationMetadata = new AnnotationMetadataHierarchy(dtoProp.getAnnotationMetadata(), mutableAnnotationMetadata);
+                if (isSamePropertyType(entityProperty.asArgument(), dtoProp.getProperty().asArgument())) {
+                    propertyAnnotationMetadata = new AnnotationMetadataHierarchy(dtoProp.getAnnotationMetadata(), entityProperty.getAnnotationMetadata(), mutableAnnotationMetadata);
+                }
                 properties.add(new BeanPropertyWithAnnotationMetadata<>(
                     dtoProp.getName(),
                     dtoProp.getProperty(),
-                    new AnnotationMetadataHierarchy(dtoProp.getAnnotationMetadata(), entityProperty.getAnnotationMetadata(), mutableAnnotationMetadata)
+                    propertyAnnotationMetadata
                 ));
             }
             return new RuntimePersistentEntity<>(


### PR DESCRIPTION
Fixes DTO projection metadata reuse for collection properties that share the same name as entity associations but use a different generic element type. The PR now covers both inferred DTO projection metadata and explicit repeated @Projection annotations, so association metadata is only merged when the DTO property argument structure matches the entity property.

Verification:
- ./gradlew --no-daemon --rerun-tasks :micronaut-data-jdbc:test --tests io.micronaut.data.jdbc.h2.one2many.OneToManyDtoProjectionSpec --stacktrace