### PR TITLE
fix: keep ANTLR tooling off runtime classpath

### DIFF
--- a/data-processor/build.gradle
+++ b/data-processor/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 	api projects.micronautDataModel
 	api(mnSql.jakarta.persistence.api)
 
-    implementation libs.antlr.runtime
+	api libs.antlr.runtime
 
 	compileOnly mn.micronaut.core.processor
     compileOnly libs.managed.jakarta.data.stateful

--- a/data-processor/build.gradle
+++ b/data-processor/build.gradle
@@ -3,6 +3,14 @@ plugins {
     id 'antlr'
 }
 
+// The Gradle ANTLR plugin wires its tooling configuration into `api`, which
+// would otherwise expose the parser generator and all of its transitive
+// dependencies at runtime. ANTLR is only needed to generate sources; the
+// generated parser itself uses the runtime dependency declared below.
+configurations.named("api") {
+    setExtendsFrom(extendsFrom.findAll { it.name != "antlr" })
+}
+
 dependencies {
 	api projects.micronautDataModel
 	api(mnSql.jakarta.persistence.api)


### PR DESCRIPTION
### Problem
Gradle's ANTLR plugin adds its tooling configuration to `api` (Gradle issue #820), causing `antlr4` and parser/tooling transitive dependencies to appear in the processor runtime and test classpaths.

### Fix
Detach the ANTLR tooling configuration from `api`; retain `antlr4-runtime` as the implementation dependency used by the generated parser.

### Verification
- `./gradlew :micronaut-data-processor:dependencies --configuration runtimeClasspath`
- `./gradlew :micronaut-data-processor:dependencies --configuration testRuntimeClasspath` (only `org.antlr:antlr4-runtime:4.13.2`)
- `./gradlew :micronaut-data-processor:test --no-parallel` (1067 tests passed, 4 skipped)