### PR TITLE
Fix Kotlin 2.4 coroutine generic bounds

### DIFF
--- a/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/CoroutineJpaSpecificationExecutor.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/CoroutineJpaSpecificationExecutor.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.2
  */
-interface CoroutineJpaSpecificationExecutor<T> {
+interface CoroutineJpaSpecificationExecutor<T : Any> {
 
     /**
      * Returns a single entity matching the given [QuerySpecification].

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutineCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutineCrudRepository.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.1.0
  */
-interface CoroutineCrudRepository<E, ID> : GenericRepository<E, ID> {
+interface CoroutineCrudRepository<E : Any, ID : Any> : GenericRepository<E, ID> {
 
     /**
      * Saves the given valid entity, returning a possibly new entity representing the saved state.

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.4.0
  */
-interface CoroutinePageableCrudRepository<E, ID> : CoroutineCrudRepository<E, ID> {
+interface CoroutinePageableCrudRepository<E : Any, ID : Any> : CoroutineCrudRepository<E, ID> {
 
     /**
      * Find all results for the given sort order.

--- a/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/CoroutineTransactionOperations.kt
+++ b/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/CoroutineTransactionOperations.kt
@@ -43,7 +43,7 @@ interface CoroutineTransactionOperations<C> {
      * @param <R> The result type
      * @return The result
      */
-    suspend fun <R> execute(definition: TransactionDefinition, handler: suspend (CoroutineTransactionStatus<C>) -> R): R
+    suspend fun <R : Any> execute(definition: TransactionDefinition, handler: suspend (CoroutineTransactionStatus<C>) -> R): R
 
     /**
      * Execute the given handler with a new transaction.
@@ -51,6 +51,6 @@ interface CoroutineTransactionOperations<C> {
      * @param <R> The result type
      * @return The result
      */
-    suspend fun <R> execute(handler: suspend (CoroutineTransactionStatus<C>) -> R) = execute(TransactionDefinition.DEFAULT, handler)
+    suspend fun <R : Any> execute(handler: suspend (CoroutineTransactionStatus<C>) -> R) = execute(TransactionDefinition.DEFAULT, handler)
 
 }

--- a/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperations.kt
+++ b/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperations.kt
@@ -43,9 +43,9 @@ import kotlin.coroutines.CoroutineContext
 @EachBean(ReactorReactiveTransactionOperations::class)
 @Singleton
 @Internal
-class DefaultCoroutineTransactionOperations<C>(private val reactiveTransactionOperations: ReactorReactiveTransactionOperations<C>) : CoroutineTransactionOperations<C> {
+class DefaultCoroutineTransactionOperations<C : Any>(private val reactiveTransactionOperations: ReactorReactiveTransactionOperations<C>) : CoroutineTransactionOperations<C> {
 
-    override suspend fun <R> execute(definition: TransactionDefinition,
+    override suspend fun <R : Any> execute(definition: TransactionDefinition,
                                      handler: suspend (CoroutineTransactionStatus<C>) -> R): R {
         return reactiveTransactionOperations.withTransaction(definition) {
             mono<R> {

--- a/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionStatus.kt
+++ b/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionStatus.kt
@@ -27,7 +27,7 @@ import io.micronaut.transaction.reactive.ReactiveTransactionStatus
  * @since 4.2.0
  */
 @Internal
-class DefaultCoroutineTransactionStatus<T>(var status: ReactiveTransactionStatus<T>) :
+class DefaultCoroutineTransactionStatus<T : Any>(var status: ReactiveTransactionStatus<T>) :
     CoroutineTransactionStatus<T> {
 
     override val connection: T


### PR DESCRIPTION
This completes the Kotlin 2.4.10 upgrade started in #3958.

Kotlin 2.4 applies the JSpecify nullness bounds from Micronaut Data’s Java APIs more strictly. The coroutine API type parameters therefore need explicit non-null (`Any`) bounds so that `Page`, `GenericRepository`, transaction state, and Reactor result types satisfy their Java declarations.

The change is deliberately limited to the declarations reported by the Kotlin compiler; it does not alter runtime behavior or broaden the dependency upgrade.

Verification:
- Reproduced the Kotlin 2.4 compilation errors on the exact Renovate head with Temurin JDK 25.
- `./gradlew :micronaut-data-model:compileKotlin :micronaut-data-tx:compileKotlin --no-daemon --console=plain`
- `./gradlew :micronaut-data-model:check :micronaut-data-tx:check --no-daemon --continue --console=plain` (219 tests passed; Spotless, Checkstyle, and binary-compatibility checks passed)
- Compiled all eight downstream Kotlin Hibernate, JDBC, R2DBC, and Mongo example modules.
- `git diff --check`

A repository-wide `check jacocoReport` also progressed beyond the original compiler failure; its integration-test phase requires a local Docker daemon, which was unavailable in this environment.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
