### PR TITLE
Support geography mapping for geographic CRS

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresGeoSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/postgres/PostgresGeoSpec.groovy
@@ -104,14 +104,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         ] as Map<String, String>
     }
 
-    @Override
-    protected boolean supportsGeometryTypeWithGeographicCrs() {
-        // Geography type should be used instead of geometry type
-        // when using geographic coordinate reference system
-        return false
-    }
-
-    void "test crud when json conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with JSON conversion"() {
         given:
         GeographyEntityJson entity = new GeographyEntityJson()
         entity.setPoint(createPoint(1))
@@ -185,7 +178,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         }
     }
 
-    void "test crud when wkt conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with WKT conversion"() {
         given:
         GeographyEntityWkt entity = new GeographyEntityWkt()
         entity.setPoint(createPoint(1))
@@ -259,7 +252,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         }
     }
 
-    void "test findByLocationNear on geography database type when geographic crs is used and wkt conversion applied"() {
+    void "test findByLocationNear with an explicit geography column and WKT conversion"() {
         given:
         DeliveryDriverWktGeography nearby = new DeliveryDriverWktGeography("Nearby Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9757d, 40.7554d))
         DeliveryDriverWktGeography closest = new DeliveryDriverWktGeography("Closest Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9827d, 40.7504d))

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerGeoSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/sqlserver/SqlServerGeoSpec.groovy
@@ -79,14 +79,7 @@ class SqlServerGeoSpec extends AbstractGeoSpec implements MSSQLTestPropertyProvi
         return false
     }
 
-    @Override
-    protected boolean supportsGeometryTypeWithGeographicCrs() {
-        // Geography type should be used instead of geometry type
-        // when using geographic coordinate reference system
-        return false
-    }
-
-    void "test crud when wkt conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with WKT conversion"() {
         given:
         GeographyEntityWkt entity = new GeographyEntityWkt()
         entity.setPoint(createPoint(1))
@@ -160,7 +153,7 @@ class SqlServerGeoSpec extends AbstractGeoSpec implements MSSQLTestPropertyProvi
         }
     }
 
-    void "test findByLocationNear on geography database type when geographic crs is used and wkt conversion applied"() {
+    void "test findByLocationNear with an explicit geography column and WKT conversion"() {
         given:
         DeliveryDriverWktGeography nearby = new DeliveryDriverWktGeography("Nearby Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9757d, 40.7554d))
         DeliveryDriverWktGeography closest = new DeliveryDriverWktGeography("Closest Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9827d, 40.7504d))

--- a/data-model/src/main/java/io/micronaut/data/annotation/Srid.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/Srid.java
@@ -38,7 +38,8 @@ public @interface Srid {
 
     /**
      * @return The coordinate reference system type. SQL query builders use this value when generating geospatial
-     * distance predicates to choose between planar and spherical distance functions where the dialect supports both.
+     * distance predicates to choose between planar and spherical distance functions where the dialect supports both,
+     * and to select geography storage for PostgreSQL and SQL Server when no explicit column definition is present.
      * @since 5.0.4
      */
     CrsType type() default CrsType.PROJECTED;
@@ -49,8 +50,9 @@ public @interface Srid {
      * This distinguishes projected coordinate systems, where distances are calculated in planar coordinate-system
      * units, from geographic coordinate systems, where coordinates describe positions on the earth and distance
      * predicates should use spherical distance functions when available. Micronaut Data uses this metadata during SQL
-     * query generation for geospatial distance predicates such as {@code near}. Currently, this distinction is applied
-     * for the MySQL and H2 dialects.
+     * query generation for geospatial distance predicates such as {@code near}. MySQL and H2 use the distinction when
+     * selecting distance functions. PostgreSQL and SQL Server additionally use it to select native geography storage
+     * when the property does not declare an explicit column definition.
      *
      * @since 5.0.4
      */

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder.java
@@ -3551,10 +3551,9 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
         }
 
         private String getPostgresGeometryFunction(String column, String columnAlias, boolean isWkt, AnnotationMetadata annotationMetadata) {
-            Optional<String> optDefinition = annotationMetadata.stringValue(MappedProperty.class, "definition");
             String function = isWkt ? "ST_AsText(" : "ST_AsGeoJSON(";
             function = function + column;
-            if (optDefinition.isPresent() && optDefinition.get().toLowerCase().contains("geography")) {
+            if (SqlQueryBuilderUtils.isGeography(annotationMetadata)) {
                 // convert value from geography to geometry since ST_AsText and ST_AsGeoJSON requires geometry
                 function = function + "::geometry";
             }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilder.java
@@ -1729,12 +1729,11 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder {
         // since sqlserver doesn't have built-in functions for conversion between
         // json and internal geospatial data type, use always Well-Known Text (WKT) functions
         AnnotationMetadata annotationMetadata = property.getAnnotationMetadata();
-        Optional<String> optDefinition = annotationMetadata.stringValue(MappedProperty.class, "definition");
         OptionalInt optSrid = annotationMetadata.intValue(Srid.class);
 
         String geoDataType;
         int defaultSrid;
-        if (optDefinition.isPresent() && optDefinition.get().toLowerCase().contains("geography")) {
+        if (SqlQueryBuilderUtils.isGeography(annotationMetadata)) {
             geoDataType = "geography";
             defaultSrid = 4326;
         } else {
@@ -1777,7 +1776,10 @@ public class SqlQueryBuilder extends AbstractSqlLikeQueryBuilder {
             }
         }
         Optional<String> optDefinition = annotationMetadata.stringValue(MappedProperty.class, "definition");
-        if (optDefinition.isPresent() && optDefinition.get().toLowerCase().contains("geography")) {
+        boolean isGeography = dialect == Dialect.POSTGRES
+            ? SqlQueryBuilderUtils.isGeography(annotationMetadata)
+            : optDefinition.filter(SqlQueryBuilderUtils::isGeographyDefinition).isPresent();
+        if (isGeography) {
             // convert result of ST_GeomFromText and ST_GeomFromGeoJSON to geography
             sb.append("::geography");
         }

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilderUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlQueryBuilderUtils.java
@@ -23,7 +23,9 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.MappedProperty;
 import io.micronaut.data.annotation.Relation;
+import io.micronaut.data.annotation.Srid;
 import io.micronaut.data.annotation.sql.JoinColumns;
 import io.micronaut.data.annotation.sql.SqlMembers;
 import io.micronaut.data.model.Association;
@@ -38,6 +40,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
@@ -239,6 +243,30 @@ final class SqlQueryBuilderUtils {
             optionalInt = annotationMetadata.intValue(annotationName, value);
         }
         return optionalInt;
+    }
+
+    /**
+     * Determines whether a spatial property should use the database geography type.
+     * An explicit column definition takes precedence over the coordinate reference system type.
+     *
+     * @param annotationMetadata The property annotation metadata
+     * @return {@code true} if the property should use geography storage
+     */
+    static boolean isGeography(AnnotationMetadata annotationMetadata) {
+        Optional<String> definition = annotationMetadata.stringValue(MappedProperty.class, "definition");
+        if (definition.isPresent()) {
+            return isGeographyDefinition(definition.get());
+        }
+        return annotationMetadata.enumValue(Srid.class, "type", Srid.CrsType.class)
+            .orElse(Srid.CrsType.PROJECTED) == Srid.CrsType.GEOGRAPHIC;
+    }
+
+    /**
+     * @param definition The database column definition
+     * @return {@code true} if the definition specifies geography storage
+     */
+    static boolean isGeographyDefinition(String definition) {
+        return definition.toLowerCase(Locale.ROOT).contains("geography");
     }
 
     /**

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlSchemaUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/SqlSchemaUtils.java
@@ -430,6 +430,9 @@ public final class SqlSchemaUtils {
             String definition = null;
             if (dialect == Dialect.ORACLE) {
                 definition = "SDO_GEOMETRY";
+            } else if ((dialect == Dialect.POSTGRES || dialect == Dialect.SQL_SERVER)
+                && SqlQueryBuilderUtils.isGeography(annotationMetadata)) {
+                definition = "GEOGRAPHY";
             } else if (dialect == Dialect.MYSQL
                 || dialect == Dialect.POSTGRES
                 || dialect == Dialect.H2

--- a/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/model/query/builder/SqlQueryBuilderSpec.groovy
@@ -616,21 +616,25 @@ interface MyRepository {
         result.query == expectedQuery
 
         where:
-        dialect            | entityClass    || expectedQuery
-        Dialect.ORACLE     | GeomEntityJson || 'INSERT INTO "GEOM_ENTITY_JSON" ("LOCATION","MULTI_POINT","LINE_STRING","MULTI_LINE_STRING","ID") VALUES (SDO_UTIL.FROM_GEOJSON(?, NULL, 3857),SDO_UTIL.FROM_GEOJSON(?),SDO_UTIL.FROM_GEOJSON(?, NULL, 3857),SDO_UTIL.FROM_GEOJSON(?),"GEOM_ENTITY_JSON_SEQ".nextval)'
-        Dialect.ORACLE     | GeomEntityWkt  || 'INSERT INTO "GEOM_ENTITY_WKT" ("LOCATION","MULTI_POINT","LINE_STRING","MULTI_LINE_STRING","ID") VALUES (SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?), 3857),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?)),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?), 3857),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?)),"GEOM_ENTITY_WKT_SEQ".nextval)'
-        Dialect.MYSQL      | GeomEntityJson || 'INSERT INTO `geom_entity_json` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromGeoJSON(?, 1, 3857),ST_GeomFromGeoJSON(?),ST_GeomFromGeoJSON(?, 1, 3857),ST_GeomFromGeoJSON(?))'
-        Dialect.MYSQL      | GeomEntityWkt  || 'INSERT INTO `geom_entity_wkt` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
-        Dialect.H2         | GeomEntityJson || 'INSERT INTO `geom_entity_json` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?),ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?))'
-        Dialect.H2         | GeomEntityWkt  || 'INSERT INTO `geom_entity_wkt` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
-        Dialect.POSTGRES   | GeomEntityJson || 'INSERT INTO "geom_entity_json" ("location","multi_point","line_string","multi_line_string") VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?),ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?))'
-        Dialect.POSTGRES   | GeomEntityWkt  || 'INSERT INTO "geom_entity_wkt" ("location","multi_point","line_string","multi_line_string") VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
-        Dialect.POSTGRES   | GeogEntityJson || 'INSERT INTO "geog_entity_json" ("location","multi_point","line_string","multi_line_string") VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857)::geography,ST_GeomFromGeoJSON(?)::geography,ST_SetSRID(ST_GeomFromGeoJSON(?), 3857)::geography,ST_GeomFromGeoJSON(?)::geography)'
-        Dialect.POSTGRES   | GeogEntityWkt  || 'INSERT INTO "geog_entity_wkt" ("location","multi_point","line_string","multi_line_string") VALUES (ST_GeomFromText(?, 3857)::geography,ST_GeomFromText(?)::geography,ST_GeomFromText(?, 3857)::geography,ST_GeomFromText(?)::geography)'
-        Dialect.SQL_SERVER | GeomEntityJson || 'INSERT INTO [geom_entity_json] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857))'
-        Dialect.SQL_SERVER | GeomEntityWkt  || 'INSERT INTO [geom_entity_wkt] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857))'
-        Dialect.SQL_SERVER | GeogEntityJson || 'INSERT INTO [geog_entity_json] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326),geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326))'
-        Dialect.SQL_SERVER | GeogEntityWkt  || 'INSERT INTO [geog_entity_wkt] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326),geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326))'
+        dialect            | entityClass        || expectedQuery
+        Dialect.ORACLE     | GeomEntityJson     || 'INSERT INTO "GEOM_ENTITY_JSON" ("LOCATION","MULTI_POINT","LINE_STRING","MULTI_LINE_STRING","ID") VALUES (SDO_UTIL.FROM_GEOJSON(?, NULL, 3857),SDO_UTIL.FROM_GEOJSON(?),SDO_UTIL.FROM_GEOJSON(?, NULL, 3857),SDO_UTIL.FROM_GEOJSON(?),"GEOM_ENTITY_JSON_SEQ".nextval)'
+        Dialect.ORACLE     | GeomEntityWkt      || 'INSERT INTO "GEOM_ENTITY_WKT" ("LOCATION","MULTI_POINT","LINE_STRING","MULTI_LINE_STRING","ID") VALUES (SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?), 3857),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?)),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?), 3857),SDO_UTIL.FROM_WKTGEOMETRY(TO_CHAR(?)),"GEOM_ENTITY_WKT_SEQ".nextval)'
+        Dialect.MYSQL      | GeomEntityJson     || 'INSERT INTO `geom_entity_json` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromGeoJSON(?, 1, 3857),ST_GeomFromGeoJSON(?),ST_GeomFromGeoJSON(?, 1, 3857),ST_GeomFromGeoJSON(?))'
+        Dialect.MYSQL      | GeomEntityWkt      || 'INSERT INTO `geom_entity_wkt` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
+        Dialect.H2         | GeomEntityJson     || 'INSERT INTO `geom_entity_json` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?),ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?))'
+        Dialect.H2         | GeomEntityWkt      || 'INSERT INTO `geom_entity_wkt` (`location`,`multi_point`,`line_string`,`multi_line_string`) VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
+        Dialect.POSTGRES   | GeomEntityJson     || 'INSERT INTO "geom_entity_json" ("location","multi_point","line_string","multi_line_string") VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?),ST_SetSRID(ST_GeomFromGeoJSON(?), 3857),ST_GeomFromGeoJSON(?))'
+        Dialect.POSTGRES   | GeomEntityWkt      || 'INSERT INTO "geom_entity_wkt" ("location","multi_point","line_string","multi_line_string") VALUES (ST_GeomFromText(?, 3857),ST_GeomFromText(?),ST_GeomFromText(?, 3857),ST_GeomFromText(?))'
+        Dialect.POSTGRES   | GeogEntityJson     || 'INSERT INTO "geog_entity_json" ("location","multi_point","line_string","multi_line_string") VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 3857)::geography,ST_GeomFromGeoJSON(?)::geography,ST_SetSRID(ST_GeomFromGeoJSON(?), 3857)::geography,ST_GeomFromGeoJSON(?)::geography)'
+        Dialect.POSTGRES   | GeogEntityWkt      || 'INSERT INTO "geog_entity_wkt" ("location","multi_point","line_string","multi_line_string") VALUES (ST_GeomFromText(?, 3857)::geography,ST_GeomFromText(?)::geography,ST_GeomFromText(?, 3857)::geography,ST_GeomFromText(?)::geography)'
+        Dialect.POSTGRES   | GeomEntityWGS84    || 'INSERT INTO "geom_entity_wgs84" ("location") VALUES (ST_SetSRID(ST_GeomFromGeoJSON(?), 4326)::geography)'
+        Dialect.POSTGRES   | GeomEntityWGS84Wkt || 'INSERT INTO "geom_entity_wgs84_wkt" ("location") VALUES (ST_GeomFromText(?, 4326)::geography)'
+        Dialect.SQL_SERVER | GeomEntityJson     || 'INSERT INTO [geom_entity_json] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857))'
+        Dialect.SQL_SERVER | GeomEntityWkt      || 'INSERT INTO [geom_entity_wkt] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857),geometry::STGeomFromText(?, 3857))'
+        Dialect.SQL_SERVER | GeogEntityJson     || 'INSERT INTO [geog_entity_json] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326),geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326))'
+        Dialect.SQL_SERVER | GeogEntityWkt      || 'INSERT INTO [geog_entity_wkt] ([location],[multi_point],[line_string],[multi_line_string]) VALUES (geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326),geography::STGeomFromText(?, 3857),geography::STGeomFromText(?, 4326))'
+        Dialect.SQL_SERVER | GeomEntityWGS84    || 'INSERT INTO [geom_entity_wgs84] ([location]) VALUES (geography::STGeomFromText(?, 4326))'
+        Dialect.SQL_SERVER | GeomEntityWGS84Wkt || 'INSERT INTO [geom_entity_wgs84_wkt] ([location]) VALUES (geography::STGeomFromText(?, 4326))'
     }
 
     @Unroll
@@ -667,6 +671,25 @@ interface MyRepository {
     }
 
     @Unroll
+    void "test encode #dialect update statement for geographic property for #entityClass.simpleName"() {
+        given:
+        def query = builder.createCriteriaUpdate(entityClass)
+        def root = query.from(entityClass)
+        query.set(root.get('point'), builder.parameter(Object))
+        query.where(builder.equal(root.get('id'), builder.parameter(Object)))
+
+        expect:
+        query.build(new SqlQueryBuilder(dialect)).query == expectedQuery
+
+        where:
+        dialect            | entityClass          || expectedQuery
+        Dialect.POSTGRES   | GeomEntityWGS84      || 'UPDATE "geom_entity_wgs84" SET "location"=ST_SetSRID(ST_GeomFromGeoJSON(?), 4326)::geography WHERE ("id" = ?)'
+        Dialect.POSTGRES   | GeomEntityWGS84Wkt   || 'UPDATE "geom_entity_wgs84_wkt" SET "location"=ST_GeomFromText(?, 4326)::geography WHERE ("id" = ?)'
+        Dialect.SQL_SERVER | GeomEntityWGS84      || 'UPDATE [geom_entity_wgs84] SET [location]=geography::STGeomFromText(?, 4326) WHERE ([id] = ?)'
+        Dialect.SQL_SERVER | GeomEntityWGS84Wkt   || 'UPDATE [geom_entity_wgs84_wkt] SET [location]=geography::STGeomFromText(?, 4326) WHERE ([id] = ?)'
+    }
+
+    @Unroll
     void "test encode #dialect read statement for geospatial properties for #entityClass.simpleName"() {
         given:
         def query = builder.createQuery(entityClass)
@@ -678,21 +701,25 @@ interface MyRepository {
         result.query == expectedQuery
 
         where:
-        dialect            | entityClass   || expectedQuery
-        Dialect.ORACLE     | GeomEntityJson || 'SELECT geom_entity_json_."ID",SDO_UTIL.TO_GEOJSON(geom_entity_json_."LOCATION") AS "LOCATION",SDO_UTIL.TO_GEOJSON(geom_entity_json_."MULTI_POINT") AS "MULTI_POINT",SDO_UTIL.TO_GEOJSON(geom_entity_json_."LINE_STRING") AS "LINE_STRING",SDO_UTIL.TO_GEOJSON(geom_entity_json_."MULTI_LINE_STRING") AS "MULTI_LINE_STRING" FROM "GEOM_ENTITY_JSON" geom_entity_json_ WHERE (geom_entity_json_."ID" = ?)'
-        Dialect.ORACLE     | GeomEntityWkt  || 'SELECT geom_entity_wkt_."ID",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."LOCATION") AS "LOCATION",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."MULTI_POINT") AS "MULTI_POINT",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."LINE_STRING") AS "LINE_STRING",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."MULTI_LINE_STRING") AS "MULTI_LINE_STRING" FROM "GEOM_ENTITY_WKT" geom_entity_wkt_ WHERE (geom_entity_wkt_."ID" = ?)'
-        Dialect.MYSQL      | GeomEntityJson || 'SELECT geom_entity_json_.`id`,ST_AsGeoJSON(geom_entity_json_.`location`) AS `location`,ST_AsGeoJSON(geom_entity_json_.`multi_point`) AS `multi_point`,ST_AsGeoJSON(geom_entity_json_.`line_string`) AS `line_string`,ST_AsGeoJSON(geom_entity_json_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_json` geom_entity_json_ WHERE (geom_entity_json_.`id` = ?)'
-        Dialect.MYSQL      | GeomEntityWkt  || 'SELECT geom_entity_wkt_.`id`,ST_AsText(geom_entity_wkt_.`location`) AS `location`,ST_AsText(geom_entity_wkt_.`multi_point`) AS `multi_point`,ST_AsText(geom_entity_wkt_.`line_string`) AS `line_string`,ST_AsText(geom_entity_wkt_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_wkt` geom_entity_wkt_ WHERE (geom_entity_wkt_.`id` = ?)'
-        Dialect.H2         | GeomEntityJson || 'SELECT geom_entity_json_.`id`,ST_AsGeoJSON(geom_entity_json_.`location`) AS `location`,ST_AsGeoJSON(geom_entity_json_.`multi_point`) AS `multi_point`,ST_AsGeoJSON(geom_entity_json_.`line_string`) AS `line_string`,ST_AsGeoJSON(geom_entity_json_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_json` geom_entity_json_ WHERE (geom_entity_json_.`id` = ?)'
-        Dialect.H2         | GeomEntityWkt  || 'SELECT geom_entity_wkt_.`id`,ST_AsText(geom_entity_wkt_.`location`) AS `location`,ST_AsText(geom_entity_wkt_.`multi_point`) AS `multi_point`,ST_AsText(geom_entity_wkt_.`line_string`) AS `line_string`,ST_AsText(geom_entity_wkt_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_wkt` geom_entity_wkt_ WHERE (geom_entity_wkt_.`id` = ?)'
-        Dialect.POSTGRES   | GeomEntityJson || 'SELECT geom_entity_json_."id",ST_AsGeoJSON(geom_entity_json_."location") AS "location",ST_AsGeoJSON(geom_entity_json_."multi_point") AS "multi_point",ST_AsGeoJSON(geom_entity_json_."line_string") AS "line_string",ST_AsGeoJSON(geom_entity_json_."multi_line_string") AS "multi_line_string" FROM "geom_entity_json" geom_entity_json_ WHERE (geom_entity_json_."id" = ?)'
-        Dialect.POSTGRES   | GeomEntityWkt  || 'SELECT geom_entity_wkt_."id",ST_AsText(geom_entity_wkt_."location") AS "location",ST_AsText(geom_entity_wkt_."multi_point") AS "multi_point",ST_AsText(geom_entity_wkt_."line_string") AS "line_string",ST_AsText(geom_entity_wkt_."multi_line_string") AS "multi_line_string" FROM "geom_entity_wkt" geom_entity_wkt_ WHERE (geom_entity_wkt_."id" = ?)'
-        Dialect.POSTGRES   | GeogEntityJson || 'SELECT geog_entity_json_."id",ST_AsGeoJSON(geog_entity_json_."location"::geometry) AS "location",ST_AsGeoJSON(geog_entity_json_."multi_point"::geometry) AS "multi_point",ST_AsGeoJSON(geog_entity_json_."line_string"::geometry) AS "line_string",ST_AsGeoJSON(geog_entity_json_."multi_line_string"::geometry) AS "multi_line_string" FROM "geog_entity_json" geog_entity_json_ WHERE (geog_entity_json_."id" = ?)'
-        Dialect.POSTGRES   | GeogEntityWkt  || 'SELECT geog_entity_wkt_."id",ST_AsText(geog_entity_wkt_."location"::geometry) AS "location",ST_AsText(geog_entity_wkt_."multi_point"::geometry) AS "multi_point",ST_AsText(geog_entity_wkt_."line_string"::geometry) AS "line_string",ST_AsText(geog_entity_wkt_."multi_line_string"::geometry) AS "multi_line_string" FROM "geog_entity_wkt" geog_entity_wkt_ WHERE (geog_entity_wkt_."id" = ?)'
-        Dialect.SQL_SERVER | GeomEntityJson || 'SELECT geom_entity_json_.[id],geom_entity_json_.[location].STAsText() AS [location],geom_entity_json_.[multi_point].STAsText() AS [multi_point],geom_entity_json_.[line_string].STAsText() AS [line_string],geom_entity_json_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geom_entity_json] geom_entity_json_ WHERE (geom_entity_json_.[id] = ?)'
-        Dialect.SQL_SERVER | GeomEntityWkt  || 'SELECT geom_entity_wkt_.[id],geom_entity_wkt_.[location].STAsText() AS [location],geom_entity_wkt_.[multi_point].STAsText() AS [multi_point],geom_entity_wkt_.[line_string].STAsText() AS [line_string],geom_entity_wkt_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geom_entity_wkt] geom_entity_wkt_ WHERE (geom_entity_wkt_.[id] = ?)'
-        Dialect.SQL_SERVER | GeogEntityJson || 'SELECT geog_entity_json_.[id],geog_entity_json_.[location].STAsText() AS [location],geog_entity_json_.[multi_point].STAsText() AS [multi_point],geog_entity_json_.[line_string].STAsText() AS [line_string],geog_entity_json_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geog_entity_json] geog_entity_json_ WHERE (geog_entity_json_.[id] = ?)'
-        Dialect.SQL_SERVER | GeogEntityWkt  || 'SELECT geog_entity_wkt_.[id],geog_entity_wkt_.[location].STAsText() AS [location],geog_entity_wkt_.[multi_point].STAsText() AS [multi_point],geog_entity_wkt_.[line_string].STAsText() AS [line_string],geog_entity_wkt_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geog_entity_wkt] geog_entity_wkt_ WHERE (geog_entity_wkt_.[id] = ?)'
+        dialect            | entityClass        || expectedQuery
+        Dialect.ORACLE     | GeomEntityJson     || 'SELECT geom_entity_json_."ID",SDO_UTIL.TO_GEOJSON(geom_entity_json_."LOCATION") AS "LOCATION",SDO_UTIL.TO_GEOJSON(geom_entity_json_."MULTI_POINT") AS "MULTI_POINT",SDO_UTIL.TO_GEOJSON(geom_entity_json_."LINE_STRING") AS "LINE_STRING",SDO_UTIL.TO_GEOJSON(geom_entity_json_."MULTI_LINE_STRING") AS "MULTI_LINE_STRING" FROM "GEOM_ENTITY_JSON" geom_entity_json_ WHERE (geom_entity_json_."ID" = ?)'
+        Dialect.ORACLE     | GeomEntityWkt      || 'SELECT geom_entity_wkt_."ID",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."LOCATION") AS "LOCATION",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."MULTI_POINT") AS "MULTI_POINT",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."LINE_STRING") AS "LINE_STRING",SDO_UTIL.TO_WKTGEOMETRY(geom_entity_wkt_."MULTI_LINE_STRING") AS "MULTI_LINE_STRING" FROM "GEOM_ENTITY_WKT" geom_entity_wkt_ WHERE (geom_entity_wkt_."ID" = ?)'
+        Dialect.MYSQL      | GeomEntityJson     || 'SELECT geom_entity_json_.`id`,ST_AsGeoJSON(geom_entity_json_.`location`) AS `location`,ST_AsGeoJSON(geom_entity_json_.`multi_point`) AS `multi_point`,ST_AsGeoJSON(geom_entity_json_.`line_string`) AS `line_string`,ST_AsGeoJSON(geom_entity_json_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_json` geom_entity_json_ WHERE (geom_entity_json_.`id` = ?)'
+        Dialect.MYSQL      | GeomEntityWkt      || 'SELECT geom_entity_wkt_.`id`,ST_AsText(geom_entity_wkt_.`location`) AS `location`,ST_AsText(geom_entity_wkt_.`multi_point`) AS `multi_point`,ST_AsText(geom_entity_wkt_.`line_string`) AS `line_string`,ST_AsText(geom_entity_wkt_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_wkt` geom_entity_wkt_ WHERE (geom_entity_wkt_.`id` = ?)'
+        Dialect.H2         | GeomEntityJson     || 'SELECT geom_entity_json_.`id`,ST_AsGeoJSON(geom_entity_json_.`location`) AS `location`,ST_AsGeoJSON(geom_entity_json_.`multi_point`) AS `multi_point`,ST_AsGeoJSON(geom_entity_json_.`line_string`) AS `line_string`,ST_AsGeoJSON(geom_entity_json_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_json` geom_entity_json_ WHERE (geom_entity_json_.`id` = ?)'
+        Dialect.H2         | GeomEntityWkt      || 'SELECT geom_entity_wkt_.`id`,ST_AsText(geom_entity_wkt_.`location`) AS `location`,ST_AsText(geom_entity_wkt_.`multi_point`) AS `multi_point`,ST_AsText(geom_entity_wkt_.`line_string`) AS `line_string`,ST_AsText(geom_entity_wkt_.`multi_line_string`) AS `multi_line_string` FROM `geom_entity_wkt` geom_entity_wkt_ WHERE (geom_entity_wkt_.`id` = ?)'
+        Dialect.POSTGRES   | GeomEntityJson     || 'SELECT geom_entity_json_."id",ST_AsGeoJSON(geom_entity_json_."location") AS "location",ST_AsGeoJSON(geom_entity_json_."multi_point") AS "multi_point",ST_AsGeoJSON(geom_entity_json_."line_string") AS "line_string",ST_AsGeoJSON(geom_entity_json_."multi_line_string") AS "multi_line_string" FROM "geom_entity_json" geom_entity_json_ WHERE (geom_entity_json_."id" = ?)'
+        Dialect.POSTGRES   | GeomEntityWkt      || 'SELECT geom_entity_wkt_."id",ST_AsText(geom_entity_wkt_."location") AS "location",ST_AsText(geom_entity_wkt_."multi_point") AS "multi_point",ST_AsText(geom_entity_wkt_."line_string") AS "line_string",ST_AsText(geom_entity_wkt_."multi_line_string") AS "multi_line_string" FROM "geom_entity_wkt" geom_entity_wkt_ WHERE (geom_entity_wkt_."id" = ?)'
+        Dialect.POSTGRES   | GeogEntityJson     || 'SELECT geog_entity_json_."id",ST_AsGeoJSON(geog_entity_json_."location"::geometry) AS "location",ST_AsGeoJSON(geog_entity_json_."multi_point"::geometry) AS "multi_point",ST_AsGeoJSON(geog_entity_json_."line_string"::geometry) AS "line_string",ST_AsGeoJSON(geog_entity_json_."multi_line_string"::geometry) AS "multi_line_string" FROM "geog_entity_json" geog_entity_json_ WHERE (geog_entity_json_."id" = ?)'
+        Dialect.POSTGRES   | GeogEntityWkt      || 'SELECT geog_entity_wkt_."id",ST_AsText(geog_entity_wkt_."location"::geometry) AS "location",ST_AsText(geog_entity_wkt_."multi_point"::geometry) AS "multi_point",ST_AsText(geog_entity_wkt_."line_string"::geometry) AS "line_string",ST_AsText(geog_entity_wkt_."multi_line_string"::geometry) AS "multi_line_string" FROM "geog_entity_wkt" geog_entity_wkt_ WHERE (geog_entity_wkt_."id" = ?)'
+        Dialect.POSTGRES   | GeomEntityWGS84    || 'SELECT geom_entity_wgs84_."id",ST_AsGeoJSON(geom_entity_wgs84_."location"::geometry) AS "location" FROM "geom_entity_wgs84" geom_entity_wgs84_ WHERE (geom_entity_wgs84_."id" = ?)'
+        Dialect.POSTGRES   | GeomEntityWGS84Wkt || 'SELECT geom_entity_wgs84_wkt_."id",ST_AsText(geom_entity_wgs84_wkt_."location"::geometry) AS "location" FROM "geom_entity_wgs84_wkt" geom_entity_wgs84_wkt_ WHERE (geom_entity_wgs84_wkt_."id" = ?)'
+        Dialect.SQL_SERVER | GeomEntityJson     || 'SELECT geom_entity_json_.[id],geom_entity_json_.[location].STAsText() AS [location],geom_entity_json_.[multi_point].STAsText() AS [multi_point],geom_entity_json_.[line_string].STAsText() AS [line_string],geom_entity_json_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geom_entity_json] geom_entity_json_ WHERE (geom_entity_json_.[id] = ?)'
+        Dialect.SQL_SERVER | GeomEntityWkt      || 'SELECT geom_entity_wkt_.[id],geom_entity_wkt_.[location].STAsText() AS [location],geom_entity_wkt_.[multi_point].STAsText() AS [multi_point],geom_entity_wkt_.[line_string].STAsText() AS [line_string],geom_entity_wkt_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geom_entity_wkt] geom_entity_wkt_ WHERE (geom_entity_wkt_.[id] = ?)'
+        Dialect.SQL_SERVER | GeogEntityJson     || 'SELECT geog_entity_json_.[id],geog_entity_json_.[location].STAsText() AS [location],geog_entity_json_.[multi_point].STAsText() AS [multi_point],geog_entity_json_.[line_string].STAsText() AS [line_string],geog_entity_json_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geog_entity_json] geog_entity_json_ WHERE (geog_entity_json_.[id] = ?)'
+        Dialect.SQL_SERVER | GeogEntityWkt      || 'SELECT geog_entity_wkt_.[id],geog_entity_wkt_.[location].STAsText() AS [location],geog_entity_wkt_.[multi_point].STAsText() AS [multi_point],geog_entity_wkt_.[line_string].STAsText() AS [line_string],geog_entity_wkt_.[multi_line_string].STAsText() AS [multi_line_string] FROM [geog_entity_wkt] geog_entity_wkt_ WHERE (geog_entity_wkt_.[id] = ?)'
+        Dialect.SQL_SERVER | GeomEntityWGS84    || 'SELECT geom_entity_wgs84_.[id],geom_entity_wgs84_.[location].STAsText() AS [location] FROM [geom_entity_wgs84] geom_entity_wgs84_ WHERE (geom_entity_wgs84_.[id] = ?)'
+        Dialect.SQL_SERVER | GeomEntityWGS84Wkt || 'SELECT geom_entity_wgs84_wkt_.[id],geom_entity_wgs84_wkt_.[location].STAsText() AS [location] FROM [geom_entity_wgs84_wkt] geom_entity_wgs84_wkt_ WHERE (geom_entity_wgs84_wkt_.[id] = ?)'
     }
 
     @Unroll
@@ -1049,14 +1076,24 @@ interface MyRepository {
         Dialect.SQL_SERVER | 'CREATE TABLE [school] ([id] BIGINT PRIMARY KEY IDENTITY(1,1) NOT NULL,[name] VARCHAR(255) NOT NULL,[point] GEOMETRY NOT NULL,[description] VARCHAR(255));'       | 'CREATE SPATIAL INDEX [idx_school_point] ON [school] ([point]);'
     }
 
-    void "test build create index for SQL Server geometry column 4326 srid"() {
+    void "test build create index for SQL Server geographic column"() {
         when:
         QueryBuilder encoder = new SqlQueryBuilder(Dialect.SQL_SERVER)
         def statements = encoder.buildCreateTableStatements(getRuntimePersistentEntity(GeomEntityWGS84))
 
         then:
-        statements[0] == 'CREATE TABLE [geom_entity_wgs84] ([id] BIGINT PRIMARY KEY IDENTITY(1,1) NOT NULL,[location] GEOMETRY NOT NULL);'
-        statements[1] == 'CREATE SPATIAL INDEX [idx_geom_entity_wgs84_location] ON [geom_entity_wgs84] ([location]) USING GEOMETRY_GRID WITH (BOUNDING_BOX = (-180, -90, 180,  90));'
+        statements[0] == 'CREATE TABLE [geom_entity_wgs84] ([id] BIGINT PRIMARY KEY IDENTITY(1,1) NOT NULL,[location] GEOGRAPHY NOT NULL);'
+        statements[1] == 'CREATE SPATIAL INDEX [idx_geom_entity_wgs84_location] ON [geom_entity_wgs84] ([location]);'
+    }
+
+    void "test build create index for PostgreSQL geographic column"() {
+        when:
+        QueryBuilder encoder = new SqlQueryBuilder(Dialect.POSTGRES)
+        def statements = encoder.buildCreateTableStatements(getRuntimePersistentEntity(GeomEntityWGS84))
+
+        then:
+        statements[0] == 'CREATE TABLE "geom_entity_wgs84" ("id" BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,"location" GEOGRAPHY NOT NULL);'
+        statements[1] == 'CREATE INDEX "idx_geom_entity_wgs84_location" ON "geom_entity_wgs84" USING GIST ("location");'
     }
 
     void "test build create table rejects composite index containing geometry column"() {

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresGeoSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/postgres/PostgresGeoSpec.groovy
@@ -108,14 +108,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         ] as Map<String, String>
     }
 
-    @Override
-    protected boolean supportsGeometryTypeWithGeographicCrs() {
-        // Geography type should be used instead of geometry type
-        // when using geographic coordinate reference system
-        return false
-    }
-
-    void "test crud when json conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with JSON conversion"() {
         given:
         GeographyEntityJson entity = new GeographyEntityJson()
         entity.setPoint(createPoint(1))
@@ -189,7 +182,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         }
     }
 
-    void "test crud when wkt conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with WKT conversion"() {
         given:
         GeographyEntityWkt entity = new GeographyEntityWkt()
         entity.setPoint(createPoint(1))
@@ -263,7 +256,7 @@ class PostgresGeoSpec extends AbstractGeoSpec implements PostgresTestPropertyPro
         }
     }
 
-    void "test findByLocationNear on geography database type when geographic crs is used and wkt conversion applied"() {
+    void "test findByLocationNear with an explicit geography column and WKT conversion"() {
         given:
         DeliveryDriverWktGeography nearby = new DeliveryDriverWktGeography("Nearby Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9757d, 40.7554d))
         DeliveryDriverWktGeography closest = new DeliveryDriverWktGeography("Closest Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9827d, 40.7504d))

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerGeoSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/sqlserver/SqlServerGeoSpec.groovy
@@ -79,14 +79,7 @@ class SqlServerGeoSpec extends AbstractGeoSpec implements SqlServerTestPropertyP
         return false
     }
 
-    @Override
-    protected boolean supportsGeometryTypeWithGeographicCrs() {
-        // Geography type should be used instead of geometry type
-        // when using geographic coordinate reference system
-        return false
-    }
-
-    void "test crud when wkt conversion used on geography type"() {
+    void "test creates, reads, updates, and clears geography with WKT conversion"() {
         given:
         GeographyEntityWkt entity = new GeographyEntityWkt()
         entity.setPoint(createPoint(1))
@@ -160,7 +153,7 @@ class SqlServerGeoSpec extends AbstractGeoSpec implements SqlServerTestPropertyP
         }
     }
 
-    void "test findByLocationNear on geography database type when geographic crs is used and wkt conversion applied"() {
+    void "test findByLocationNear with an explicit geography column and WKT conversion"() {
         given:
         DeliveryDriverWktGeography nearby = new DeliveryDriverWktGeography("Nearby Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9757d, 40.7554d))
         DeliveryDriverWktGeography closest = new DeliveryDriverWktGeography("Closest Driver", DeliveryDriverWktGeography.Status.AVAILABLE, new Point(-73.9827d, 40.7504d))

--- a/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractGeoSpec.groovy
+++ b/data-tck/src/main/groovy/io/micronaut/data/tck/tests/AbstractGeoSpec.groovy
@@ -61,7 +61,7 @@ abstract class AbstractGeoSpec extends Specification {
         getDeliveryDriverWktRepository()?.deleteAll()
     }
 
-    void "test creating, reading and updating when json conversion used on embedded geometry type"() {
+    void "test creates, reads, and updates embedded geometry with JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -104,7 +104,7 @@ abstract class AbstractGeoSpec extends Specification {
         }
     }
 
-    void "test creating, reading and updating when json conversion used on geometry type"() {
+    void "test creates, reads, and updates geometry with JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -161,7 +161,7 @@ abstract class AbstractGeoSpec extends Specification {
         }
     }
 
-    void "test delete when json conversion used on geometry type"() {
+    void "test updates geometry to null with JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
         assumeTrue(supportsDeletingGeometryTypes())
 
@@ -216,7 +216,7 @@ abstract class AbstractGeoSpec extends Specification {
         }
     }
 
-    void "test crud when wkt conversion used on geometry type"() {
+    void "test creates, reads, updates, and clears geometry with WKT conversion"() {
         given:
         GeometryEntityWkt entity = new GeometryEntityWkt()
         entity.setPoint(createPoint(1))
@@ -290,7 +290,7 @@ abstract class AbstractGeoSpec extends Specification {
         }
     }
 
-    void "test findByLocationGeoWithin when json conversion is used"() {
+    void "test findByLocationGeoWithin with JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -321,7 +321,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationGeoIntersects when json conversion used"() {
+    void "test findByLocationGeoIntersects with JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -347,7 +347,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationGeoWithin when wkt conversion used"() {
+    void "test findByLocationGeoWithin with WKT conversion"() {
         given:
         HotelWkt inside1 = new HotelWkt("Grand Plaza Hotel", new Point(10.0, 10.0))
         HotelWkt inside2 = new HotelWkt("Sunset Resort", new Point(12.0, 12.0))
@@ -376,7 +376,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationGeoIntersects when wkt conversion used"() {
+    void "test findByLocationGeoIntersects with WKT conversion"() {
         given:
         HotelWkt onRoute1 = new HotelWkt("Grand Plaza Hotel", new Point(10.0, 10.0))
         HotelWkt onRoute2 = new HotelWkt("Sunset Resort", new Point(12.0, 12.0))
@@ -400,7 +400,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationNear on geometry database type when projected crs is used and json conversion applied"() {
+    void "test findByLocationNear with projected CRS and JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -423,7 +423,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationNear on geometry database type when projected crs is used and wkt conversion applied"() {
+    void "test findByLocationNear with projected CRS and WKT conversion"() {
         given:
         HotelWkt nearby1 = new HotelWkt("Grand Plaza Hotel", new Point(11.0, 11.0))
         HotelWkt nearby2 = new HotelWkt("Sunset Resort", new Point(12.0, 10.0))
@@ -444,8 +444,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Sunset Resort")
     }
 
-    void "test findByLocationNear on geometry database type when geographic crs is used and json conversion applied"() {
-        assumeTrue(supportsGeometryTypeWithGeographicCrs())
+    void "test findByLocationNear with geographic CRS and JSON conversion"() {
         assumeTrue(supportsGeometryJsonConversion())
 
         given:
@@ -471,9 +470,7 @@ abstract class AbstractGeoSpec extends Specification {
         names.contains("Closest Driver")
     }
 
-    void "test findByLocationNear on geometry database type when geographic crs is used and wkt conversion applied"() {
-        assumeTrue(supportsGeometryTypeWithGeographicCrs())
-
+    void "test findByLocationNear with geographic CRS and WKT conversion"() {
         given:
         DeliveryDriverWkt nearby = new DeliveryDriverWkt("Nearby Driver", DeliveryDriverWkt.Status.AVAILABLE, new Point(-73.9757d, 40.7554d))
         DeliveryDriverWkt closest = new DeliveryDriverWkt("Closest Driver", DeliveryDriverWkt.Status.AVAILABLE, new Point(-73.9827d, 40.7504d))
@@ -502,10 +499,6 @@ abstract class AbstractGeoSpec extends Specification {
     }
 
     protected boolean supportsDeletingGeometryTypes() {
-        return true
-    }
-
-    protected boolean supportsGeometryTypeWithGeographicCrs() {
         return true
     }
 

--- a/src/main/docs/guide/dbc/sqlMapping/sqlGeospatial.adoc
+++ b/src/main/docs/guide/dbc/sqlMapping/sqlGeospatial.adoc
@@ -61,8 +61,9 @@ for planar and spherical distance checks:
 |===
 
 For the other supported SQL dialects, `Srid.CrsType` does not currently change the generated `Near` predicate function.
-It also does not change the database column type. Use `@MappedProperty(definition = "geography")` when a dialect such as
-PostgreSQL / PostGIS or SQL Server should use a native `GEOGRAPHY` column.
+For PostgreSQL / PostGIS and SQL Server, `Srid.CrsType.GEOGRAPHIC` selects the native `GEOGRAPHY` column type and matching
+read and write conversions. Other dialects retain their native geometry column type. An explicit
+`@MappedProperty(definition = "...")` always takes precedence over the inferred column type.
 
 === Query predicates
 


### PR DESCRIPTION
Closes https://github.com/micronaut-projects/micronaut-data/issues/3991

**Issue**

Entities using a geographic SRID and crs type, for example
```
@Srid(value = 4326, type = Srid.CrsType.GEOGRAPHIC)
```
 could not be used with PostgreSQL/PostGIS or SQL Server without explicitly setting `geography` definition
```
@MappedProperty(definition = "geography")
```
That requirement reduced portability of the entity mapping across supported databases.

**Fix**

Infer the native GEOGRAPHY type from `@Srid(type = Srid.CrsType.GEOGRAPHIC)` for PostgreSQL and SQL Server when no explicit column definition is provided.

- PostgreSQL and SQL Server now generate geography columns and use the corresponding geometry conversion/read expressions.
- An explicit `MappedProperty(definition = "...")` continues to override inferred behavior.
- Updated schema/query-builder tests and clarified geospatial documentation.
- Renamed geospatial TCK feature names for clearer, consistent coverage descriptions.