### PR TITLE
Fix returning operations for assigned-id entities in JDBC/R2DBC

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -732,7 +732,9 @@ public final class DefaultJdbcRepositoryOperations extends AbstractSqlRepository
             SqlStoredQuery<E, R> storedQuery = getSqlStoredQuery(operation.getStoredQuery());
             JdbcOperationContext ctx = createContext(operation, connection, storedQuery);
             RuntimePersistentEntity<E> persistentEntity = storedQuery.getPersistentEntity();
-            if (isSupportsBatchDelete(persistentEntity, storedQuery.getDialect())) {
+            // DELETE_RETURNING must use the returning path so returned rows are mapped; Oracle also requires OUT parameters.
+            if (storedQuery.getOperationType() != StoredQuery.OperationType.DELETE_RETURNING
+                    && isSupportsBatchDelete(persistentEntity, storedQuery.getDialect())) {
                 JdbcEntitiesOperations<E> op = new JdbcEntitiesOperations<>(ctx, persistentEntity, operation, storedQuery);
                 op.delete();
                 return (List<R>) op.getEntities();

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/OracleXERepositorySpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.data.jdbc.oraclexe
 
 import groovy.transform.Memoized
 import io.micronaut.data.tck.entities.Address
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity
 import io.micronaut.data.tck.entities.Restaurant
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.entities.BookDto
@@ -410,6 +411,73 @@ class OracleXERepositorySpec extends AbstractRepositorySpec implements OracleTes
         // verify persisted
         bookRepository.findById(newBook.id).get().title == "My book ORA"
         bookRepository.findByTitle("My book ORA")
+    }
+
+    void "test returning insert update and delete with assigned id"() {
+        given:
+        def repository = context.getBean(OracleXEAssignedIdReturningRepository)
+        repository.deleteAll()
+        def entity = new AssignedIdReturningEntity(1L, "Assigned Insert")
+
+        when:
+        def inserted = repository.insertReturning(entity)
+
+        then:
+        !inserted.is(entity)
+        inserted.id == 1L
+        inserted.title == "Assigned Insert"
+        repository.findById(1L).get().title == "Assigned Insert"
+
+        when:
+        inserted.title = "Assigned Update"
+        def updated = repository.updateReturning(inserted)
+
+        then:
+        !updated.is(inserted)
+        updated.id == 1L
+        updated.title == "Assigned Update"
+        repository.findById(1L).get().title == "Assigned Update"
+
+        when:
+        def deleted = repository.deleteReturning(updated)
+
+        then:
+        deleted.id == 1L
+        deleted.title == "Assigned Update"
+        !repository.existsById(1L)
+
+        when:
+        def entities = [
+                new AssignedIdReturningEntity(2L, "Assigned Insert 2"),
+                new AssignedIdReturningEntity(3L, "Assigned Insert 3")
+        ]
+        def insertedEntities = repository.insertReturning(entities)
+
+        then:
+        insertedEntities*.id == [2L, 3L]
+        insertedEntities*.title == ["Assigned Insert 2", "Assigned Insert 3"]
+        repository.findById(2L).get().title == "Assigned Insert 2"
+        repository.findById(3L).get().title == "Assigned Insert 3"
+
+        when:
+        insertedEntities[0].title = "Assigned Update 2"
+        insertedEntities[1].title = "Assigned Update 3"
+        def updatedEntities = repository.updateReturning(insertedEntities)
+
+        then:
+        updatedEntities*.id == [2L, 3L]
+        updatedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        repository.findById(2L).get().title == "Assigned Update 2"
+        repository.findById(3L).get().title == "Assigned Update 3"
+
+        when:
+        def deletedEntities = repository.deleteReturning(updatedEntities)
+
+        then:
+        deletedEntities*.id == [2L, 3L]
+        deletedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        !repository.existsById(2L)
+        !repository.existsById(3L)
     }
 
     void "test insert returning books"() {

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresRepositorySpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.data.jdbc.postgres
 
 import groovy.transform.Memoized
 import io.micronaut.data.model.Sort
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.repositories.*
 import io.micronaut.data.tck.tests.AbstractRepositorySpec
@@ -321,6 +322,73 @@ class PostgresRepositorySpec extends AbstractRepositorySpec implements PostgresT
             newBook.postPersist == 1
             bookRepository.findById(newBook.id).get().title == "My book"
             bookRepository.findByTitle("My book")
+    }
+
+    void "test returning insert update and delete with assigned id"() {
+        given:
+            def repository = context.getBean(PostgresAssignedIdReturningRepository)
+            repository.deleteAll()
+            def entity = new AssignedIdReturningEntity(1L, "Assigned Insert")
+
+        when:
+            def inserted = repository.insertReturning(entity)
+
+        then:
+            !inserted.is(entity)
+            inserted.id == 1L
+            inserted.title == "Assigned Insert"
+            repository.findById(1L).get().title == "Assigned Insert"
+
+        when:
+            inserted.title = "Assigned Update"
+            def updated = repository.updateReturning(inserted)
+
+        then:
+            !updated.is(inserted)
+            updated.id == 1L
+            updated.title == "Assigned Update"
+            repository.findById(1L).get().title == "Assigned Update"
+
+        when:
+            def deleted = repository.deleteReturning(updated)
+
+        then:
+            deleted.id == 1L
+            deleted.title == "Assigned Update"
+            !repository.existsById(1L)
+
+        when:
+            def entities = [
+                    new AssignedIdReturningEntity(2L, "Assigned Insert 2"),
+                    new AssignedIdReturningEntity(3L, "Assigned Insert 3")
+            ]
+            def insertedEntities = repository.insertReturning(entities)
+
+        then:
+            insertedEntities*.id == [2L, 3L]
+            insertedEntities*.title == ["Assigned Insert 2", "Assigned Insert 3"]
+            repository.findById(2L).get().title == "Assigned Insert 2"
+            repository.findById(3L).get().title == "Assigned Insert 3"
+
+        when:
+            insertedEntities[0].title = "Assigned Update 2"
+            insertedEntities[1].title = "Assigned Update 3"
+            def updatedEntities = repository.updateReturning(insertedEntities)
+
+        then:
+            updatedEntities*.id == [2L, 3L]
+            updatedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+            repository.findById(2L).get().title == "Assigned Update 2"
+            repository.findById(3L).get().title == "Assigned Update 3"
+
+        when:
+            def deletedEntities = repository.deleteReturning(updatedEntities)
+
+        then:
+            deletedEntities*.id == [2L, 3L]
+            deletedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+            !repository.existsById(2L)
+            !repository.existsById(3L)
     }
 
     void "test insert returning books"() {

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEAssignedIdReturningRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/oraclexe/OracleXEAssignedIdReturningRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.oraclexe;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity;
+
+import java.util.List;
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+public interface OracleXEAssignedIdReturningRepository extends CrudRepository<AssignedIdReturningEntity, Long> {
+
+    AssignedIdReturningEntity insertReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> insertReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    AssignedIdReturningEntity updateReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> updateReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    AssignedIdReturningEntity deleteReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> deleteReturning(Iterable<AssignedIdReturningEntity> entities);
+}

--- a/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresAssignedIdReturningRepository.java
+++ b/data-jdbc/src/test/java/io/micronaut/data/jdbc/postgres/PostgresAssignedIdReturningRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.postgres;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity;
+
+import java.util.List;
+
+@JdbcRepository(dialect = Dialect.POSTGRES)
+public interface PostgresAssignedIdReturningRepository extends CrudRepository<AssignedIdReturningEntity, Long> {
+
+    AssignedIdReturningEntity insertReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> insertReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    AssignedIdReturningEntity updateReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> updateReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    AssignedIdReturningEntity deleteReturning(AssignedIdReturningEntity entity);
+
+    List<AssignedIdReturningEntity> deleteReturning(Iterable<AssignedIdReturningEntity> entities);
+}

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/operations/DefaultR2dbcRepositoryOperations.java
@@ -1368,27 +1368,33 @@ final class DefaultR2dbcRepositoryOperations extends AbstractSqlRepositoryOperat
             }
             Statement statement = prepare(ctx.connection);
             setParameters(statement, storedQuery);
-            if (hasGeneratedId) {
+            // DELETE_RETURNING is handled by the dedicated deleteReturning/deleteAllReturning paths.
+            if (storedQuery.getOperationType() == OperationType.INSERT_RETURNING
+                || storedQuery.getOperationType() == OperationType.UPDATE_RETURNING) {
                 data = data.flatMap(d -> {
                     if (d.vetoed) {
                         return Mono.just(d);
                     }
-                    if (storedQuery.getOperationType() == OperationType.INSERT_RETURNING) {
-                        SqlTypeMapper<Row, ?> mapper = createMapper(storedQuery, Row.class);
-                        if (!(mapper instanceof SqlResultEntityTypeMapper<?, ?> rawEntityTypeMapper)) {
-                            return Mono.error(new DataAccessException("Expected entity mapper for INSERT_RETURNING operation: " + storedQuery.getQuery()));
-                        }
-                        @SuppressWarnings("unchecked")
-                        SqlResultEntityTypeMapper<Readable, T> entityTypeMapper = isOracleReturningQuery(storedQuery)
-                            ? getOracleReturningEntityMapper(storedQuery)
-                            : (SqlResultEntityTypeMapper<Readable, T>) (SqlResultEntityTypeMapper<?, ?>) rawEntityTypeMapper;
-                        Mono<T> result = isOracleReturningQuery(storedQuery)
-                            ? executeAndMapOracleReturningSingle(statement, ctx.dialect, entityTypeMapper::readEntity)
-                            : executeAndMapEachRowSingle(statement, ctx.dialect, row -> entityTypeMapper.readEntity(row));
-                        return result.map(entity -> {
-                            d.entity = entity;
-                            return d;
-                        });
+                    SqlTypeMapper<Row, ?> mapper = createMapper(storedQuery, Row.class);
+                    if (!(mapper instanceof SqlResultEntityTypeMapper<?, ?> rawEntityTypeMapper)) {
+                        return Mono.error(new DataAccessException("Expected entity mapper for returning operation: " + storedQuery.getQuery()));
+                    }
+                    @SuppressWarnings("unchecked")
+                    SqlResultEntityTypeMapper<Readable, T> entityTypeMapper = isOracleReturningQuery(storedQuery)
+                        ? getOracleReturningEntityMapper(storedQuery)
+                        : (SqlResultEntityTypeMapper<Readable, T>) (SqlResultEntityTypeMapper<?, ?>) rawEntityTypeMapper;
+                    Mono<T> result = isOracleReturningQuery(storedQuery)
+                        ? executeAndMapOracleReturningSingle(statement, ctx.dialect, entityTypeMapper::readEntity)
+                        : executeAndMapEachRowSingle(statement, ctx.dialect, row -> entityTypeMapper.readEntity(row));
+                    return result.map(entity -> {
+                        d.entity = entity;
+                        return d;
+                    });
+                });
+            } else if (hasGeneratedId) {
+                data = data.flatMap(d -> {
+                    if (d.vetoed) {
+                        return Mono.just(d);
                     }
                     RuntimePersistentProperty<T> identity = persistentEntity.getIdentity();
                     Function<Object, Data> idMapper = id -> {

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/oraclexe/OracleXEReactiveRepositorySpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.data.r2dbc.oraclexe
 
 import groovy.transform.Memoized
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.entities.BookDto
 import io.micronaut.data.tck.repositories.BookReactiveRepository
@@ -48,6 +49,73 @@ class OracleXEReactiveRepositorySpec extends AbstractReactiveRepositorySpec impl
         expect:
             personRepository.add1(123).block() == 124
             personRepository.add1Aliased(123).block() == 124
+    }
+
+    void "test returning insert update and delete with assigned id"() {
+        given:
+        def repository = context.getBean(OracleReactiveAssignedIdReturningRepository)
+        repository.deleteAll().block()
+        def entity = new AssignedIdReturningEntity(1L, "Assigned Insert")
+
+        when:
+        def inserted = repository.insertReturning(entity).block()
+
+        then:
+        !inserted.is(entity)
+        inserted.id == 1L
+        inserted.title == "Assigned Insert"
+        repository.findById(1L).block().title == "Assigned Insert"
+
+        when:
+        inserted.title = "Assigned Update"
+        def updated = repository.updateReturning(inserted).block()
+
+        then:
+        !updated.is(inserted)
+        updated.id == 1L
+        updated.title == "Assigned Update"
+        repository.findById(1L).block().title == "Assigned Update"
+
+        when:
+        def deleted = repository.deleteReturning(updated).block()
+
+        then:
+        deleted.id == 1L
+        deleted.title == "Assigned Update"
+        !repository.existsById(1L).block()
+
+        when:
+        def entities = [
+                new AssignedIdReturningEntity(2L, "Assigned Insert 2"),
+                new AssignedIdReturningEntity(3L, "Assigned Insert 3")
+        ]
+        def insertedEntities = repository.insertReturning(entities).collectList().block()
+
+        then:
+        insertedEntities*.id == [2L, 3L]
+        insertedEntities*.title == ["Assigned Insert 2", "Assigned Insert 3"]
+        repository.findById(2L).block().title == "Assigned Insert 2"
+        repository.findById(3L).block().title == "Assigned Insert 3"
+
+        when:
+        insertedEntities[0].title = "Assigned Update 2"
+        insertedEntities[1].title = "Assigned Update 3"
+        def updatedEntities = repository.updateReturning(insertedEntities).collectList().block()
+
+        then:
+        updatedEntities*.id == [2L, 3L]
+        updatedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        repository.findById(2L).block().title == "Assigned Update 2"
+        repository.findById(3L).block().title == "Assigned Update 3"
+
+        when:
+        def deletedEntities = repository.deleteReturning(updatedEntities).collectList().block()
+
+        then:
+        deletedEntities*.id == [2L, 3L]
+        deletedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        !repository.existsById(2L).block()
+        !repository.existsById(3L).block()
     }
 
     void "test returning insert update and delete"() {

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresReactiveRepositorySpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.data.r2dbc.postgres
 
 import groovy.transform.Memoized
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity
 import io.micronaut.data.tck.entities.Book
 import io.micronaut.data.tck.repositories.BookReactiveRepository
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
@@ -121,6 +122,74 @@ class PostgresReactiveRepositorySpec extends AbstractReactiveRepositorySpec impl
         deletedBook.title == "Reactive Derived It Updated"
         deletedBooks*.id == savedBooks*.id
         deletedBooks*.title == savedBooks*.title
+    }
+
+    void "test returning insert update and delete with assigned id"() {
+        given:
+        def repository = context.getBean(PostgresReactiveAssignedIdReturningRepository)
+        repository.deleteAll().block()
+        def entity = new AssignedIdReturningEntity(1L, "Assigned Insert")
+
+        when:
+        def inserted = repository.insertReturning(entity).block()
+
+        then:
+        !inserted.is(entity)
+        inserted.id == 1L
+        inserted.title == "Assigned Insert"
+        repository.findById(1L).block().title == "Assigned Insert"
+
+        when:
+        inserted.title = "Assigned Update"
+        def updated = repository.updateReturning(inserted).block()
+
+        then:
+        !updated.is(inserted)
+        updated.id == 1L
+        updated.title == "Assigned Update"
+        repository.findById(1L).block().title == "Assigned Update"
+
+        when:
+        def deleted = repository.deleteReturning(updated).block()
+
+        then:
+        !deleted.is(updated)
+        deleted.id == 1L
+        deleted.title == "Assigned Update"
+        !repository.existsById(1L).block()
+
+        when:
+        def entities = [
+                new AssignedIdReturningEntity(2L, "Assigned Insert 2"),
+                new AssignedIdReturningEntity(3L, "Assigned Insert 3")
+        ]
+        def insertedEntities = repository.insertReturning(entities).collectList().block()
+
+        then:
+        insertedEntities*.id == [2L, 3L]
+        insertedEntities*.title == ["Assigned Insert 2", "Assigned Insert 3"]
+        repository.findById(2L).block().title == "Assigned Insert 2"
+        repository.findById(3L).block().title == "Assigned Insert 3"
+
+        when:
+        insertedEntities[0].title = "Assigned Update 2"
+        insertedEntities[1].title = "Assigned Update 3"
+        def updatedEntities = repository.updateReturning(insertedEntities).collectList().block()
+
+        then:
+        updatedEntities*.id == [2L, 3L]
+        updatedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        repository.findById(2L).block().title == "Assigned Update 2"
+        repository.findById(3L).block().title == "Assigned Update 3"
+
+        when:
+        def deletedEntities = repository.deleteReturning(updatedEntities).collectList().block()
+
+        then:
+        deletedEntities*.id == [2L, 3L]
+        deletedEntities*.title == ["Assigned Update 2", "Assigned Update 3"]
+        !repository.existsById(2L).block()
+        !repository.existsById(3L).block()
     }
 
     void "test returning insert update and delete"() {

--- a/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/oraclexe/OracleReactiveAssignedIdReturningRepository.java
+++ b/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/oraclexe/OracleReactiveAssignedIdReturningRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.oraclexe;
+
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository;
+import io.micronaut.data.repository.reactive.ReactorCrudRepository;
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@R2dbcRepository(dialect = Dialect.ORACLE)
+public interface OracleReactiveAssignedIdReturningRepository extends ReactorCrudRepository<AssignedIdReturningEntity, Long> {
+
+    Mono<AssignedIdReturningEntity> insertReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> insertReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    Mono<AssignedIdReturningEntity> updateReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> updateReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    Mono<AssignedIdReturningEntity> deleteReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> deleteReturning(Iterable<AssignedIdReturningEntity> entities);
+}

--- a/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/postgres/PostgresReactiveAssignedIdReturningRepository.java
+++ b/data-r2dbc/src/test/java/io/micronaut/data/r2dbc/postgres/PostgresReactiveAssignedIdReturningRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.postgres;
+
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository;
+import io.micronaut.data.repository.reactive.ReactorCrudRepository;
+import io.micronaut.data.tck.entities.AssignedIdReturningEntity;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@R2dbcRepository(dialect = Dialect.POSTGRES)
+public interface PostgresReactiveAssignedIdReturningRepository extends ReactorCrudRepository<AssignedIdReturningEntity, Long> {
+
+    Mono<AssignedIdReturningEntity> insertReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> insertReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    Mono<AssignedIdReturningEntity> updateReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> updateReturning(Iterable<AssignedIdReturningEntity> entities);
+
+    Mono<AssignedIdReturningEntity> deleteReturning(AssignedIdReturningEntity entity);
+
+    Flux<AssignedIdReturningEntity> deleteReturning(Iterable<AssignedIdReturningEntity> entities);
+}

--- a/data-tck/src/main/java/io/micronaut/data/tck/entities/AssignedIdReturningEntity.java
+++ b/data-tck/src/main/java/io/micronaut/data/tck/entities/AssignedIdReturningEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.tck.entities;
+
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity("assigned_id_returning_entity")
+public class AssignedIdReturningEntity {
+
+    @Id
+    private Long id;
+    private String title;
+
+    public AssignedIdReturningEntity(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}


### PR DESCRIPTION
- Adds JDBC and R2DBC coverage for insertReturning, updateReturning, and deleteReturning with entities that use assigned IDs, including single and multi-entity operations for Postgres and Oracle.

- Fixes R2DBC insert/update returning so assigned-id entities are mapped from returned rows instead of falling through to the non-generated-id update-count path.

- Fixes JDBC deleteAllReturning so delete-returning operations use the returning path instead of the batch delete helper, ensuring returned rows are mapped and Oracle returning OUT parameters are registered correctly.