### PR TITLE
Fix Oracle generic vector similarity format

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/vector/OracleJdbcVectorEntitySpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/oraclexe/vector/OracleJdbcVectorEntitySpec.groovy
@@ -12,8 +12,10 @@ import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.jdbc.oraclexe.OracleTestPropertyProvider
 import io.micronaut.data.model.Sort
 import io.micronaut.data.model.vector.DoubleVector
+import io.micronaut.data.model.vector.FloatVector
 import io.micronaut.data.model.vector.SparseDoubleVector
 import io.micronaut.data.model.vector.Vector
+import io.micronaut.data.model.vector.search.SearchResults
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.repository.PageableRepository
 import io.micronaut.transaction.SynchronousTransactionManager
@@ -40,6 +42,9 @@ class OracleJdbcVectorEntitySpec extends Specification implements OracleTestProp
     SparseVectorDocRepository sparseVectorRepository = context.getBean(SparseVectorDocRepository)
 
     @Shared
+    GenericVectorSearchRepository genericVectorSearchRepository = context.getBean(GenericVectorSearchRepository)
+
+    @Shared
     DataSource dataSource = context.getBean(DataSource)
 
     @Override
@@ -52,6 +57,7 @@ class OracleJdbcVectorEntitySpec extends Specification implements OracleTestProp
         // Clean table between tests
         executeSilently "DELETE FROM vector_doc"
         executeSilently "DELETE FROM vector_sparse_doc"
+        executeSilently "DELETE FROM generic_vector_search_doc"
         // no-op transaction boundary to flush
         context.getBean(SynchronousTransactionManager).executeWrite { status -> null }
     }
@@ -176,6 +182,23 @@ class OracleJdbcVectorEntitySpec extends Specification implements OracleTestProp
         }
     }
 
+    void "test similarity search converts float query to generic vector format"() {
+        given:
+        genericVectorSearchRepository.save(
+            new GenericVectorSearchDoc(embedding: Vector.of([1d, 0d, 0d] as double[]))
+        )
+
+        when:
+        def results = genericVectorSearchRepository.searchByEmbeddingNear(
+            Vector.of([1f, 0f, 0f] as float[]),
+            2d
+        ).results()
+
+        then:
+        results.size() == 1
+        results.first().entity().embedding.toDoubleArray().toList() == [1d, 0d, 0d]
+    }
+
     void "test top2 derived queries with explicit ORDER BY"() {
         given:
         vectorRepository.saveCustom(Vector.of([1d, 0d, 0d] as double[]))
@@ -251,6 +274,21 @@ interface VectorDocRepository extends PageableRepository<VectorDoc, Long> {
 
     List<VectorDoc> findTop2OrderByIdAsc()
 
+}
+
+@MappedEntity("generic_vector_search_doc")
+class GenericVectorSearchDoc {
+    @Id
+    @GeneratedValue(value = GeneratedValue.Type.SEQUENCE, ref = "VECTOR_DOC_SEQ")
+    Long id
+
+    Vector embedding
+}
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface GenericVectorSearchRepository extends PageableRepository<GenericVectorSearchDoc, Long> {
+
+    SearchResults<GenericVectorSearchDoc> searchByEmbeddingNear(FloatVector vector, Double maxDistance)
 }
 
 @MappedEntity("vector_sparse_doc")

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/VectorSimilarityDialect.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/VectorSimilarityDialect.java
@@ -100,7 +100,7 @@ interface VectorSimilarityDialect {
         if (property.isAssignable(ByteVector.class)) {
             return new OracleVectorConfig(dimensions, ORACLE_INT8, sparse);
         }
-        if (property.isAssignable(Vector.class)) {
+        if (Vector.class.getName().equals(property.getTypeName())) {
             return new OracleVectorConfig(dimensions, sparse ? ORACLE_FLOAT32 : ORACLE_FLOAT64, sparse);
         }
         return null;

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/VectorSimilarityDialect.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/VectorSimilarityDialect.java
@@ -22,6 +22,7 @@ import io.micronaut.data.annotation.VectorStorage;
 import io.micronaut.data.model.vector.ByteVector;
 import io.micronaut.data.model.vector.DoubleVector;
 import io.micronaut.data.model.vector.FloatVector;
+import io.micronaut.data.model.vector.Vector;
 import jakarta.persistence.criteria.Expression;
 import org.jspecify.annotations.Nullable;
 
@@ -98,6 +99,9 @@ interface VectorSimilarityDialect {
         }
         if (property.isAssignable(ByteVector.class)) {
             return new OracleVectorConfig(dimensions, ORACLE_INT8, sparse);
+        }
+        if (property.isAssignable(Vector.class)) {
+            return new OracleVectorConfig(dimensions, sparse ? ORACLE_FLOAT32 : ORACLE_FLOAT64, sparse);
         }
         return null;
     }


### PR DESCRIPTION
Oracle similarity queries omit the target dimension format when the mapped property uses the generic `Vector` type. `TO_VECTOR` then defaults a `FloatVector` query parameter to `FLOAT32`, while a dense generic `Vector` column is generated as `FLOAT64`, causing ORA-51812.

Resolve generic Oracle vector metadata consistently with schema generation:
- dense `Vector` uses `FLOAT64`
- sparse `Vector` uses `FLOAT32`

Add an Oracle integration regression covering a generic `Vector` entity property searched with a `FloatVector` parameter.

Tests:
- `./gradlew :micronaut-data-jdbc:test --tests io.micronaut.data.jdbc.oraclexe.vector.OracleJdbcVectorEntitySpec`
- `./gradlew :micronaut-data-model:checkstyleMain`