### PR TITLE
Fix @Embeddable / @MappedEntity types whose introspection creator is a Jackson @JsonCreator

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/Country.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/Country.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.Embeddable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * The ISO 3166-2 value object of issue #3752: deserialized from a single JSON string ("US-NY") through
+ * {@code @JsonCreator}, serialized back to that same string through {@code @JsonValue}, but persisted as two
+ * separate columns.
+ *
+ * <p>The introspection exposes a single creator and Jackson claims it here, so Micronaut Data cannot use it to
+ * map the two persisted columns. It instantiates through the no-argument constructor and the setters instead.</p>
+ */
+@Embeddable
+@Serdeable
+public class Country {
+
+    private String countryCode;
+
+    @Nullable
+    private String regionCode;
+
+    public Country() {
+    }
+
+    @JsonCreator
+    public Country(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    @Nullable
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(@Nullable String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntity.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Relation;
+import io.micronaut.serde.annotation.Serdeable;
+
+@MappedEntity("jc_customer")
+@Serdeable
+public record CustomerEntity(
+
+    @Id
+    @GeneratedValue
+    @Nullable
+    Long id,
+
+    @Relation(Relation.Kind.EMBEDDED)
+    @Nullable
+    Country country,
+
+    String data
+) {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntityRepository.java
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/CustomerEntityRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.H2)
+public interface CustomerEntityRepository extends CrudRepository<CustomerEntity, Long> {
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/EmbeddableJsonCreatorRoundTripSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/jsoncreator/EmbeddableJsonCreatorRoundTripSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.h2.jsoncreator
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.data.annotation.InstantiateWithDefaultConstructor
+import io.micronaut.data.jdbc.h2.H2TestPropertyProvider
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import io.micronaut.serde.ObjectMapper
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Round trip of issue #3752: an {@code @Embeddable} value object that Jackson builds from a single string while
+ * Micronaut Data maps it to two columns. Both halves have to keep working at the same time.
+ */
+class EmbeddableJsonCreatorRoundTripSpec extends Specification implements H2TestPropertyProvider {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(getProperties())
+
+    void "the @JsonCreator stays the creator of the introspection"() {
+        when:
+        def introspection = BeanIntrospection.getIntrospection(Country)
+
+        then: "Micronaut Data leaves the creator Jackson claimed alone"
+        introspection.constructorArguments*.name == ['value']
+
+        and: "the processor marked the type to be instantiated with its default constructor"
+        introspection.hasAnnotation(InstantiateWithDefaultConstructor)
+        new RuntimePersistentEntity(introspection).constructorArguments.length == 0
+    }
+
+    void "serde still deserializes the value object from a single string"() {
+        given:
+        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
+
+        when:
+        String json = objectMapper.writeValueAsString(new Country("US-NY"))
+
+        then:
+        json == '"US-NY"'
+
+        when:
+        Country parsed = objectMapper.readValue('"US-NY"', Country)
+
+        then:
+        parsed.countryCode == 'US'
+        parsed.regionCode == 'NY'
+    }
+
+    void "data maps the value object to two columns"() {
+        given:
+        def repository = applicationContext.getBean(CustomerEntityRepository)
+
+        when:
+        def saved = repository.save(new CustomerEntity(null, new Country("US-NY"), "hello"))
+        def loaded = repository.findById(saved.id()).orElse(null)
+
+        then:
+        loaded
+        loaded.country().countryCode == 'US'
+        loaded.country().regionCode == 'NY'
+        loaded.data() == 'hello'
+
+        when: "a value object without the optional part is stored"
+        def withoutRegion = repository.save(new CustomerEntity(null, new Country("DE"), "world"))
+        def loadedWithoutRegion = repository.findById(withoutRegion.id()).orElse(null)
+
+        then:
+        loadedWithoutRegion.country().countryCode == 'DE'
+        loadedWithoutRegion.country().regionCode == null
+    }
+
+    void "an optional embedded whose columns are all null is loaded as null"() {
+        given:
+        def repository = applicationContext.getBean(CustomerEntityRepository)
+
+        when:
+        def saved = repository.save(new CustomerEntity(null, null, "no country"))
+        def loaded = repository.findById(saved.id()).orElse(null)
+
+        then:
+        loaded.country() == null
+        loaded.data() == 'no country'
+    }
+}

--- a/data-model/src/main/java/io/micronaut/data/annotation/InstantiateWithDefaultConstructor.java
+++ b/data-model/src/main/java/io/micronaut/data/annotation/InstantiateWithDefaultConstructor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.annotation;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Internal metadata computed by the annotation processor: the type is instantiated with its no-argument constructor
+ * and populated through property setters, because the creator exposed by its bean introspection is not usable for
+ * persistence - for example a Jackson {@code @JsonCreator} that builds a value object from a single JSON value.
+ *
+ * @since 5.2.0
+ */
+@Internal
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Documented
+public @interface InstantiateWithDefaultConstructor {
+}

--- a/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
+++ b/data-model/src/main/java/io/micronaut/data/model/runtime/RuntimePersistentEntity.java
@@ -22,6 +22,7 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.GeneratedValue;
 import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.InstantiateWithDefaultConstructor;
 import io.micronaut.data.annotation.Relation;
 import io.micronaut.data.annotation.Transient;
 import io.micronaut.data.annotation.Version;
@@ -101,7 +102,12 @@ public class RuntimePersistentEntity<T> extends AbstractPersistentEntity {
         super(introspection);
         ArgumentUtils.requireNonNull("introspection", introspection);
         this.introspection = introspection;
-        Argument<?>[] constructorArguments = introspection.getConstructorArguments();
+        // The introspection creator can be reserved for another purpose (a Jackson @JsonCreator building the type
+        // from a single JSON value); the annotation processor then marks the type to be instantiated with its
+        // default constructor and populated through setters instead.
+        Argument<?>[] constructorArguments = introspection.hasAnnotation(InstantiateWithDefaultConstructor.class)
+            ? Argument.ZERO_ARGUMENTS
+            : introspection.getConstructorArguments();
         Set<String> constructorArgumentNames = Arrays.stream(constructorArguments).map(Argument::getName).collect(Collectors.toSet());
         RuntimePersistentProperty<T> version = null;
         List<RuntimePersistentProperty<T>> ids = new ArrayList<>(5);

--- a/data-processor/build.gradle
+++ b/data-processor/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation projects.micronautDataJdbc
     testImplementation libs.managed.jakarta.data.api
     testImplementation mn.micronaut.sourcegen.annotations
+    testImplementation mn.jackson.annotations
 
     antlr libs.antlr
 }

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.data.annotation.EmbeddedNaming;
 import io.micronaut.data.annotation.Index;
 import io.micronaut.data.annotation.Indexes;
+import io.micronaut.data.annotation.InstantiateWithDefaultConstructor;
 import io.micronaut.data.annotation.JsonSubView;
 import io.micronaut.data.annotation.JsonView;
 import io.micronaut.data.annotation.MappedEntity;
@@ -37,18 +38,24 @@ import io.micronaut.data.processor.model.SourcePersistentEntity;
 import io.micronaut.data.processor.model.SourcePersistentProperty;
 import io.micronaut.data.processor.visitors.finders.TypeUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ConstructorElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static io.micronaut.data.processor.visitors.Utils.getConfiguredDataConverters;
 import static io.micronaut.data.processor.visitors.Utils.getConfiguredDataTypes;
@@ -67,6 +74,8 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     private static final String JSON_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonView";
     private static final String JSON_SUB_VIEW_ANNOTATION = "io.micronaut.data.annotation.JsonSubView";
+    private static final String JSON_CREATOR_ANNOTATION = "com.fasterxml.jackson.annotation.JsonCreator";
+    private static final String JACKSON3_JSON_CREATOR_ANNOTATION = "tools.jackson.annotation.JsonCreator";
     private static final String JSON_PROPERTY_ANNOTATION = "com.fasterxml.jackson.annotation.JsonProperty";
     private static final String SERDE_CONFIG_ANNOTATION = "io.micronaut.serde.config.annotation.SerdeConfig";
     private static final String JSON_VIEW_ID = "_id";
@@ -96,6 +105,7 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
         SourcePersistentEntity entity = entityResolver.apply(element);
+        resolveJsonCreatorConflict(element, entity);
         Map<String, DataType> dataTypes = getConfiguredDataTypes(element);
         Map<String, String> dataConverters = getConfiguredDataConverters(element);
         boolean legacyEmbeddedNaming = isLegacyEmbeddedNaming(element, context);
@@ -134,6 +144,81 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         if (entity.hasAnnotation(JSON_VIEW_ANNOTATION) || entity.hasAnnotation(JSON_SUB_VIEW_ANNOTATION)) {
             validateJsonView(entity, context);
         }
+    }
+
+    /**
+     * Jackson's {@code @JsonCreator} is mapped to {@link io.micronaut.core.annotation.Creator}, which makes it the
+     * single creator exposed by the bean introspection. When its arguments are not persistent properties (a value
+     * object built from one JSON value, see issue #3752) the introspection creator cannot be used to instantiate
+     * the type from the persisted columns. The type is then instantiated with its no-argument constructor and
+     * populated through setters, which is recorded with {@link InstantiateWithDefaultConstructor}; when that is not
+     * possible compilation fails with a description of the conflict instead of a mapping error at runtime.
+     *
+     * @param element The entity or embeddable
+     * @param entity  The source persistent entity
+     */
+    private void resolveJsonCreatorConflict(ClassElement element, SourcePersistentEntity entity) {
+        MethodElement creator = element.getPrimaryConstructor().orElse(null);
+        if (creator == null || !isJsonCreator(creator)) {
+            return;
+        }
+        List<String> unmappedArguments = new ArrayList<>();
+        for (ParameterElement parameter : creator.getParameters()) {
+            if (entity.getPropertyByName(parameter.getName()) == null) {
+                unmappedArguments.add(parameter.getName());
+            }
+        }
+        if (unmappedArguments.isEmpty()) {
+            return;
+        }
+        List<String> readOnlyProperties = new ArrayList<>();
+        for (SourcePersistentProperty property : allPersistentProperties(entity)) {
+            if (property.getPropertyElement().isReadOnly()) {
+                readOnlyProperties.add(property.getName());
+            }
+        }
+        boolean hasDefaultConstructor = element.getDefaultConstructor().isPresent();
+        if (hasDefaultConstructor && readOnlyProperties.isEmpty()) {
+            element.annotate(InstantiateWithDefaultConstructor.class);
+            return;
+        }
+        List<String> reasons = new ArrayList<>(2);
+        if (!hasDefaultConstructor) {
+            reasons.add("there is no accessible no-argument constructor");
+        }
+        if (!readOnlyProperties.isEmpty()) {
+            reasons.add("the properties " + readOnlyProperties + " cannot be set after construction");
+        }
+        throw new ProcessingException(creator, "@JsonCreator " + describeCreator(element, creator)
+            + " is the bean introspection creator of [" + element.getName() + "] but its argument(s) " + unmappedArguments
+            + " are not persistent properties, so Micronaut Data cannot instantiate the type from the persisted columns, and "
+            + String.join(" and ", reasons)
+            + ". Either add a no-argument constructor and setters for all persistent properties, "
+            + "or remove @JsonCreator and use a custom Serde deserializer (@Serdeable.Deserializable(using = ...)).");
+    }
+
+    private static boolean isJsonCreator(MethodElement element) {
+        return element.hasAnnotation(JSON_CREATOR_ANNOTATION) || element.hasAnnotation(JACKSON3_JSON_CREATOR_ANNOTATION);
+    }
+
+    private static List<SourcePersistentProperty> allPersistentProperties(SourcePersistentEntity entity) {
+        List<SourcePersistentProperty> properties = new ArrayList<>(entity.getPersistentProperties());
+        if (entity.hasCompositeIdentity()) {
+            properties.addAll(Arrays.asList(entity.getCompositeIdentity()));
+        } else if (entity.hasIdentity()) {
+            properties.add(entity.getIdentity());
+        }
+        if (entity.hasVersion()) {
+            properties.add(entity.getVersion());
+        }
+        return properties;
+    }
+
+    private static String describeCreator(ClassElement element, MethodElement creator) {
+        String name = creator instanceof ConstructorElement ? element.getSimpleName() : element.getSimpleName() + "." + creator.getName();
+        return name + "(" + Arrays.stream(creator.getParameters())
+            .map(parameter -> parameter.getType().getSimpleName() + " " + parameter.getName())
+            .collect(Collectors.joining(", ")) + ")";
     }
 
     private void computeMappingDefaults(

--- a/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/visitors/MappedEntityVisitor.java
@@ -171,10 +171,14 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
         if (unmappedArguments.isEmpty()) {
             return;
         }
+        // getPersistentPropertyNames() and getPropertyByName() are backed by the same map, which also holds the
+        // identity, the composite identity components and the version, so both checks above and here see the very
+        // same definition of "persistent property"
         List<String> readOnlyProperties = new ArrayList<>();
-        for (SourcePersistentProperty property : allPersistentProperties(entity)) {
-            if (property.getPropertyElement().isReadOnly()) {
-                readOnlyProperties.add(property.getName());
+        for (String propertyName : entity.getPersistentPropertyNames()) {
+            SourcePersistentProperty property = entity.getPropertyByName(propertyName);
+            if (property != null && property.getPropertyElement().isReadOnly()) {
+                readOnlyProperties.add(propertyName);
             }
         }
         boolean hasDefaultConstructor = element.getDefaultConstructor().isPresent();
@@ -199,19 +203,6 @@ public class MappedEntityVisitor implements TypeElementVisitor<MappedEntity, Obj
 
     private static boolean isJsonCreator(MethodElement element) {
         return element.hasAnnotation(JSON_CREATOR_ANNOTATION) || element.hasAnnotation(JACKSON3_JSON_CREATOR_ANNOTATION);
-    }
-
-    private static List<SourcePersistentProperty> allPersistentProperties(SourcePersistentEntity entity) {
-        List<SourcePersistentProperty> properties = new ArrayList<>(entity.getPersistentProperties());
-        if (entity.hasCompositeIdentity()) {
-            properties.addAll(Arrays.asList(entity.getCompositeIdentity()));
-        } else if (entity.hasIdentity()) {
-            properties.add(entity.getIdentity());
-        }
-        if (entity.hasVersion()) {
-            properties.add(entity.getVersion());
-        }
-        return properties;
     }
 
     private static String describeCreator(ClassElement element, MethodElement creator) {

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -62,9 +62,10 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         entity.constructorArguments*.name == expected
 
         where:
-        title                              | className          | source                 | expected
-        'mappable @JsonCreator'            | 'test.PojoCountry' | CLASS_MAPPABLE_CREATOR | ['countryCode', 'regionCode']
-        'no jackson, several constructors' | 'test.Thing'       | SEVERAL_CONSTRUCTORS   | ['name']
+        title                              | className              | source                 | expected
+        'mappable @JsonCreator'            | 'test.PojoCountry'     | CLASS_MAPPABLE_CREATOR | ['countryCode', 'regionCode']
+        'no jackson, several constructors' | 'test.Thing'           | SEVERAL_CONSTRUCTORS   | ['name']
+        'arguments are the id and version' | 'test.VersionedThing'  | ID_AND_VERSION_CREATOR | ['id', 'version', 'name']
     }
 
     @Unroll
@@ -85,6 +86,7 @@ class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
         'class with final fields and two constructors' | 'test.PojoCountry' | CLASS_FINAL_FIELDS        | 'PojoCountry(String value)'    | 'there is no accessible no-argument constructor'
         'mutable class without no-arg constructor'   | 'test.Country'     | CLASS_SETTERS_WITHOUT_NOARG | 'Country.fromJson(String value)' | 'there is no accessible no-argument constructor'
         'default constructor but read-only property' | 'test.Country'     | CLASS_NOARG_READ_ONLY       | 'Country(String value)'        | 'the properties [regionCode] cannot be set after construction'
+        'default constructor but read-only id'       | 'test.ReadOnlyIdEntity' | ENTITY_READ_ONLY_ID    | 'ReadOnlyIdEntity(String value)' | 'the properties [id] cannot be set after construction'
     }
 
     // Issue #3752, first variant
@@ -330,6 +332,82 @@ public class PojoCountry {
 
     public String getRegionCode() {
         return regionCode;
+    }
+}
+'''
+
+    // The identity and the version are persistent properties too, so a creator built from them is mappable
+    private static final String ID_AND_VERSION_CREATOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Version;
+
+@MappedEntity
+public class VersionedThing {
+    @Id
+    private final Long id;
+    @Version
+    private final Long version;
+    private final String name;
+
+    @JsonCreator
+    public VersionedThing(Long id, Long version, String name) {
+        this.id = id;
+        this.version = version;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public String getName() {
+        return name;
+    }
+}
+'''
+
+    // The read-only scan has to see the identity as well, not just the plain properties
+    private static final String ENTITY_READ_ONLY_ID = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class ReadOnlyIdEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+
+    public ReadOnlyIdEntity() {
+    }
+
+    @JsonCreator
+    public ReadOnlyIdEntity(String value) {
+        this.name = value;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }
 '''

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/visitors/EmbeddableJsonCreatorSpec.groovy
@@ -1,0 +1,487 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.processor.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.data.annotation.InstantiateWithDefaultConstructor
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import spock.lang.Unroll
+
+/**
+ * Issue #3752. {@code @JsonCreator} is mapped to {@code @Creator} by micronaut-core, which makes it the single
+ * creator the introspection exposes. Micronaut Data must not fight over that creator - Jackson needs it to build
+ * the value object from a single JSON string - it just must not assume it can be used to map the persisted
+ * properties.
+ */
+class EmbeddableJsonCreatorSpec extends AbstractTypeElementSpec {
+
+    @Unroll
+    void "a type whose @JsonCreator cannot be mapped is instantiated with its default constructor: #title"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection(className, source)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then: "the creator Jackson claimed is left untouched"
+        introspection.constructorArguments*.name == ['value']
+
+        and: "the processor recorded the fallback and data doesn't use the creator"
+        introspection.hasAnnotation(InstantiateWithDefaultConstructor)
+        entity.constructorArguments.length == 0
+        entity.persistentPropertyNames as Set == propertyNames as Set
+
+        where:
+        title                                | className                | source                                | propertyNames
+        'class with extra constructor'       | 'test.PojoCountry'       | CLASS_CONSTRUCTOR                     | ['countryCode', 'regionCode']
+        'class with static factory'          | 'test.PojoCountry'       | CLASS_STATIC                          | ['countryCode', 'regionCode']
+        'static factory, several constructors' | 'test.Thing'           | STATIC_CREATOR_AND_SEVERAL_CONSTRUCTORS | ['name', 'nullableValue']
+        'mapped entity'                      | 'test.PojoCountryEntity' | ENTITY_CONSTRUCTOR                    | ['id', 'countryCode', 'regionCode']
+    }
+
+    @Unroll
+    void "a data mappable creator is still used: #title"() {
+        when:
+        BeanIntrospection introspection = buildBeanIntrospection(className, source)
+        RuntimePersistentEntity entity = new RuntimePersistentEntity(introspection)
+
+        then:
+        !introspection.hasAnnotation(InstantiateWithDefaultConstructor)
+        entity.constructorArguments*.name == expected
+
+        where:
+        title                              | className          | source                 | expected
+        'mappable @JsonCreator'            | 'test.PojoCountry' | CLASS_MAPPABLE_CREATOR | ['countryCode', 'regionCode']
+        'no jackson, several constructors' | 'test.Thing'       | SEVERAL_CONSTRUCTORS   | ['name']
+    }
+
+    @Unroll
+    void "a type whose creator is claimed by jackson and cannot use a default constructor fails to compile: #title"() {
+        when:
+        buildBeanIntrospection(className, source)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("@JsonCreator $creator is the bean introspection creator of [$className] but its argument(s) [value] are not persistent properties")
+        e.message.contains(reason)
+        e.message.contains('remove @JsonCreator and use a custom Serde deserializer')
+
+        where:
+        title                                        | className          | source                      | creator                        | reason
+        'record with extra constructor'              | 'test.Country'     | RECORD_CONSTRUCTOR          | 'Country(String value)'        | 'there is no accessible no-argument constructor and the properties [countryCode, regionCode] cannot be set after construction'
+        'record with static factory'                 | 'test.Country'     | RECORD_STATIC               | 'Country.create(String value)' | 'there is no accessible no-argument constructor and the properties [countryCode, regionCode] cannot be set after construction'
+        'class with final fields and two constructors' | 'test.PojoCountry' | CLASS_FINAL_FIELDS        | 'PojoCountry(String value)'    | 'there is no accessible no-argument constructor'
+        'mutable class without no-arg constructor'   | 'test.Country'     | CLASS_SETTERS_WITHOUT_NOARG | 'Country.fromJson(String value)' | 'there is no accessible no-argument constructor'
+        'default constructor but read-only property' | 'test.Country'     | CLASS_NOARG_READ_ONLY       | 'Country(String value)'        | 'the properties [regionCode] cannot be set after construction'
+    }
+
+    // Issue #3752, first variant
+    private static final String RECORD_CONSTRUCTOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public record Country(String countryCode, String regionCode) {
+    @JsonCreator
+    public Country(String value) {
+        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    // Issue #3752, second variant
+    private static final String RECORD_STATIC = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public record Country(String countryCode, String regionCode) {
+    @JsonCreator
+    public static Country create(String value) {
+        return new Country(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    // Issue #3752, third variant
+    private static final String CLASS_FINAL_FIELDS = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    public final String countryCode;
+    public final String regionCode;
+
+    public PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @JsonCreator
+    public PojoCountry(String value) {
+        this(value.substring(0, 2), value.length() > 3 ? value.substring(3) : null);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_CONSTRUCTOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private String countryCode;
+    private String regionCode;
+
+    public PojoCountry() {
+    }
+
+    @JsonCreator
+    public PojoCountry(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String CLASS_STATIC = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private String countryCode;
+    private String regionCode;
+
+    public PojoCountry() {
+    }
+
+    @JsonCreator
+    public static PojoCountry create(String value) {
+        PojoCountry country = new PojoCountry();
+        country.setCountryCode(value.substring(0, 2));
+        country.setRegionCode(value.length() > 3 ? value.substring(3) : null);
+        return country;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return countryCode + (regionCode != null ? "-" + regionCode : "");
+    }
+}
+'''
+
+    private static final String ENTITY_CONSTRUCTOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class PojoCountryEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String countryCode;
+    private String regionCode;
+
+    public PojoCountryEntity() {
+    }
+
+    @JsonCreator
+    public PojoCountryEntity(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+}
+'''
+
+    private static final String CLASS_MAPPABLE_CREATOR = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class PojoCountry {
+    private final String countryCode;
+    private final String regionCode;
+
+    @JsonCreator
+    public PojoCountry(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+}
+'''
+
+    private static final String SEVERAL_CONSTRUCTORS = '''
+package test;
+
+import io.micronaut.data.annotation.Embeddable;
+import java.util.UUID;
+
+@Embeddable
+public class Thing {
+    private final String name;
+    private final UUID nullableValue;
+
+    public Thing(String name) {
+        this(name, null);
+    }
+
+    public Thing(String name, UUID nullableValue) {
+        this.name = name;
+        this.nullableValue = nullableValue;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getNullableValue() {
+        return nullableValue;
+    }
+}
+'''
+
+    private static final String CLASS_SETTERS_WITHOUT_NOARG = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class Country {
+    private String countryCode;
+    private String regionCode;
+
+    public Country(String countryCode, String regionCode) {
+        this.countryCode = countryCode;
+        this.regionCode = regionCode;
+    }
+
+    @JsonCreator
+    public static Country fromJson(String value) {
+        return new Country(value.substring(0, 2),
+            value.length() > 3 ? value.substring(3) : null);
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String value) {
+        countryCode = value;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String value) {
+        regionCode = value;
+    }
+}
+'''
+
+    private static final String CLASS_NOARG_READ_ONLY = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+
+@Embeddable
+public class Country {
+    private String countryCode;
+    private String regionCode;
+
+    public Country() {
+    }
+
+    @JsonCreator
+    public Country(String value) {
+        this.countryCode = value.substring(0, 2);
+        this.regionCode = value.length() > 3 ? value.substring(3) : null;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+}
+'''
+
+    private static final String STATIC_CREATOR_AND_SEVERAL_CONSTRUCTORS = '''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.data.annotation.Embeddable;
+import java.util.UUID;
+
+@Embeddable
+public class Thing {
+    private String name;
+    private UUID nullableValue;
+
+    public Thing() {
+    }
+
+    public Thing(String name) {
+        this.name = name;
+    }
+
+    public Thing(String name, UUID nullableValue) {
+        this.name = name;
+        this.nullableValue = nullableValue;
+    }
+
+    @JsonCreator
+    public static Thing parse(String value) {
+        return new Thing(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public UUID getNullableValue() {
+        return nullableValue;
+    }
+
+    public void setNullableValue(UUID nullableValue) {
+        this.nullableValue = nullableValue;
+    }
+}
+'''
+}

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -513,8 +513,11 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             }
 
             K entity;
+            // An optional embedded instantiated with its default constructor is null when none of its columns has a value
+            boolean nullIfNoValue = false;
             if (ArrayUtils.isEmpty(constructorArguments)) {
                 entity = introspection.instantiate();
+                nullIfNoValue = nullableEmbedded;
             } else {
                 int len = constructorArguments.length;
                 @Nullable Object[] args = new Object[len];
@@ -604,6 +607,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     entity = convertAndSetWithValue(entity, version, version.getProperty(), v);
                 }
             }
+            boolean hasValue = id != null;
             for (RuntimePersistentProperty<K> rpp : persistentEntity.getPersistentProperties()) {
                 if (rpp.isReadOnly()) {
                     continue;
@@ -621,11 +625,15 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                 if (rpp instanceof RuntimeAssociation<K> entityAssociation) {
                     if (rpp instanceof Embedded embedded) {
                         Object value = readEntity(rs, ctx.embedded(embedded), parent == null ? entity : parent, null);
+                        if (value != null) {
+                            hasValue = true;
+                        }
                         entity = setProperty(property, entity, value);
                     } else {
                         final boolean isInverse = parent != null && entityAssociation.getKind().isSingleEnded() && ctx.association != null && ctx.association.getOwner() == entityAssociation.getAssociatedEntity();
                         // Before setting property value, check if mappedBy is not different from the property name
                         if (isInverse && mappedByMatchesOrEmpty(Objects.requireNonNull(ctx.association), property)) {
+                            hasValue = true;
                             entity = setProperty(property, entity, parent);
                         } else {
                             MappingContext<K> joinCtx = ctx.join(fetchJoinPaths, entityAssociation);
@@ -639,6 +647,9 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                             if (joinCtx.jp != null) {
                                 if (entityAssociation.getKind().isSingleEnded()) {
                                     Object associatedEntity = readEntity(rs, joinCtx, entity, associatedId);
+                                    if (associatedEntity != null) {
+                                        hasValue = true;
+                                    }
                                     entity = setProperty(property, entity, associatedEntity);
                                 } else {
                                     MappingContext<K> associatedCtx = joinCtx.copy();
@@ -647,6 +658,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                                     }
                                     Object associatedEntity = readEntity(rs, associatedCtx, entity, associatedId);
                                     if (associatedEntity != null) {
+                                        hasValue = true;
                                         Objects.requireNonNull(associatedId);
                                         joinCtx.associate(associatedCtx, associatedId, associatedEntity);
                                     } else if (joinCtx.manyAssociations == null) {
@@ -655,6 +667,9 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                                 }
                             } else if (entityAssociation.getKind().isSingleEnded() && !entityAssociation.isForeignKey()) {
                                 Object value = buildIdOnlyEntity(rs, ctx.path(entityAssociation), associatedId);
+                                if (value != null) {
+                                    hasValue = true;
+                                }
                                 entity = setProperty(property, entity, value);
                             }
                         }
@@ -662,9 +677,13 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                 } else {
                     Object v = readProperty(rs, ctx, rpp);
                     if (v != null) {
+                        hasValue = true;
                         entity = convertAndSetWithValue(entity, rpp, property, v);
                     }
                 }
+            }
+            if (nullIfNoValue && !hasValue) {
+                return null;
             }
             return entity;
         } catch (InstantiationException e) {


### PR DESCRIPTION
Supersedes #3997 (thanks @arimu1 for the analysis and the test scaffolding, which this PR keeps).

## Problem

Jackson's `@JsonCreator` is mapped to `@Creator`, so it becomes the single creator exposed by the bean introspection. For a value object built from one JSON value (`Country(String value)` in #3752) that creator has no relation to the persisted columns, and `RuntimePersistentEntity` failed with `Constructor argument [value] ... must have an associated getter`.

## Approach

#3997 detected the conflict at runtime, where `BeanIntrospection` cannot tell whether a no-argument constructor exists, so it had to accept any unmappable creator and defer the failure to the first query. This PR moves the decision to the annotation processor, which sees all constructors:

- `MappedEntityVisitor` (also used for `@Embeddable`) checks whether the primary constructor is a `@JsonCreator` whose arguments are not persistent properties.
  - If the type has an accessible no-argument constructor and every persistent property is writable, it is annotated with the new internal `@InstantiateWithDefaultConstructor`.
  - Otherwise compilation fails with a message describing the conflict and the two ways out (add a no-arg constructor + setters, or drop `@JsonCreator` in favour of a custom Serde deserializer, the workaround from #3752).
- `RuntimePersistentEntity` treats a type carrying the marker as having no constructor arguments; every other type keeps the existing behaviour, including the eager `MappingException` for genuinely mis-declared constructors.
- `SqlResultEntityTypeMapper`: an optional `@Relation(EMBEDDED)` instantiated through its default constructor is now loaded as `null` when none of its columns has a value, matching the constructor-argument path. Before, any setter-based embeddable came back as a non-null instance with all-null fields.

The `@JsonCreator` itself is left untouched, so Serde keeps deserializing the value object from a single string (covered by the H2 round-trip spec).

## What this does and does not fix

- Mutable value objects (no-arg constructor + setters) with a `@JsonCreator`/`@JsonValue` pair now work with JDBC/R2DBC. The H2 spec round-trips #3752's `CustomerEntity` / `Country` through both Serde and the repository.
- Immutable types (all four variants reported in #3752 are records or final-field classes) still cannot be supported: one introspection has one creator, and Serde needs it to be the `@JsonCreator`. They now fail at **compile time** with an explanation instead of at runtime with the getter message. The custom Serde deserializer remains the answer for those.
- MongoDB / Azure Cosmos deserialize entities through Serde and are not affected by the fallback.

## Test plan

- [x] `:micronaut-data-processor:test --tests EmbeddableJsonCreatorSpec` (11 cases: fallback for classes, static factories and `@MappedEntity`; mappable creators untouched; compile errors for the immutable variants of #3752, a mutable class without a no-arg constructor, and a read-only property)
- [x] `:micronaut-data-jdbc:test --tests EmbeddableJsonCreatorRoundTripSpec` (introspection creator untouched, Serde round trip, two-column mapping, optional embedded loaded as `null`)
- [x] `:micronaut-data-processor:test`, `:micronaut-data-runtime:test`, `:micronaut-data-jdbc:test --tests 'io.micronaut.data.jdbc.h2.*'`
- [x] `checkstyleMain` for data-model, data-runtime, data-processor

Closes #3752
Closes #3997

🤖 Generated with [Claude Code](https://claude.com/claude-code)
