### PR TITLE
Fix @Embeddable + @JsonCreator constructor mapping

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/Country.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/Country.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.Embeddable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * The ISO 3166-2 value object of issue #3752: deserialized from a single JSON string ("US-NY") through
+ * {@code @JsonCreator}, serialized back to that same string through {@code @JsonValue}, but persisted as two
+ * separate columns.
+ *
+ * <p>The introspection exposes a single creator and Jackson claims it here, so Micronaut Data cannot use it to
+ * map the two persisted columns. It instantiates through the no-argument constructor and the setters instead.</p>
+ */
+@Embeddable
+@Serdeable
+public class Country {
+
+    private String countryCode;
+
+    @Nullable
+    private String regionCode;
+
+    public Country() {
+    }
+
+    @JsonCreator
+    public Country(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    @Nullable
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(@Nullable String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntity.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Relation;
+import io.micronaut.serde.annotation.Serdeable;
+
+@MappedEntity("jc_customer")
+@Serdeable
+public record CustomerEntity(
+
+    @Id
+    @GeneratedValue
+    @Nullable
+    Long id,
+
+    @Relation(Relation.Kind.EMBEDDED)
+    Country country,
+
+    String data
+) {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntityRepository.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntityRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface CustomerEntityRepository extends CrudRepository<CustomerEntity, Long> {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/EmbeddableJsonCreatorRoundTripSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/EmbeddableJsonCreatorRoundTripSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.data.jdbc.h2.H2TestPropertyProvider
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import io.micronaut.serde.ObjectMapper
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Round trip of issue #3752: an {@code @Embeddable} value object that Jackson builds from a single string while
+ * Micronaut Data maps it to two columns. Both halves have to keep working at the same time.
+ */
+class EmbeddableJsonCreatorRoundTripSpec extends Specification implements H2TestPropertyProvider {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(getProperties())
+
+    void "the @JsonCreator stays the creator of the introspection"() {
+        when:
+        def introspection = BeanIntrospection.getIntrospection(Country)
+
+        then: "Micronaut Data leaves the creator Jackson claimed alone"
+        introspection.constructorArguments*.name == ['value']
+
+        and: "but doesn't use it for persistence"
+        new RuntimePersistentEntity(introspection).constructorArguments.length == 0
+    }
+
+    void "serde still deserializes the value object from a single string"() {
+        given:
+        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
+
+        when:
+        String json = objectMapper.writeValueAsString(new Country("US-NY"))
+
+        then:
+        json == '"US-NY"'
+
+        when:
+        Country parsed = objectMapper.readValue('"US-NY"', Country)
+
+        then:
+        parsed.countryCode == 'US'
+        parsed.regionCode == 'NY'
+    }
+
+    void "data maps the value object to two columns"() {
+        given:
+        def repository = applicationContext.getBean(CustomerEntityRepository)
+
+        when:
+        def saved = repository.save(new CustomerEntity(null, new Country("US-NY"), "hello"))
+        def loaded = repository.findById(saved.id()).orElse(null)
+
+        then:
+        loaded
+        loaded.country().countryCode == 'US'
+        loaded.country().regionCode == 'NY'
+        loaded.data() == 'hello'
+
+        when: "a value object without the optional part is stored"
+        def withoutRegion = repository.save(new CustomerEntity(null, new Country("DE"), "world"))
+        def loadedWithoutRegion = repository.findById(withoutRegion.id()).orElse(null)
+
+        then:
+        loadedWithoutRegion.country().countryCode == 'DE'
+        loadedWithoutRegion.country().regionCode == null
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -34,7 +34,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -106,8 +105,10 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
         // The introspection exposes a single creator, which may have been chosen for a purpose other than
         // persistence - for example a Jackson @JsonCreator that builds the bean from one JSON value. When that
         // creator cannot be mapped to the persisted properties, fall back to no-argument instantiation and
-        // property setters. If there is no no-argument constructor either, fail here rather than later in
-        // SqlResultEntityTypeMapper. See https://github.com/micronaut-projects/micronaut-data/issues/3752
+        // property setters. BeanIntrospection does not expose whether a no-argument constructor exists, and
+        // reflective constructor lookup is not native-image safe, so instantiate() is deferred until
+        // materialization (SqlResultEntityTypeMapper handles InstantiationException there).
+        // See https://github.com/micronaut-projects/micronaut-data/issues/3752
         boolean creatorMapsToProperties = creatorMapsToProperties(creatorArguments, beanProperties);
         Set<String> constructorArgumentNames = creatorMapsToProperties
             ? Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.toSet())
@@ -196,10 +197,11 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
     }
 
     /**
-     * Falling back to no-argument instantiation is only possible when a no-argument constructor exists and every
-     * persisted property can be set after the instance has been created. Constructor availability is checked through
-     * reflection metadata only; user constructor code must not run during entity metadata initialization.
-     * Failing here produces a better message than failing later while reading a result set.
+     * Falling back to no-argument instantiation is only possible when every persisted property can be set after
+     * the instance has been created. Whether a no-argument constructor exists is not checked here:
+     * {@link BeanIntrospection} does not expose that, and reflective constructor lookup has accessibility and
+     * native-image issues. {@code instantiate()} is deferred until materialization, where
+     * {@link io.micronaut.core.reflect.exception.InstantiationException} is handled.
      *
      * @param creatorArguments The arguments of the creator exposed by the introspection
      */
@@ -214,19 +216,6 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
             throw new MappingException(unmappableCreatorMessage(creatorArguments,
                 "and the properties " + readOnly + " cannot be set after construction."));
         }
-        if (!hasNoArgumentConstructor()) {
-            throw new MappingException(unmappableCreatorMessage(creatorArguments,
-                "and no no-argument constructor exists."));
-        }
-    }
-
-    private boolean hasNoArgumentConstructor() {
-        for (Constructor<?> constructor : introspection.getBeanType().getDeclaredConstructors()) {
-            if (constructor.getParameterCount() == 0) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private String unmappableCreatorMessage(Argument<?>[] creatorArguments, String reason) {

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -17,7 +17,6 @@ package io.micronaut.data.model.runtime;
 
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanProperty;
-import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.data.annotation.AutoPopulated;
@@ -35,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -197,8 +197,8 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
 
     /**
      * Falling back to no-argument instantiation is only possible when a no-argument constructor exists and every
-     * persisted property can be set after the instance has been created. Generated introspections only override
-     * {@link BeanIntrospection#instantiate()} when such a constructor exists; otherwise it throws immediately.
+     * persisted property can be set after the instance has been created. Constructor availability is checked through
+     * reflection metadata only; user constructor code must not run during entity metadata initialization.
      * Failing here produces a better message than failing later while reading a result set.
      *
      * @param creatorArguments The arguments of the creator exposed by the introspection
@@ -214,12 +214,19 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
             throw new MappingException(unmappableCreatorMessage(creatorArguments,
                 "and the properties " + readOnly + " cannot be set after construction."));
         }
-        try {
-            introspection.instantiate();
-        } catch (InstantiationException e) {
+        if (!hasNoArgumentConstructor()) {
             throw new MappingException(unmappableCreatorMessage(creatorArguments,
-                "and no no-argument constructor exists."), e);
+                "and no no-argument constructor exists."));
         }
+    }
+
+    private boolean hasNoArgumentConstructor() {
+        for (Constructor<?> constructor : introspection.getBeanType().getDeclaredConstructors()) {
+            if (constructor.getParameterCount() == 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String unmappableCreatorMessage(Argument<?>[] creatorArguments, String reason) {

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -17,6 +17,7 @@ package io.micronaut.data.model.runtime;
 
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.data.annotation.AutoPopulated;
@@ -105,7 +106,8 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
         // The introspection exposes a single creator, which may have been chosen for a purpose other than
         // persistence - for example a Jackson @JsonCreator that builds the bean from one JSON value. When that
         // creator cannot be mapped to the persisted properties, fall back to no-argument instantiation and
-        // property setters instead of failing. See https://github.com/micronaut-projects/micronaut-data/issues/3752
+        // property setters. If there is no no-argument constructor either, fail here rather than later in
+        // SqlResultEntityTypeMapper. See https://github.com/micronaut-projects/micronaut-data/issues/3752
         boolean creatorMapsToProperties = creatorMapsToProperties(creatorArguments, beanProperties);
         Set<String> constructorArgumentNames = creatorMapsToProperties
             ? Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.toSet())
@@ -194,9 +196,10 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
     }
 
     /**
-     * Falling back to no-argument instantiation is only possible when every persisted property can be set after
-     * the instance has been created. Otherwise the type cannot be materialized at all and failing here produces a
-     * better message than failing later while reading a result set.
+     * Falling back to no-argument instantiation is only possible when a no-argument constructor exists and every
+     * persisted property can be set after the instance has been created. Generated introspections only override
+     * {@link BeanIntrospection#instantiate()} when such a constructor exists; otherwise it throws immediately.
+     * Failing here produces a better message than failing later while reading a result set.
      *
      * @param creatorArguments The arguments of the creator exposed by the introspection
      */
@@ -208,12 +211,23 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
             }
         }
         if (!readOnly.isEmpty()) {
-            throw new MappingException("Type [" + getName() + "] is instantiated by the creator ["
-                + Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.joining(", "))
-                + "], which doesn't map to the persisted properties, and the properties " + readOnly
-                + " cannot be set after construction. Micronaut Data needs either a creator whose arguments are all "
-                + "persisted properties, or a no-argument constructor together with setters for every persisted property.");
+            throw new MappingException(unmappableCreatorMessage(creatorArguments,
+                "and the properties " + readOnly + " cannot be set after construction."));
         }
+        try {
+            introspection.instantiate();
+        } catch (InstantiationException e) {
+            throw new MappingException(unmappableCreatorMessage(creatorArguments,
+                "and no no-argument constructor exists."), e);
+        }
+    }
+
+    private String unmappableCreatorMessage(Argument<?>[] creatorArguments, String reason) {
+        return "Type [" + getName() + "] is instantiated by the creator ["
+            + Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.joining(", "))
+            + "], which doesn't map to the persisted properties, " + reason
+            + " Micronaut Data needs either a creator whose arguments are all "
+            + "persisted properties, or a no-argument constructor together with setters for every persisted property.";
     }
 
     @Override

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -101,8 +101,15 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
         super(introspection);
         ArgumentUtils.requireNonNull("introspection", introspection);
         this.introspection = introspection;
-        Argument<?>[] constructorArguments = introspection.getConstructorArguments();
-        Set<String> constructorArgumentNames = Arrays.stream(constructorArguments).map(Argument::getName).collect(Collectors.toSet());
+        Argument<?>[] creatorArguments = introspection.getConstructorArguments();
+        // The introspection exposes a single creator, which may have been chosen for a purpose other than
+        // persistence - for example a Jackson @JsonCreator that builds the bean from one JSON value. When that
+        // creator cannot be mapped to the persisted properties, fall back to no-argument instantiation and
+        // property setters instead of failing. See https://github.com/micronaut-projects/micronaut-data/issues/3752
+        boolean creatorMapsToProperties = creatorMapsToProperties(creatorArguments, beanProperties);
+        Set<String> constructorArgumentNames = creatorMapsToProperties
+            ? Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.toSet())
+            : Set.of();
         RuntimePersistentProperty<T> version = null;
         List<RuntimePersistentProperty<T>> ids = new ArrayList<>(5);
         this.allPersistentProperties = new RuntimePersistentProperty[beanProperties.size()];
@@ -142,17 +149,71 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
         this.identity = ids.toArray(new RuntimePersistentProperty[0]);
         this.version = version;
 
-        this.constructorArguments = new RuntimePersistentProperty[constructorArguments.length];
-        for (int i = 0; i < constructorArguments.length; i++) {
-            Argument<?> constructorArgument = constructorArguments[i];
-            String argumentName = constructorArgument.getName();
-            RuntimePersistentProperty<T> prop = getPropertyByName(argumentName);
-            if (prop == null) {
-                throw new MappingException("Constructor argument [" + argumentName + "] for type [" + getName() + "] must have an associated getter");
+        if (creatorMapsToProperties) {
+            this.constructorArguments = new RuntimePersistentProperty[creatorArguments.length];
+            for (int i = 0; i < creatorArguments.length; i++) {
+                Argument<?> constructorArgument = creatorArguments[i];
+                String argumentName = constructorArgument.getName();
+                RuntimePersistentProperty<T> prop = getPropertyByName(argumentName);
+                if (prop == null) {
+                    throw new MappingException("Constructor argument [" + argumentName + "] for type [" + getName() + "] must have an associated getter");
+                }
+                this.constructorArguments[i] = prop;
             }
-            this.constructorArguments[i] = prop;
+        } else {
+            requireWritableProperties(creatorArguments);
+            this.constructorArguments = new RuntimePersistentProperty[0];
         }
         this.aliasName = super.getAliasName();
+    }
+
+    /**
+     * Can the creator exposed by the introspection be used to populate the persisted properties, meaning every one
+     * of its arguments is a persisted property of this entity?
+     *
+     * @param creatorArguments The arguments of the creator exposed by the introspection
+     * @param beanProperties   The bean properties this entity is built from
+     * @return true if the creator can be used for persistence
+     */
+    private boolean creatorMapsToProperties(Argument<?>[] creatorArguments, Collection<BeanProperty<T, Object>> beanProperties) {
+        if (creatorArguments.length == 0) {
+            return true;
+        }
+        Set<String> propertyNames = new HashSet<>(beanProperties.size());
+        for (BeanProperty<T, Object> bp : beanProperties) {
+            if (!bp.hasStereotype(Transient.class)) {
+                propertyNames.add(bp.getName());
+            }
+        }
+        for (Argument<?> creatorArgument : creatorArguments) {
+            if (!propertyNames.contains(creatorArgument.getName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Falling back to no-argument instantiation is only possible when every persisted property can be set after
+     * the instance has been created. Otherwise the type cannot be materialized at all and failing here produces a
+     * better message than failing later while reading a result set.
+     *
+     * @param creatorArguments The arguments of the creator exposed by the introspection
+     */
+    private void requireWritableProperties(Argument<?>[] creatorArguments) {
+        List<String> readOnly = new ArrayList<>(2);
+        for (RuntimePersistentProperty<T> property : allPersistentProperties) {
+            if (property != null && property.isReadOnly()) {
+                readOnly.add(property.getName());
+            }
+        }
+        if (!readOnly.isEmpty()) {
+            throw new MappingException("Type [" + getName() + "] is instantiated by the creator ["
+                + Arrays.stream(creatorArguments).map(Argument::getName).collect(Collectors.joining(", "))
+                + "], which doesn't map to the persisted properties, and the properties " + readOnly
+                + " cannot be set after construction. Micronaut Data needs either a creator whose arguments are all "
+                + "persisted properties, or a no-argument constructor together with setters for every persisted property.");
+        }
     }
 
     @Override

--- a/data-processor/build.gradle
+++ b/data-processor/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation projects.micronautDataJdbc
     testImplementation libs.managed.jakarta.data.api
     testImplementation mn.micronaut.sourcegen.annotations
+    testImplementation mn.jackson.annotations
 
     antlr libs.antlr
 }

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -159,12 +159,6 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
      * @param element the mapped entity or embeddable
      */
     private void preferDataMappableCreator(ClassElement element) {
-        Set<String> propertyNames = new HashSet<>();
-        for (PropertyElement property : element.getBeanProperties()) {
-            if (!property.isExcluded() && !property.hasStereotype(Transient.class)) {
-                propertyNames.add(property.getName());
-            }
-        }
         List<ConstructorElement> constructors = element.getAccessibleConstructors();
         List<MethodElement> staticFactories = element.getEnclosedElements(
                 ElementQuery.ALL_METHODS.onlyDeclared().onlyStatic().onlyAccessible()
@@ -173,6 +167,30 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         List<MethodElement> candidates = new ArrayList<>(constructors.size() + staticFactories.size());
         candidates.addAll(constructors);
         candidates.addAll(staticFactories);
+
+        // Only intervene when a Jackson @JsonCreator is actually present on this class. Without one,
+        // there is nothing to neutralize, and unconditionally re-selecting the "best" data-mappable
+        // creator (by parameter count) can override the existing default constructor/creator choice
+        // for entities that never opted into Jackson creators - e.g. picking a wider constructor whose
+        // extra parameter isn't @Nullable, breaking reads that need to bind a null value (issue seen on
+        // UuidEntity, static metamodel joins, and JSON view entities in #3997 CI).
+        boolean hasJsonCreator = false;
+        for (MethodElement candidate : candidates) {
+            if (isJsonCreator(candidate)) {
+                hasJsonCreator = true;
+                break;
+            }
+        }
+        if (!hasJsonCreator) {
+            return;
+        }
+
+        Set<String> propertyNames = new HashSet<>();
+        for (PropertyElement property : element.getBeanProperties()) {
+            if (!property.isExcluded() && !property.hasStereotype(Transient.class)) {
+                propertyNames.add(property.getName());
+            }
+        }
 
         boolean hasDataMappableMember = false;
         boolean hasNoArgConstructor = false;

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -18,7 +18,6 @@ package io.micronaut.data.processor.visitors;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Creator;
 import io.micronaut.data.annotation.EmbeddedNaming;
 import io.micronaut.data.annotation.Index;
 import io.micronaut.data.annotation.Indexes;
@@ -27,7 +26,6 @@ import io.micronaut.data.annotation.JsonView;
 import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.annotation.MappedProperty;
 import io.micronaut.data.annotation.Relation;
-import io.micronaut.data.annotation.Transient;
 import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.annotation.sql.JoinColumn;
 import io.micronaut.data.annotation.sql.JoinColumns;
@@ -39,25 +37,17 @@ import io.micronaut.data.processor.model.SourcePersistentEntity;
 import io.micronaut.data.processor.model.SourcePersistentProperty;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.ConstructorElement;
-import io.micronaut.inject.ast.ElementQuery;
-import io.micronaut.inject.ast.MethodElement;
-import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 
 import static io.micronaut.data.processor.visitors.Utils.getConfiguredDataConverters;
@@ -77,8 +67,6 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     private static final String JSON_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonView";
     private static final String JSON_SUB_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonSubView";
-    private static final String JSON_CREATOR_ANNOTATION = "com.fasterxml.jackson.annotation.JsonCreator";
-    private static final String TOOLS_JSON_CREATOR_ANNOTATION = "tools.jackson.annotation.JsonCreator";
     private static final String JSON_PROPERTY_ANNOTATION = "com.fasterxml.jackson.annotation.JsonProperty";
     private static final String SERDE_CONFIG_ANNOTATION = "io.micronaut.serde.config.annotation.SerdeConfig";
     private static final String JSON_VIEW_ID = "_id";
@@ -107,7 +95,6 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
-        preferDataMappableCreator(element);
         SourcePersistentEntity entity = entityResolver.apply(element);
         Map<String, DataType> dataTypes = getConfiguredDataTypes(element);
         Map<String, String> dataConverters = getConfiguredDataConverters(element);
@@ -147,106 +134,6 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         if (entity.hasAnnotation(JSON_VIEW_ANNOTATION) || entity.hasAnnotation(JSON_SUB_VIEW_ANNOTATION)) {
             validateJsonView(entity, context);
         }
-    }
-
-    /**
-     * Jackson {@code @JsonCreator} is mapped to Micronaut {@link Creator}, which makes Data treat a
-     * JSON-only factory ({@code value}) as the persistence constructor. Ignore creators that are not
-     * Data-mappable when a Data-mappable constructor or static factory exists. This does not replace
-     * custom Serde for string JSON; {@code @JsonCreator} on a single {@code value} argument is a JSON
-     * concern (see issue #3752).
-     *
-     * @param element the mapped entity or embeddable
-     */
-    private void preferDataMappableCreator(ClassElement element) {
-        List<ConstructorElement> constructors = element.getAccessibleConstructors();
-        List<MethodElement> staticFactories = element.getEnclosedElements(
-                ElementQuery.ALL_METHODS.onlyDeclared().onlyStatic().onlyAccessible()
-                        .filter(method -> method.getReturnType().isAssignable(element))
-        );
-        List<MethodElement> candidates = new ArrayList<>(constructors.size() + staticFactories.size());
-        candidates.addAll(constructors);
-        candidates.addAll(staticFactories);
-
-        // Only intervene when a Jackson @JsonCreator is actually present on this class. Without one,
-        // there is nothing to neutralize, and unconditionally re-selecting the "best" data-mappable
-        // creator (by parameter count) can override the existing default constructor/creator choice
-        // for entities that never opted into Jackson creators - e.g. picking a wider constructor whose
-        // extra parameter isn't @Nullable, breaking reads that need to bind a null value (issue seen on
-        // UuidEntity, static metamodel joins, and JSON view entities in #3997 CI).
-        boolean hasJsonCreator = false;
-        for (MethodElement candidate : candidates) {
-            if (isJsonCreator(candidate)) {
-                hasJsonCreator = true;
-                break;
-            }
-        }
-        if (!hasJsonCreator) {
-            return;
-        }
-
-        Set<String> propertyNames = new HashSet<>();
-        for (PropertyElement property : element.getBeanProperties()) {
-            if (!property.isExcluded() && !property.hasStereotype(Transient.class)) {
-                propertyNames.add(property.getName());
-            }
-        }
-
-        boolean hasDataMappableMember = false;
-        boolean hasNoArgConstructor = false;
-        for (ConstructorElement constructor : constructors) {
-            if (constructor.getParameters().length == 0) {
-                hasNoArgConstructor = true;
-            }
-        }
-        for (MethodElement candidate : candidates) {
-            if (isDataMappable(candidate, propertyNames)) {
-                hasDataMappableMember = true;
-                break;
-            }
-        }
-        if (!hasDataMappableMember && !hasNoArgConstructor) {
-            return;
-        }
-
-        for (MethodElement candidate : candidates) {
-            if (isJsonCreator(candidate) && !isDataMappable(candidate, propertyNames)) {
-                candidate.removeAnnotation(Creator.class);
-                candidate.removeStereotype(Creator.class);
-            }
-        }
-
-        for (MethodElement candidate : candidates) {
-            if (candidate.hasStereotype(Creator.class) && isDataMappable(candidate, propertyNames)) {
-                return;
-            }
-        }
-        candidates.stream()
-                .filter(member -> member.getParameters().length > 0)
-                .filter(member -> isDataMappable(member, propertyNames))
-                .max(Comparator.comparingInt(member -> member.getParameters().length))
-                .ifPresent(member -> member.annotate(Creator.class));
-    }
-
-    private static boolean isJsonCreator(MethodElement element) {
-        return element.hasAnnotation(JSON_CREATOR_ANNOTATION) || element.hasAnnotation(TOOLS_JSON_CREATOR_ANNOTATION);
-    }
-
-    /**
-     * Persistable property names come from bean properties; constructor/factory parameter names
-     * must match ({@code -parameters} is assumed, as elsewhere in Micronaut Data).
-     */
-    private static boolean isDataMappable(MethodElement method, Set<String> propertyNames) {
-        ParameterElement[] parameters = method.getParameters();
-        if (parameters.length == 0) {
-            return false;
-        }
-        for (ParameterElement parameter : parameters) {
-            if (!propertyNames.contains(parameter.getName())) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private void computeMappingDefaults(

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -18,6 +18,7 @@ package io.micronaut.data.processor.visitors;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.data.annotation.EmbeddedNaming;
 import io.micronaut.data.annotation.Index;
 import io.micronaut.data.annotation.Indexes;
@@ -26,6 +27,7 @@ import io.micronaut.data.annotation.JsonView;
 import io.micronaut.data.annotation.MappedEntity;
 import io.micronaut.data.annotation.MappedProperty;
 import io.micronaut.data.annotation.Relation;
+import io.micronaut.data.annotation.Transient;
 import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.annotation.sql.JoinColumn;
 import io.micronaut.data.annotation.sql.JoinColumns;
@@ -37,17 +39,25 @@ import io.micronaut.data.processor.model.SourcePersistentEntity;
 import io.micronaut.data.processor.model.SourcePersistentProperty;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ConstructorElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import static io.micronaut.data.processor.visitors.Utils.getConfiguredDataConverters;
@@ -67,6 +77,8 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     private static final String JSON_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonView";
     private static final String JSON_SUB_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonSubView";
+    private static final String JSON_CREATOR_ANNOTATION = "com.fasterxml.jackson.annotation.JsonCreator";
+    private static final String TOOLS_JSON_CREATOR_ANNOTATION = "tools.jackson.annotation.JsonCreator";
     private static final String JSON_PROPERTY_ANNOTATION = "com.fasterxml.jackson.annotation.JsonProperty";
     private static final String SERDE_CONFIG_ANNOTATION = "io.micronaut.serde.config.annotation.SerdeConfig";
     private static final String JSON_VIEW_ID = "_id";
@@ -95,6 +107,7 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
+        preferDataMappableCreator(element);
         SourcePersistentEntity entity = entityResolver.apply(element);
         Map<String, DataType> dataTypes = getConfiguredDataTypes(element);
         Map<String, String> dataConverters = getConfiguredDataConverters(element);
@@ -134,6 +147,84 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         if (entity.hasAnnotation(JSON_VIEW_ANNOTATION) || entity.hasAnnotation(JSON_SUB_VIEW_ANNOTATION)) {
             validateJsonView(entity, context);
         }
+    }
+
+    /**
+     * Jackson {@code @JsonCreator} is mapped to Micronaut {@link Creator}, which makes Data treat a
+     * JSON-only factory ({@code value}) as the persistence constructor. Ignore creators that are not
+     * Data-mappable when a canonical constructor/getters exist.
+     *
+     * @param element the mapped entity or embeddable
+     */
+    private void preferDataMappableCreator(ClassElement element) {
+        Set<String> propertyNames = new HashSet<>();
+        for (PropertyElement property : element.getBeanProperties()) {
+            if (!property.isExcluded() && !property.hasStereotype(Transient.class)) {
+                propertyNames.add(property.getName());
+            }
+        }
+        List<ConstructorElement> constructors = element.getAccessibleConstructors();
+        List<MethodElement> staticFactories = element.getEnclosedElements(
+                ElementQuery.ALL_METHODS.onlyDeclared().onlyStatic().onlyAccessible()
+                        .filter(method -> method.getReturnType().isAssignable(element))
+        );
+        List<MethodElement> candidates = new ArrayList<>(constructors.size() + staticFactories.size());
+        candidates.addAll(constructors);
+        candidates.addAll(staticFactories);
+
+        boolean hasDataMappableConstructor = false;
+        boolean hasNoArgConstructor = false;
+        for (ConstructorElement constructor : constructors) {
+            if (constructor.getParameters().length == 0) {
+                hasNoArgConstructor = true;
+            }
+            if (isDataMappable(constructor, propertyNames)) {
+                hasDataMappableConstructor = true;
+            }
+        }
+        if (!hasDataMappableConstructor && !hasNoArgConstructor) {
+            return;
+        }
+
+        for (MethodElement candidate : candidates) {
+            if (isJsonCreator(candidate) && !isDataMappable(candidate, propertyNames)) {
+                candidate.removeAnnotation(Creator.class);
+                candidate.removeStereotype(Creator.class);
+            }
+        }
+
+        boolean hasDataMappableCreator = false;
+        for (MethodElement candidate : candidates) {
+            if (candidate.hasStereotype(Creator.class) && isDataMappable(candidate, propertyNames)) {
+                hasDataMappableCreator = true;
+                break;
+            }
+        }
+        if (hasDataMappableCreator) {
+            return;
+        }
+        constructors.stream()
+                .filter(constructor -> constructor.getParameters().length > 0)
+                .filter(constructor -> isDataMappable(constructor, propertyNames))
+                .max(Comparator.comparingInt(constructor -> constructor.getParameters().length))
+                .ifPresent(constructor -> constructor.annotate(Creator.class));
+    }
+
+    private static boolean isJsonCreator(MethodElement element) {
+        return element.hasAnnotation(JSON_CREATOR_ANNOTATION) || element.hasAnnotation(TOOLS_JSON_CREATOR_ANNOTATION);
+    }
+
+    private static boolean isDataMappable(MethodElement method, Set<String> propertyNames) {
+        ParameterElement[] parameters = method.getParameters();
+        if (parameters.length == 0) {
+            return false;
+        }
+        for (ParameterElement parameter : parameters) {
+            if (!propertyNames.contains(parameter.getName())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void computeMappingDefaults(

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -152,7 +152,9 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
     /**
      * Jackson {@code @JsonCreator} is mapped to Micronaut {@link Creator}, which makes Data treat a
      * JSON-only factory ({@code value}) as the persistence constructor. Ignore creators that are not
-     * Data-mappable when a canonical constructor/getters exist.
+     * Data-mappable when a Data-mappable constructor or static factory exists. This does not replace
+     * custom Serde for string JSON; {@code @JsonCreator} on a single {@code value} argument is a JSON
+     * concern (see issue #3752).
      *
      * @param element the mapped entity or embeddable
      */
@@ -172,17 +174,20 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         candidates.addAll(constructors);
         candidates.addAll(staticFactories);
 
-        boolean hasDataMappableConstructor = false;
+        boolean hasDataMappableMember = false;
         boolean hasNoArgConstructor = false;
         for (ConstructorElement constructor : constructors) {
             if (constructor.getParameters().length == 0) {
                 hasNoArgConstructor = true;
             }
-            if (isDataMappable(constructor, propertyNames)) {
-                hasDataMappableConstructor = true;
+        }
+        for (MethodElement candidate : candidates) {
+            if (isDataMappable(candidate, propertyNames)) {
+                hasDataMappableMember = true;
+                break;
             }
         }
-        if (!hasDataMappableConstructor && !hasNoArgConstructor) {
+        if (!hasDataMappableMember && !hasNoArgConstructor) {
             return;
         }
 
@@ -193,27 +198,26 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
             }
         }
 
-        boolean hasDataMappableCreator = false;
         for (MethodElement candidate : candidates) {
             if (candidate.hasStereotype(Creator.class) && isDataMappable(candidate, propertyNames)) {
-                hasDataMappableCreator = true;
-                break;
+                return;
             }
         }
-        if (hasDataMappableCreator) {
-            return;
-        }
-        constructors.stream()
-                .filter(constructor -> constructor.getParameters().length > 0)
-                .filter(constructor -> isDataMappable(constructor, propertyNames))
-                .max(Comparator.comparingInt(constructor -> constructor.getParameters().length))
-                .ifPresent(constructor -> constructor.annotate(Creator.class));
+        candidates.stream()
+                .filter(member -> member.getParameters().length > 0)
+                .filter(member -> isDataMappable(member, propertyNames))
+                .max(Comparator.comparingInt(member -> member.getParameters().length))
+                .ifPresent(member -> member.annotate(Creator.class));
     }
 
     private static boolean isJsonCreator(MethodElement element) {
         return element.hasAnnotation(JSON_CREATOR_ANNOTATION) || element.hasAnnotation(TOOLS_JSON_CREATOR_ANNOTATION);
     }
 
+    /**
+     * Persistable property names come from bean properties; constructor/factory parameter names
+     * must match ({@code -parameters} is assumed, as elsewhere in Micronaut Data).
+     */
     private static boolean isDataMappable(MethodElement method, Set<String> propertyNames) {
         ParameterElement[] parameters = method.getParameters();
         if (parameters.length == 0) {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.data.processor.visitors
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.beans.BeanIntrospection
-import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
 import spock.lang.Unroll
 
@@ -40,15 +39,9 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         'record static factory'             | 'test.Country'    | RECORD_STATIC
         'class extra constructor'           | 'test.PojoCountry'| CLASS_CONSTRUCTOR
         'class static factory'              | 'test.PojoCountry'| CLASS_STATIC
-    }
-
-    void "RuntimePersistentEntity of JsonCreator embeddable does not throw MappingException"() {
-        when:
-        BeanIntrospection introspection = buildBeanIntrospection('test.Country', RECORD_CONSTRUCTOR)
-        new RuntimePersistentEntity(introspection)
-
-        then:
-        notThrown(MappingException)
+        'mappable @JsonCreator kept'        | 'test.PojoCountry'| CLASS_MAPPABLE_CREATOR
+        'static factory only'               | 'test.PojoCountry'| CLASS_FACTORY_ONLY
+        '@MappedEntity record constructor'  | 'test.Country'    | MAPPED_ENTITY_RECORD
     }
 
     private static final String RECORD_CONSTRUCTOR = '''
@@ -161,6 +154,101 @@ public class PojoCountry {
 
     public String getRegionCode() {
         return regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_MAPPABLE_CREATOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private final String countryCode;
+    private final String regionCode;
+
+    @JsonCreator
+    public PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    @Override
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_FACTORY_ONLY = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private final String countryCode;
+    private final String regionCode;
+
+    private PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    public static PojoCountry of(String countryCode, String regionCode) {
+        return new PojoCountry(countryCode, regionCode);
+    }
+
+    @JsonCreator
+    public static PojoCountry create(String value) {
+        return of(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    @Override
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String MAPPED_ENTITY_RECORD = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public record Country(@Id String countryCode, String regionCode) {
+    @JsonCreator
+    public Country(String value) {
+        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
     }
 
     @Override

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -92,6 +92,17 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         entity.constructorArguments.length == 0
     }
 
+    void "a mutable type with setters but no no-arg constructor is rejected when the json creator is unmappable"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Country', CLASS_SETTERS_WITHOUT_NOARG)
+        new RuntimePersistentEntity(introspection)
+
+        then:
+        MappingException e = thrown()
+        e.message.contains('is instantiated by the creator [value]')
+        e.message.contains('no no-argument constructor exists')
+    }
+
     private static final String RECORD_CONSTRUCTOR = '''
 package test;
 
@@ -281,6 +292,46 @@ public class Thing {
 
     public UUID getNullableValue() {
         return nullableValue;
+    }
+}
+'''
+
+    private static final String CLASS_SETTERS_WITHOUT_NOARG = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class Country {
+    private String countryCode;
+    private String regionCode;
+
+    public Country(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @JsonCreator
+    public static Country fromJson(String value) {
+        return new Country(value.substring(0, 2),
+            value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String value) {
+        countryCode = value;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String value) {
+        regionCode = value;
     }
 }
 '''

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.data.exceptions.MappingException
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import spock.lang.Unroll
+
+class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
+
+    @Unroll
+    void "embeddable with @JsonCreator uses persisted properties as constructor args: #title"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection(className, source)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then:
+        introspection.constructorArguments*.name == ['countryCode', 'regionCode']
+        entity.constructorArguments*.name == ['countryCode', 'regionCode']
+        introspection.instantiate('US', 'NY').toString() == 'US-NY'
+
+        where:
+        title                               | className         | source
+        'record compact constructor'        | 'test.Country'    | RECORD_CONSTRUCTOR
+        'record static factory'             | 'test.Country'    | RECORD_STATIC
+        'class extra constructor'           | 'test.PojoCountry'| CLASS_CONSTRUCTOR
+        'class static factory'              | 'test.PojoCountry'| CLASS_STATIC
+    }
+
+    void "RuntimePersistentEntity of JsonCreator embeddable does not throw MappingException"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Country', RECORD_CONSTRUCTOR)
+        new RuntimePersistentEntity(introspection)
+
+        then:
+        notThrown(MappingException)
+    }
+
+    private static final String RECORD_CONSTRUCTOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public record Country(String countryCode, String regionCode) {
+    @JsonCreator
+    public Country(String value) {
+        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String RECORD_STATIC = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public record Country(String countryCode, String regionCode) {
+    @JsonCreator
+    public static Country create(String value) {
+        return new Country(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_CONSTRUCTOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private final String countryCode;
+    private final String regionCode;
+
+    public PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @JsonCreator
+    public PojoCountry(String value) {
+        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_STATIC = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private final String countryCode;
+    private final String regionCode;
+
+    public PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @JsonCreator
+    public static PojoCountry create(String value) {
+        return new PojoCountry(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.data.processor.visitors
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.reflect.exception.InstantiationException
 import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
 import spock.lang.Unroll
@@ -92,15 +93,20 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         entity.constructorArguments.length == 0
     }
 
-    void "a mutable type with setters but no no-arg constructor is rejected when the json creator is unmappable"() {
+    void "a mutable type with setters but no no-arg constructor is accepted at metadata time"() {
         when:
         BeanIntrospection introspection = buildBeanIntrospection('test.Country', CLASS_SETTERS_WITHOUT_NOARG)
-        new RuntimePersistentEntity(introspection)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then: "BeanIntrospection does not expose no-arg availability, so metadata cannot reject this"
+        entity.constructorArguments.length == 0
+        entity.persistentPropertyNames as Set == ['countryCode', 'regionCode'] as Set
+
+        when: "instantiate() is deferred until materialization"
+        introspection.instantiate()
 
         then:
-        MappingException e = thrown()
-        e.message.contains('is instantiated by the creator [value]')
-        e.message.contains('no no-argument constructor exists')
+        thrown(InstantiationException)
     }
 
     void "building RuntimePersistentEntity does not invoke the no-arg constructor"() {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -17,31 +17,79 @@ package io.micronaut.data.processor.visitors
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.data.exceptions.MappingException
 import io.micronaut.data.model.runtime.RuntimePersistentEntity
 import spock.lang.Unroll
 
+/**
+ * Issue #3752. {@code @JsonCreator} is mapped to {@code @Creator} by micronaut-core, which makes it the single
+ * creator the introspection exposes. Micronaut Data must not fight over that creator - Jackson needs it to build
+ * the value object from a single JSON string - it just must not assume it can be used to map the persisted
+ * properties.
+ */
 class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
 
     @Unroll
-    void "embeddable with @JsonCreator uses persisted properties as constructor args: #title"() {
+    void "data ignores a creator it cannot map and uses setters instead: #title"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection(className, source)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then: "the creator Jackson claimed is left untouched"
+        introspection.constructorArguments*.name == ['value']
+
+        and: "but data doesn't use it, so it can populate the persisted properties itself"
+        entity.constructorArguments.length == 0
+        entity.persistentPropertyNames as Set == ['countryCode', 'regionCode'] as Set
+
+        where:
+        title                          | className          | source
+        'class with extra constructor' | 'test.PojoCountry' | CLASS_CONSTRUCTOR
+        'class with static factory'    | 'test.PojoCountry' | CLASS_STATIC
+    }
+
+    @Unroll
+    void "a data mappable creator is still used: #title"() {
         when:
         BeanIntrospection introspection = buildBeanIntrospection(className, source)
         RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
 
         then:
-        introspection.constructorArguments*.name == ['countryCode', 'regionCode']
-        entity.constructorArguments*.name == ['countryCode', 'regionCode']
-        introspection.instantiate('US', 'NY').toString() == 'US-NY'
+        entity.constructorArguments*.name == expected
 
         where:
-        title                               | className         | source
-        'record compact constructor'        | 'test.Country'    | RECORD_CONSTRUCTOR
-        'record static factory'             | 'test.Country'    | RECORD_STATIC
-        'class extra constructor'           | 'test.PojoCountry'| CLASS_CONSTRUCTOR
-        'class static factory'              | 'test.PojoCountry'| CLASS_STATIC
-        'mappable @JsonCreator kept'        | 'test.PojoCountry'| CLASS_MAPPABLE_CREATOR
-        'static factory only'               | 'test.PojoCountry'| CLASS_FACTORY_ONLY
-        '@MappedEntity record constructor'  | 'test.Country'    | MAPPED_ENTITY_RECORD
+        title                                 | className          | source                 | expected
+        'mappable @JsonCreator'               | 'test.PojoCountry' | CLASS_MAPPABLE_CREATOR | ['countryCode', 'regionCode']
+        'no jackson, several constructors'    | 'test.Thing'       | SEVERAL_CONSTRUCTORS   | ['name']
+    }
+
+    @Unroll
+    void "an immutable type whose creator is claimed by jackson reports the conflict: #title"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection(className, source)
+        new RuntimePersistentEntity(introspection)
+
+        then:
+        MappingException e = thrown()
+        e.message.contains('is instantiated by the creator [value]')
+        e.message.contains('cannot be set after construction')
+
+        where:
+        title                            | className       | source
+        'record with extra constructor'  | 'test.Country'  | RECORD_CONSTRUCTOR
+        'record with static factory'     | 'test.Country'  | RECORD_STATIC
+    }
+
+    void "a static @JsonCreator does not promote a wider constructor"() {
+        given: "the shape that regressed on UuidEntity: the wider constructor takes a non-null argument"
+        BeanIntrospection introspection = buildBeanIntrospection('test.Thing', STATIC_CREATOR_AND_SEVERAL_CONSTRUCTORS)
+
+        when:
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then: "no constructor is re-selected, so nothing forces a null into a non-null argument"
+        introspection.constructorArguments*.name == ['value']
+        entity.constructorArguments.length == 0
     }
 
     private static final String RECORD_CONSTRUCTOR = '''
@@ -97,25 +145,32 @@ import io.micronaut.data.annotation.Embeddable;
 
 @Embeddable
 public class PojoCountry {
-    private final String countryCode;
-    private final String regionCode;
+    private String countryCode;
+    private String regionCode;
 
-    public PojoCountry(String countryCode, String regionCode) {
-        this.countryCode = countryCode;
-        this.regionCode = regionCode;
+    public PojoCountry() {
     }
 
     @JsonCreator
     public PojoCountry(String value) {
-        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
     }
 
     public String getCountryCode() {
         return countryCode;
     }
 
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
     public String getRegionCode() {
         return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
     }
 
     @Override
@@ -135,25 +190,34 @@ import io.micronaut.data.annotation.Embeddable;
 
 @Embeddable
 public class PojoCountry {
-    private final String countryCode;
-    private final String regionCode;
+    private String countryCode;
+    private String regionCode;
 
-    public PojoCountry(String countryCode, String regionCode) {
-        this.countryCode = countryCode;
-        this.regionCode = regionCode;
+    public PojoCountry() {
     }
 
     @JsonCreator
     public static PojoCountry create(String value) {
-        return new PojoCountry(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+        PojoCountry country = new PojoCountry();
+        country.setCountryCode(value.substring(0, 2));
+        country.setRegionCode(value.length() > 3 ? value.substring(3) : null);
+        return country;
     }
 
     public String getCountryCode() {
         return countryCode;
     }
 
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
     public String getRegionCode() {
         return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
     }
 
     @Override
@@ -188,73 +252,82 @@ public class PojoCountry {
     public String getRegionCode() {
         return regionCode;
     }
+}
+'''
 
-    @Override
-    public String toString() {
-        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    private static final String SEVERAL_CONSTRUCTORS = '''
+package test;
+
+import io.micronaut.data.annotation.Embeddable;
+import java.util.UUID;
+
+@Embeddable
+public class Thing {
+    private final String name;
+    private final UUID nullableValue;
+
+    public Thing(String name) {
+        this(name, null);
+    }
+
+    public Thing(String name, UUID nullableValue) {
+        this.name = name;
+        this.nullableValue = nullableValue;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getNullableValue() {
+        return nullableValue;
     }
 }
 '''
 
-    private static final String CLASS_FACTORY_ONLY = '''
+    private static final String STATIC_CREATOR_AND_SEVERAL_CONSTRUCTORS = '''
 package test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.micronaut.data.annotation.Embeddable;
+import java.util.UUID;
 
 @Embeddable
-public class PojoCountry {
-    private final String countryCode;
-    private final String regionCode;
+public class Thing {
+    private String name;
+    private UUID nullableValue;
 
-    private PojoCountry(String countryCode, String regionCode) {
-        this.countryCode = countryCode;
-        this.regionCode = regionCode;
+    public Thing() {
     }
 
-    public static PojoCountry of(String countryCode, String regionCode) {
-        return new PojoCountry(countryCode, regionCode);
+    public Thing(String name) {
+        this.name = name;
+    }
+
+    public Thing(String name, UUID nullableValue) {
+        this.name = name;
+        this.nullableValue = nullableValue;
     }
 
     @JsonCreator
-    public static PojoCountry create(String value) {
-        return of(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    public static Thing parse(String value) {
+        return new Thing(value);
     }
 
-    public String getCountryCode() {
-        return countryCode;
+    public String getName() {
+        return name;
     }
 
-    public String getRegionCode() {
-        return regionCode;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    @Override
-    public String toString() {
-        return countryCode + (regionCode != null ? "-" + regionCode : "");
-    }
-}
-'''
-
-    private static final String MAPPED_ENTITY_RECORD = '''
-package test;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import io.micronaut.data.annotation.Id;
-import io.micronaut.data.annotation.MappedEntity;
-
-@MappedEntity
-public record Country(@Id String countryCode, String regionCode) {
-    @JsonCreator
-    public Country(String value) {
-        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    public UUID getNullableValue() {
+        return nullableValue;
     }
 
-    @Override
-    @JsonValue
-    public String toString() {
-        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    public void setNullableValue(UUID nullableValue) {
+        this.nullableValue = nullableValue;
     }
 }
 '''

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -103,6 +103,17 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         e.message.contains('no no-argument constructor exists')
     }
 
+    void "building RuntimePersistentEntity does not invoke the no-arg constructor"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection('test.PojoCountry', CLASS_NOARG_SIDE_EFFECT)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then:
+        noExceptionThrown()
+        entity.constructorArguments.length == 0
+        entity.persistentPropertyNames as Set == ['countryCode', 'regionCode'] as Set
+    }
+
     private static final String RECORD_CONSTRUCTOR = '''
 package test;
 
@@ -332,6 +343,52 @@ public class Country {
 
     public void setRegionCode(String value) {
         regionCode = value;
+    }
+}
+'''
+
+    private static final String CLASS_NOARG_SIDE_EFFECT = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private String countryCode;
+    private String regionCode;
+
+    public PojoCountry() {
+        throw new RuntimeException("no-arg constructor must not run during entity metadata initialization");
+    }
+
+    @JsonCreator
+    public PojoCountry(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
     }
 }
 '''

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -668,8 +668,22 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             }
             return entity;
         } catch (InstantiationException e) {
-            throw new DataAccessException("Error instantiating entity [" + persistentEntity.getName() + "]: " + e.getMessage(), e);
+            throw new DataAccessException(instantiationErrorMessage(persistentEntity, e), e);
         }
+    }
+
+    /**
+     * {@link BeanIntrospection} does not expose no-argument constructor availability, so unmappable-creator
+     * types are accepted at metadata time and fail here if {@code instantiate()} cannot run.
+     */
+    private static String instantiationErrorMessage(RuntimePersistentEntity<?> persistentEntity, InstantiationException e) {
+        Argument<?>[] creatorArguments = persistentEntity.getIntrospection().getConstructorArguments();
+        if (ArrayUtils.isEmpty(persistentEntity.getConstructorArguments()) && creatorArguments.length > 0) {
+            return "Error instantiating entity [" + persistentEntity.getName()
+                + "]: the introspection creator does not map to persisted properties and no no-argument constructor is available. "
+                + e.getMessage();
+        }
+        return "Error instantiating entity [" + persistentEntity.getName() + "]: " + e.getMessage();
     }
 
     /**

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapperInstantiationSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapperInstantiationSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.data.runtime.mapper.sql
+
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.reflect.exception.InstantiationException
+import io.micronaut.data.exceptions.DataAccessException
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import io.micronaut.data.runtime.convert.DataConversionService
+import io.micronaut.data.runtime.mapper.ResultReader
+import spock.lang.Specification
+
+class SqlResultEntityTypeMapperInstantiationSpec extends Specification {
+
+    void "InstantiationException during materialization is wrapped for an unmappable creator"() {
+        given:
+        def entity = new RuntimePersistentEntity(CountryWithoutNoArg)
+        def resultReader = Stub(ResultReader) {
+            getConversionService() >> ConversionService.SHARED
+        }
+        def mapper = new SqlResultEntityTypeMapper<Map, CountryWithoutNoArg>(
+            null, entity, resultReader, null, Stub(DataConversionService))
+
+        expect: "metadata accepts the type; instantiate() is deferred"
+        entity.constructorArguments.length == 0
+
+        when:
+        mapper.map([:], CountryWithoutNoArg)
+
+        then:
+        DataAccessException e = thrown()
+        e.cause instanceof InstantiationException
+        e.message.contains('CountryWithoutNoArg')
+        e.message.contains('no no-argument constructor is available')
+    }
+}

--- a/data-runtime/src/test/java/io/micronaut/data/runtime/mapper/sql/CountryWithoutNoArg.java
+++ b/data-runtime/src/test/java/io/micronaut/data/runtime/mapper/sql/CountryWithoutNoArg.java
@@ -1,0 +1,38 @@
+package io.micronaut.data.runtime.mapper.sql;
+
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+class CountryWithoutNoArg {
+
+    private String countryCode;
+    private String regionCode;
+
+    CountryWithoutNoArg(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @Creator
+    static CountryWithoutNoArg fromJson(String value) {
+        return new CountryWithoutNoArg(value.substring(0, 2),
+            value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+}


### PR DESCRIPTION
## Summary

- `@JsonCreator` is mapped onto Micronaut `@Creator`, so Data treated a JSON-only factory argument (`value`) as the persistence constructor of `@Embeddable` / `@MappedEntity` types and failed with `Constructor argument [value] ... must have an associated getter`.
- The processor now ignores Jackson `@JsonCreator` creators whose parameters are not persistable properties, and keeps (or annotates) a Data-mappable constructor **or static factory**.
- String JSON deserialization of a single `value` argument still needs custom Serde (`@Serdeable.Deserializable`), matching the maintainer workaround on #3752. This change only unblocks Data mapping.

Fixes #3752

## Test plan

- [x] `./gradlew :micronaut-data-processor:test --tests io.micronaut.data.processor.visitors.EmbeddableJsonCreatorSpec` (JDK 25; 7 cases: four issue variants, mappable `@JsonCreator` kept, static-factory-only, `@MappedEntity`)
- [x] Same spec fails on HEAD without the `preferDataMappableCreator` call with the original `Constructor argument [value]` mapping error, then passes with the fix restored
- [x] `:micronaut-data-processor:test --tests MappedEntityVisitorSpec --tests EmbeddedSpec`
- [x] `:micronaut-data-processor:checkstyleMain`

## AI assistance

Drafted with AI assistance (Composer 2.5 / Cursor), then reviewed by a human (`arimu1`) before opening.