### PR TITLE
Handle inserts with only generated IDs

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -1383,9 +1383,18 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder {
                 });
             }
 
-            builder = INSERT_INTO + getTableName(entity) +
-                " (" + String.join(",", columns) + CLOSE_BRACKET + " " +
-                "VALUES (" + String.join(String.valueOf(COMMA), values) + CLOSE_BRACKET;
+            if (columns.isEmpty()) {
+                // MySQL/MariaDB do not support DEFAULT VALUES syntax
+                if (dialect == Dialect.MYSQL) {
+                    builder = INSERT_INTO + getTableName(entity) + " () VALUES ()";
+                } else {
+                    builder = INSERT_INTO + getTableName(entity) + " DEFAULT VALUES";
+                }
+            } else {
+                builder = INSERT_INTO + getTableName(entity) +
+                    " (" + String.join(",", columns) + CLOSE_BRACKET + " " +
+                    "VALUES (" + String.join(String.valueOf(COMMA), values) + CLOSE_BRACKET;
+            }
 
             if (definition.returning()) {
                 if (dialect == Dialect.ORACLE) {

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -1387,6 +1387,8 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder {
                 // MySQL/MariaDB do not support DEFAULT VALUES syntax
                 if (dialect == Dialect.MYSQL) {
                     builder = INSERT_INTO + getTableName(entity) + " () VALUES ()";
+                } else if (dialect == Dialect.ORACLE) {
+                    builder = INSERT_INTO + getTableName(entity) + " VALUES (DEFAULT)";
                 } else {
                     builder = INSERT_INTO + getTableName(entity) + " DEFAULT VALUES";
                 }

--- a/data-processor/src/test/groovy/io/micronaut/data/model/entities/GeneratedIdOnlyEntity.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/entities/GeneratedIdOnlyEntity.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.entities
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+
+@Entity
+class GeneratedIdOnlyEntity {
+    @GeneratedValue
+    @Id
+    Long id
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/model/entities/GeneratedIdentityOnlyEntity.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/entities/GeneratedIdentityOnlyEntity.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.model.entities
+
+import io.micronaut.data.annotation.GeneratedValue
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+
+@Entity
+class GeneratedIdentityOnlyEntity {
+    @GeneratedValue(GeneratedValue.Type.IDENTITY)
+    @Id
+    Long id
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -491,7 +491,6 @@ interface MyRepository {
         Dialect.MYSQL    || 'INSERT INTO `generated_id_only_entity` () VALUES ()'
         Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
         Dialect.SQL_SERVER || 'INSERT INTO [generated_id_only_entity] DEFAULT VALUES'
-        Dialect.ORACLE   || 'INSERT INTO "GENERATED_ID_ONLY_ENTITY" DEFAULT VALUES'
     }
 
     void "test encode insert statement for embedded"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -491,6 +491,7 @@ interface MyRepository {
         Dialect.MYSQL    || 'INSERT INTO `generated_id_only_entity` () VALUES ()'
         Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
         Dialect.SQL_SERVER || 'INSERT INTO [generated_id_only_entity] DEFAULT VALUES'
+        Dialect.ORACLE   || 'INSERT INTO "GENERATED_ID_ONLY_ENTITY" ("ID") VALUES ("GENERATED_ID_ONLY_ENTITY_SEQ".nextval)'
     }
 
     void "test encode insert statement for embedded"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.PersistentEntity
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.entities.Bike
+import io.micronaut.data.model.entities.GeneratedIdentityOnlyEntity
 import io.micronaut.data.model.entities.GeneratedIdOnlyEntity
 import io.micronaut.data.model.entities.GeogEntityJson
 import io.micronaut.data.model.entities.GeogEntityWkt
@@ -492,6 +493,15 @@ interface MyRepository {
         Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
         Dialect.SQL_SERVER || 'INSERT INTO [generated_id_only_entity] DEFAULT VALUES'
         Dialect.ORACLE   || 'INSERT INTO "GENERATED_ID_ONLY_ENTITY" ("ID") VALUES ("GENERATED_ID_ONLY_ENTITY_SEQ".nextval)'
+    }
+
+    void "test encode oracle insert statement with only identity id"() {
+        given:
+        def result = builder.createCriteriaInsert(GeneratedIdentityOnlyEntity).build(new SqlQueryBuilder(Dialect.ORACLE))
+
+        expect:
+        result.query == 'INSERT INTO "GENERATED_IDENTITY_ONLY_ENTITY" VALUES (DEFAULT)'
+        result.parameters.isEmpty()
     }
 
     void "test encode insert statement for embedded"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.PersistentEntity
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.entities.Bike
+import io.micronaut.data.model.entities.GeneratedIdOnlyEntity
 import io.micronaut.data.model.entities.GeogEntityJson
 import io.micronaut.data.model.entities.GeogEntityWkt
 import io.micronaut.data.model.entities.GeomEntityCompositeIndex
@@ -472,6 +473,23 @@ interface MyRepository {
         expect:
         result.query == 'INSERT INTO "person" ("name","age","enabled","public_id","company_id") VALUES (?,?,?,?,?)'
         result.parameters.equals('1': 'name', '2': 'age', '3': 'enabled', '4': "publicId", '5': 'company.myId')
+    }
+
+    @Unroll
+    void "test encode #dialect insert statement with only generated id"() {
+        given:
+        def result = builder.createCriteriaInsert(GeneratedIdOnlyEntity).build(new SqlQueryBuilder(dialect))
+
+        expect:
+        result.query == expectedQuery
+        result.parameters.isEmpty()
+
+        where:
+        dialect          || expectedQuery
+        Dialect.ANSI     || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
+        Dialect.H2       || 'INSERT INTO `generated_id_only_entity` DEFAULT VALUES'
+        Dialect.MYSQL    || 'INSERT INTO `generated_id_only_entity` () VALUES ()'
+        Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
     }
 
     void "test encode insert statement for embedded"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -490,6 +490,8 @@ interface MyRepository {
         Dialect.H2       || 'INSERT INTO `generated_id_only_entity` DEFAULT VALUES'
         Dialect.MYSQL    || 'INSERT INTO `generated_id_only_entity` () VALUES ()'
         Dialect.POSTGRES || 'INSERT INTO "generated_id_only_entity" DEFAULT VALUES'
+        Dialect.SQL_SERVER || 'INSERT INTO [generated_id_only_entity] DEFAULT VALUES'
+        Dialect.ORACLE   || 'INSERT INTO "GENERATED_ID_ONLY_ENTITY" DEFAULT VALUES'
     }
 
     void "test encode insert statement for embedded"() {


### PR DESCRIPTION
Generate valid insert SQL when an entity has no explicit insert columns. Use DEFAULT VALUES for supported dialects and MySQL-compatible empty column/value lists, with coverage for ANSI, H2, MySQL, and Postgres.