### PR TITLE
Fix Oracle JSON RETURNING raw select parsing

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/finders/RawQueryMethodMatcher.java
@@ -249,10 +249,28 @@ public class RawQueryMethodMatcher implements MethodMatcher {
             persistentEntity = matchContext.getEntity(entitiesParameter.getGenericType().getFirstTypeArgument().orElseThrow(IllegalStateException::new));
         }
 
-        QueryResult queryResult = getQueryResult(matchContext, queryString, parameters, namedParameters, entityParam, persistentEntity, methodMatchInfo.getResultType());
+        QueryResult queryResult = getQueryResult(
+            matchContext,
+            queryString,
+            parameters,
+            namedParameters,
+            entityParam,
+            persistentEntity,
+            methodMatchInfo.getResultType(),
+            operationType
+        );
         String cq = matchContext.getAnnotationMetadata().stringValue(Query.class, "countQuery")
             .orElse(null);
-        QueryResult countQueryResult = cq == null ? null : getQueryResult(matchContext, cq, parameters, namedParameters, entityParam, persistentEntity, methodMatchInfo.getResultType());
+        QueryResult countQueryResult = cq == null ? null : getQueryResult(
+            matchContext,
+            cq,
+            parameters,
+            namedParameters,
+            entityParam,
+            persistentEntity,
+            methodMatchInfo.getResultType(),
+            DataMethod.OperationType.QUERY
+        );
         boolean encodeEntityParameters;
         if (implicitQueries) {
             encodeEntityParameters = persistentEntity != null || operationType == DataMethod.OperationType.INSERT;
@@ -275,7 +293,8 @@ public class RawQueryMethodMatcher implements MethodMatcher {
                                        @Nullable
                                        SourcePersistentEntity persistentEntity,
                                        @Nullable
-                                       TypedElement resultType) {
+                                       TypedElement resultType,
+                                       DataMethod.OperationType operationType) {
         String newQueryString = queryString.replace(COLON_ESCAPE_PATTERN, COLON_TEMP_REPLACEMENT);
         Matcher matcher = VARIABLE_PATTERN.matcher(newQueryString);
 
@@ -320,7 +339,7 @@ public class RawQueryMethodMatcher implements MethodMatcher {
 
         String cleanLower = SQL_COMMENT_PATTERN.matcher(finalQueryString).replaceAll("").trim().toLowerCase(Locale.ENGLISH);
         boolean hasReturning = containsReturningClause(cleanLower);
-        if (hasReturning) {
+        if (hasReturning && isReturningOperation(operationType)) {
             Dialect dialect = matchContext.getRepositoryClass().enumValue(Repository.class, "dialect", Dialect.class)
                 .orElse(Dialect.ANSI);
             if (dialect == Dialect.ORACLE) {
@@ -338,6 +357,12 @@ public class RawQueryMethodMatcher implements MethodMatcher {
 
         // Default: no transformation
         return QueryResult.of(finalQueryString, queryParts, parameterBindings);
+    }
+
+    private static boolean isReturningOperation(DataMethod.OperationType operationType) {
+        return operationType == DataMethod.OperationType.INSERT_RETURNING
+            || operationType == DataMethod.OperationType.UPDATE_RETURNING
+            || operationType == DataMethod.OperationType.DELETE_RETURNING;
     }
 
     private static boolean containsReturningClause(String query) {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/BuildQuerySpec.groovy
@@ -2815,6 +2815,35 @@ interface ProductRepository extends GenericRepository<Product, Long> {
         method.classValue(DataMethod, "interceptor").get() == FindOneInterceptor
     }
 
+    void "test oracle raw select keeps json returning clauses as query syntax"() {
+        given:
+        def repository = buildRepository('test.ProductRepository', """
+import io.micronaut.data.annotation.Query;
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.GenericRepository;
+import io.micronaut.data.tck.entities.Product;
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface ProductRepository extends GenericRepository<Product, Long> {
+
+    @Query("SELECT json_serialize(json_object('id' VALUE p.id) RETURNING CLOB) FROM product p WHERE p.id = :id")
+    String serializeProduct(Long id);
+
+    @Query("SELECT json_arrayagg(p.name ORDER BY p.name RETURNING CLOB) FROM product p")
+    String aggregateNames();
+}
+""")
+        def serializeProductMethod = repository.getRequiredMethod("serializeProduct", Long)
+        def aggregateNamesMethod = repository.getRequiredMethod("aggregateNames")
+
+        expect:
+        getRawQuery(serializeProductMethod) == "SELECT json_serialize(json_object('id' VALUE p.id) RETURNING CLOB) FROM product p WHERE p.id = ?"
+        serializeProductMethod.classValue(DataMethod, "interceptor").get() == FindOneInterceptor
+        getRawQuery(aggregateNamesMethod) == "SELECT json_arrayagg(p.name ORDER BY p.name RETURNING CLOB) FROM product p"
+        aggregateNamesMethod.classValue(DataMethod, "interceptor").get() == FindOneInterceptor
+    }
+
     void "test raw REPLACE INTO is treated as UPDATE (MySQL)"() {
         given:
         def repository = buildRepository('test.Repo', """


### PR DESCRIPTION
Fixes #3884

Oracle JSON functions can use RETURNING as a type clause, for example json_serialize(... RETURNING CLOB). Micronaut Data was routing those raw Oracle SELECT queries through the Oracle DML RETURNING INTO handling.

This keeps normal raw SELECT queries on the query path while preserving Oracle INSERT/UPDATE/DELETE RETURNING INTO support.