### PR TITLE
Document JDBC timeout guidance for transaction recovery

### DIFF
--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -96,12 +96,13 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Retry attempts also run on a fresh transaction/connection
 - Recovery is attempted only when commit handling or the commit acknowledgement
   produces an exception whose type matches the exception types configured by
-  `on` (by default `java.sql.SQLRecoverableException`, including a matching
-  wrapped cause). If a particular network and driver setup can leave JDBC
-  operations waiting indefinitely before an exception is surfaced, users may
-  configure an appropriate Oracle JDBC or infrastructure read timeout.
+  `on` (by default `java.sql.SQLRecoverableException`; a configured exception
+  type matches if it appears anywhere in the exception cause chain). If a
+  particular network and driver setup can leave JDBC operations waiting
+  indefinitely before an exception is surfaced, users may configure an
+  appropriate Oracle JDBC or infrastructure read timeout.
   Micronaut Data does not set this timeout. It applies to JDBC reads generally
   and must be tuned for the deployment; an immediate connection reset may not
-  require one. The timeout does not determine the Oracle commit outcome
+  require one. The timeout does not determine the Oracle commit outcome.
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -94,5 +94,11 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Replayed work must be safe to execute again when Oracle reports `NOT_COMMITTED`
 - Outcome resolution always uses a fresh connection
 - Retry attempts also run on a fresh transaction/connection
+- Recovery begins only after the JDBC driver reports a connection failure. If
+  a network failure can leave JDBC operations waiting indefinitely, configure
+  an appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data
+  does not set this timeout; it applies to JDBC reads generally and must be
+  tuned for the deployment. The timeout does not determine the Oracle commit
+  outcome.
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -94,11 +94,10 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Replayed work must be safe to execute again when Oracle reports `NOT_COMMITTED`
 - Outcome resolution always uses a fresh connection
 - Retry attempts also run on a fresh transaction/connection
-- Recovery begins only after the JDBC driver reports a connection failure. If
-  a network failure can leave JDBC operations waiting indefinitely, configure
-  an appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data
-  does not set this timeout; it applies to JDBC reads generally and must be
-  tuned for the deployment. The timeout does not determine the Oracle commit
-  outcome.
+- Recovery begins only after the JDBC driver reports a connection failure. If a
+  network failure can leave JDBC operations waiting indefinitely, configure an
+  appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data does
+  not set this timeout; it applies to JDBC reads generally and must be tuned
+  for the deployment. The timeout does not determine the Oracle commit outcome.
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -97,10 +97,11 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Recovery is attempted only when commit handling or acknowledgement produces
   an exception matching the configured `on` types (by default
   `java.sql.SQLRecoverableException`, including a matching wrapped cause). If
-  a network failure can leave JDBC operations waiting indefinitely before an
-  exception is surfaced, configure an appropriate Oracle JDBC or
-  infrastructure read timeout. Micronaut Data does not set this timeout; it
-  applies to JDBC reads generally and must be tuned for the deployment. The
+  a particular network and driver setup can leave JDBC operations waiting
+  indefinitely before an exception is surfaced, users may configure an
+  appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data does
+  not set this timeout. It applies to JDBC reads generally and must be tuned
+  for the deployment; an immediate connection reset may not require one. The
   timeout does not determine the Oracle commit outcome.
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -94,9 +94,10 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Replayed work must be safe to execute again when Oracle reports `NOT_COMMITTED`
 - Outcome resolution always uses a fresh connection
 - Retry attempts also run on a fresh transaction/connection
-- Recovery is attempted only when commit handling or acknowledgement produces
-  an exception matching the configured `on` types (by default
-  `java.sql.SQLRecoverableException`, including a matching wrapped cause). If
+- Recovery is attempted only when commit handling or the commit acknowledgement
+  produces an exception whose type matches the exception types configured by
+  `on` (by default `java.sql.SQLRecoverableException`, including a matching
+  wrapped cause). If
   a particular network and driver setup can leave JDBC operations waiting
   indefinitely before an exception is surfaced, users may configure an
   appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data does

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -94,10 +94,13 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Replayed work must be safe to execute again when Oracle reports `NOT_COMMITTED`
 - Outcome resolution always uses a fresh connection
 - Retry attempts also run on a fresh transaction/connection
-- Recovery begins only after the JDBC driver reports a connection failure. If a
-  network failure can leave JDBC operations waiting indefinitely, configure an
-  appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data does
-  not set this timeout; it applies to JDBC reads generally and must be tuned
-  for the deployment. The timeout does not determine the Oracle commit outcome.
+- Recovery is attempted only when commit handling or acknowledgement produces
+  an exception matching the configured `on` types (by default
+  `java.sql.SQLRecoverableException`, including a matching wrapped cause). If
+  a network failure can leave JDBC operations waiting indefinitely before an
+  exception is surfaced, configure an appropriate Oracle JDBC or
+  infrastructure read timeout. Micronaut Data does not set this timeout; it
+  applies to JDBC reads generally and must be tuned for the deployment. The
+  timeout does not determine the Oracle commit outcome.
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path

--- a/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
+++ b/src/main/docs/guide/shared/transactions/recoverableTransactions.adoc
@@ -97,12 +97,11 @@ If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut trea
 - Recovery is attempted only when commit handling or the commit acknowledgement
   produces an exception whose type matches the exception types configured by
   `on` (by default `java.sql.SQLRecoverableException`, including a matching
-  wrapped cause). If
-  a particular network and driver setup can leave JDBC operations waiting
-  indefinitely before an exception is surfaced, users may configure an
-  appropriate Oracle JDBC or infrastructure read timeout. Micronaut Data does
-  not set this timeout. It applies to JDBC reads generally and must be tuned
-  for the deployment; an immediate connection reset may not require one. The
-  timeout does not determine the Oracle commit outcome.
+  wrapped cause). If a particular network and driver setup can leave JDBC
+  operations waiting indefinitely before an exception is surfaced, users may
+  configure an appropriate Oracle JDBC or infrastructure read timeout.
+  Micronaut Data does not set this timeout. It applies to JDBC reads generally
+  and must be tuned for the deployment; an immediate connection reset may not
+  require one. The timeout does not determine the Oracle commit outcome
 - If Oracle reports `COMMITTED` with `USER_CALL_COMPLETED = FALSE`, Micronaut treats the transaction as committed, logs a warning, and returns the already produced result without replay
 - If you are already relying on TAF or Application Continuity to own the replay flow, do not add explicit transaction recovery on top of that path


### PR DESCRIPTION
Clarify that recovery starts only after JDBC reports a connection failure, and document that users may need to configure an appropriate Oracle JDBC or infrastructure read timeout for stalled network connections. State that Micronaut Data does not configure this timeout and that it does not determine the Oracle commit outcome.