### PR TITLE
Handle inserts with only generated IDs

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -1383,9 +1383,18 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder {
                 });
             }
 
-            builder = INSERT_INTO + getTableName(entity) +
-                " (" + String.join(",", columns) + CLOSE_BRACKET + " " +
-                "VALUES (" + String.join(String.valueOf(COMMA), values) + CLOSE_BRACKET;
+            if (columns.isEmpty()) {
+                // MySQL/MariaDB do not support DEFAULT VALUES syntax
+                if (dialect == Dialect.MYSQL) {
+                    builder = INSERT_INTO + getTableName(entity) + " () VALUES ()";
+                } else {
+                    builder = INSERT_INTO + getTableName(entity) + " DEFAULT VALUES";
+                }
+            } else {
+                builder = INSERT_INTO + getTableName(entity) +
+                    " (" + String.join(",", columns) + CLOSE_BRACKET + " " +
+                    "VALUES (" + String.join(String.valueOf(COMMA), values) + CLOSE_BRACKET;
+            }
 
             if (definition.returning()) {
                 if (dialect == Dialect.ORACLE) {

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.PersistentEntity
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.entities.Bike
+import io.micronaut.data.model.entities.GeneratedIdOnlyEntity
 import io.micronaut.data.model.entities.GeogEntityJson
 import io.micronaut.data.model.entities.GeogEntityWkt
 import io.micronaut.data.model.entities.GeomEntityCompositeIndex
@@ -472,6 +473,23 @@ interface MyRepository {
         expect:
         result.query == 'INSERT INTO "person" ("name","age","enabled","public_id","company_id") VALUES (?,?,?,?,?)'
         result.parameters.equals('1': 'name', '2': 'age', '3': 'enabled', '4': "publicId", '5': 'company.myId')
+    }
+
+    @Unroll
+    void "test encode #dialect insert statement with only generated id"() {
+        given:
+        def result = builder.createCriteriaInsert(GeneratedIdOnlyEntity).build(new SqlQueryBuilder(dialect))
+
+        expect:
+        result.query == expectedQuery
+        result.parameters.isEmpty()
+
+        where:
+        dialect          || expectedQuery
+        Dialect.ANSI     || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
+        Dialect.H2       || 'INSERT INTO `generated_id_only_entity` DEFAULT VALUES'
+        Dialect.MYSQL    || 'INSERT INTO `generated_id_only_entity` () VALUES ()'
+        Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
     }
 
     void "test encode insert statement for embedded"() {


### PR DESCRIPTION
Generate valid insert SQL when an entity has no explicit insert columns. Use DEFAULT VALUES for supported dialects and MySQL-compatible empty column/value lists, with coverage for ANSI, H2, MySQL, and Postgres.