### PR TITLE
Fix ConnectionCustomizer not invoked during execute()

### DIFF
--- a/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/support/AbstractConnectionOperations.java
@@ -108,7 +108,11 @@ public abstract class AbstractConnectionOperations<C> implements ConnectionOpera
                 logger.debug("Executing with a connection: [{}]", connection);
             }
             setupConnection(connection);
-            return connection.propagate(() -> callback.apply(connection));
+            for (ConnectionCustomizer<C> connectionCustomizer : connectionCustomizers) {
+                callback = connectionCustomizer.intercept(callback);
+            }
+            Function<ConnectionStatus<C>, R> finalCallback = callback;
+            return connection.propagate(() -> finalCallback.apply(connection));
         } finally {
             complete(connection);
         }

--- a/data-connection/src/test/java/io/micronaut/data/connection/support/AbstractConnectionOperationsTest.java
+++ b/data-connection/src/test/java/io/micronaut/data/connection/support/AbstractConnectionOperationsTest.java
@@ -1,0 +1,63 @@
+package io.micronaut.data.connection.support;
+
+import io.micronaut.data.connection.ConnectionDefinition;
+import io.micronaut.data.connection.ConnectionStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+class AbstractConnectionOperationsTest {
+
+    @Test
+    void customizersFireInOrderAndWrapCallback() {
+        var operations = new StubConnectionOperations();
+        var events = new ArrayList<String>();
+        operations.addConnectionCustomizer(new TaggingCustomizer<>("A", events, 10));
+        operations.addConnectionCustomizer(new TaggingCustomizer<>("B", events, 20));
+
+        operations.execute(ConnectionDefinition.DEFAULT, _ -> {
+            events.add("callback");
+            return "result";
+        });
+
+        assertIterableEquals(List.of("B-before", "A-before", "callback", "A-after", "B-after"), events);
+    }
+
+    private static final class StubConnectionOperations extends AbstractConnectionOperations<Object> {
+        @Override
+        protected Object openConnection(ConnectionDefinition definition) {
+            return new Object();
+        }
+
+        @Override
+        protected void setupConnection(ConnectionStatus<Object> connectionStatus) {
+        }
+
+        @Override
+        protected void closeConnection(ConnectionStatus<Object> connectionStatus) {
+        }
+    }
+
+    private record TaggingCustomizer<C>(String tag, List<String> events, int order)
+        implements ConnectionCustomizer<C> {
+
+        @Override
+        public int getOrder() {
+            return order;
+        }
+
+        @Override
+        public <R> Function<ConnectionStatus<C>, R> intercept(Function<ConnectionStatus<C>, R> operation) {
+            return status -> {
+                events.add(tag + "-before");
+                R result = operation.apply(status);
+                events.add(tag + "-after");
+                return result;
+            };
+        }
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleClientInfoConnectionCustomizerSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleClientInfoConnectionCustomizerSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.data.jdbc.oraclexe
+
+import io.micronaut.data.connection.ConnectionDefinition
+import io.micronaut.data.connection.ConnectionOperations
+import io.micronaut.data.connection.jdbc.oracle.OracleClientInfoConnectionCustomizer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import java.sql.Connection
+
+/**
+ * Integration test verifying that {@link OracleClientInfoConnectionCustomizer}
+ * sets Oracle client info properties during {@link ConnectionOperations#execute} and restores them afterward.
+ */
+@MicronautTest(transactional = false)
+class OracleClientInfoConnectionCustomizerSpec extends Specification implements OracleTestPropertyProvider {
+
+    @Inject
+    ConnectionOperations<Connection> connectionOperations
+
+    @Override
+    Map<String, String> getProperties() {
+        return OracleTestPropertyProvider.super.getProperties() + [
+                'micronaut.application.name'                      : 'test-app',
+                'datasources.default.enable-oracle-client-info'   : 'true',
+                'datasources.default.schema-generate'             : 'NONE',
+                'datasources.default.packages'                    : '',
+        ]
+    }
+
+    void "client info is set during execute"() {
+        when:
+        def capturedClientInfo = new Properties()
+        connectionOperations.execute(ConnectionDefinition.DEFAULT) { status ->
+            capturedClientInfo.putAll(status.getConnection().getClientInfo())
+        }
+
+        then: "OCSID.CLIENTID is the configured application name"
+        capturedClientInfo.getProperty('OCSID.CLIENTID') == 'test-app'
+
+        and: "OCSID.CLIENT_INFO is the thread name"
+        capturedClientInfo.getProperty('OCSID.CLIENT_INFO') != null
+    }
+
+    void "client info is set on each execute call"() {
+        when:
+        def firstCallInfo = new Properties()
+        def secondCallInfo = new Properties()
+
+        connectionOperations.execute(ConnectionDefinition.REQUIRES_NEW) { status ->
+            firstCallInfo.putAll(status.getConnection().getClientInfo())
+        }
+        connectionOperations.execute(ConnectionDefinition.REQUIRES_NEW) { status ->
+            secondCallInfo.putAll(status.getConnection().getClientInfo())
+        }
+
+        then:
+        firstCallInfo.getProperty('OCSID.CLIENTID') == 'test-app'
+        secondCallInfo.getProperty('OCSID.CLIENTID') == 'test-app'
+    }
+}


### PR DESCRIPTION
## Summary

- Restore `ConnectionCustomizer` iteration in `AbstractConnectionOperations.execute()`, which was dropped during the v5 refactor (#3615)
- `OracleClientInfoConnectionCustomizer` and any user-registered customizers were silently ignored since 5.0.0
- Fixes #3891

## Changes

**Fix:** `AbstractConnectionOperations.execute()` now iterates registered `ConnectionCustomizer` instances to wrap the callback before invoking it, matching the 4.x behavior.

**Unit test:** `AbstractConnectionOperationsTest` — verifies customizers fire in order and correctly wrap the callback (before/after semantics).

**Integration test:** `OracleClientInfoConnectionCustomizerSpec` — verifies `OCSID.CLIENTID` is set on a real Oracle connection during `execute()` when `enable-oracle-client-info: true`.

## Test plan

Unit test uses a stub `AbstractConnectionOperations<Object>` with no database. Oracle integration test uses Testcontainers Oracle Free via test-resources. Both tests fail without the fix, pass with it.