### PR TITLE
Cache JDBC column ordinals in SqlResultEntityTypeMapper

### DIFF
--- a/benchmarks/benchmark-micronaut-data-jdbc/build.gradle
+++ b/benchmarks/benchmark-micronaut-data-jdbc/build.gradle
@@ -9,4 +9,9 @@ dependencies {
     runtimeOnly mnSql.micronaut.jdbc.hikari
     runtimeOnly mnSql.h2
     runtimeOnly mn.snakeyaml
+
+    // Drivers for running the result set mapping benchmark against a database other than the default H2
+    jmh mnSql.ojdbc11
+    jmh mnSql.postgresql
+    jmh mnSql.mysql.connector.j
 }

--- a/benchmarks/benchmark-micronaut-data-jdbc/src/jmh/java/benchmark/ResultSetMapping.java
+++ b/benchmarks/benchmark-micronaut-data-jdbc/src/jmh/java/benchmark/ResultSetMapping.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package benchmark;
+
+import example.WideBook;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.data.jdbc.mapper.ColumnNameResultSetReader;
+import io.micronaut.data.model.runtime.RuntimePersistentEntity;
+import io.micronaut.data.model.runtime.RuntimePersistentProperty;
+import io.micronaut.data.runtime.convert.DataConversionService;
+import io.micronaut.data.runtime.mapper.AbstractDelegatingResultReader;
+import io.micronaut.data.runtime.mapper.ResultReader;
+import io.micronaut.data.runtime.mapper.sql.SqlResultEntityTypeMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Measures {@link SqlResultEntityTypeMapper} reading a result set of a wide entity.
+ *
+ * <p>The {@code columnIndexes} parameter switches the column ordinal caching on and off: when off the mapper is
+ * given a reader that reports no column index reader, which is how the mapper behaved before the ordinals were
+ * cached. Both arms therefore run the same binary and differ only in that one flag.</p>
+ *
+ * <p>The query is executed once and re-read with a scrollable result set, so the measured work is the mapping of
+ * the rows rather than the execution of the statement. A mapper is created per invocation, the way the repository
+ * operations create one per query execution.</p>
+ *
+ * <p>By default this runs against in-memory H2, which resolves a column label with a map lookup. Point it at
+ * another database to measure a driver with a more expensive resolution, for example the Oracle driver which
+ * quotes the identifier on every lookup:</p>
+ *
+ * <pre>{@code -Dbench.jdbc.url=jdbc:oracle:thin:@//localhost:1521/FREEPDB1
+ * -Dbench.jdbc.user=system -Dbench.jdbc.password=...}</pre>
+ */
+@State(Scope.Benchmark)
+public class ResultSetMapping {
+
+    private static final String URL_PROPERTY = "bench.jdbc.url";
+    private static final String USER_PROPERTY = "bench.jdbc.user";
+    private static final String PASSWORD_PROPERTY = "bench.jdbc.password";
+    private static final String DEFAULT_URL = "jdbc:h2:mem:mapperbench;DB_CLOSE_DELAY=-1";
+
+    @Param({"1", "10", "100"})
+    int rows;
+
+    @Param({"true", "false"})
+    boolean columnIndexes;
+
+    private ApplicationContext applicationContext;
+    private Connection connection;
+    private PreparedStatement statement;
+    private ResultSet resultSet;
+    private RuntimePersistentEntity<WideBook> entity;
+    private ResultReader<ResultSet, String> resultReader;
+    private DataConversionService conversionService;
+    private String quote;
+    private boolean oracle;
+
+    @Setup
+    public void prepare() throws SQLException {
+        applicationContext = ApplicationContext.run();
+        conversionService = applicationContext.getBean(DataConversionService.class);
+        entity = new RuntimePersistentEntity<>(WideBook.class);
+
+        ColumnNameResultSetReader nameReader = new ColumnNameResultSetReader(conversionService);
+        resultReader = columnIndexes ? nameReader : new NoColumnIndexReader(nameReader);
+
+        connection = DriverManager.getConnection(
+            System.getProperty(URL_PROPERTY, DEFAULT_URL),
+            System.getProperty(USER_PROPERTY, "sa"),
+            System.getProperty(PASSWORD_PROPERTY, ""));
+        // Quote every identifier so the result set labels match the names the mapper asks for exactly
+        quote = connection.getMetaData().getIdentifierQuoteString();
+        oracle = connection.getMetaData().getDatabaseProductName().toLowerCase().contains("oracle");
+        createTable();
+        insertRows();
+
+        statement = connection.prepareStatement(
+            "SELECT * FROM " + quoted(entity.getPersistedName()),
+            ResultSet.TYPE_SCROLL_INSENSITIVE,
+            ResultSet.CONCUR_READ_ONLY);
+        resultSet = statement.executeQuery();
+    }
+
+    @TearDown
+    public void cleanup() throws SQLException {
+        resultSet.close();
+        statement.close();
+        dropTable();
+        connection.close();
+        applicationContext.close();
+    }
+
+    /**
+     * Maps every row of the result set with a mapper created for this result set.
+     */
+    @Benchmark
+    public List<WideBook> mapRows() throws SQLException {
+        resultSet.beforeFirst();
+        SqlResultEntityTypeMapper.PushingMapper<ResultSet, List<WideBook>> mapper =
+            new SqlResultEntityTypeMapper<ResultSet, WideBook>(entity, resultReader, Set.of(), null, conversionService)
+                .readManyMapper();
+        while (resultSet.next()) {
+            mapper.processRow(resultSet);
+        }
+        return mapper.getResult();
+    }
+
+    private void createTable() throws SQLException {
+        dropTable();
+        StringJoiner columns = new StringJoiner(", ");
+        for (RuntimePersistentProperty<WideBook> property : allProperties()) {
+            columns.add(quoted(property.getPersistedName()) + " " + sqlType(property));
+        }
+        try (Statement s = connection.createStatement()) {
+            s.execute("CREATE TABLE " + quoted(entity.getPersistedName()) + " (" + columns + ")");
+        }
+    }
+
+    private void dropTable() {
+        try (Statement s = connection.createStatement()) {
+            s.execute("DROP TABLE " + quoted(entity.getPersistedName()));
+        } catch (SQLException e) {
+            // The table doesn't exist yet
+        }
+    }
+
+    private void insertRows() throws SQLException {
+        List<RuntimePersistentProperty<WideBook>> properties = allProperties();
+        StringJoiner columns = new StringJoiner(", ");
+        StringJoiner values = new StringJoiner(", ");
+        for (RuntimePersistentProperty<WideBook> property : properties) {
+            columns.add(quoted(property.getPersistedName()));
+            values.add("?");
+        }
+        String sql = "INSERT INTO " + quoted(entity.getPersistedName())
+            + " (" + columns + ") VALUES (" + values + ")";
+        try (PreparedStatement s = connection.prepareStatement(sql)) {
+            for (int row = 0; row < rows; row++) {
+                for (int i = 0; i < properties.size(); i++) {
+                    RuntimePersistentProperty<WideBook> property = properties.get(i);
+                    if (property.getType() == String.class) {
+                        s.setString(i + 1, property.getName() + "-" + row);
+                    } else {
+                        s.setLong(i + 1, row);
+                    }
+                }
+                s.addBatch();
+            }
+            s.executeBatch();
+        }
+    }
+
+    private List<RuntimePersistentProperty<WideBook>> allProperties() {
+        List<RuntimePersistentProperty<WideBook>> properties = new ArrayList<>();
+        properties.add(entity.getIdentity());
+        properties.addAll(entity.getPersistentProperties());
+        return properties;
+    }
+
+    private String quoted(String identifier) {
+        return quote + identifier + quote;
+    }
+
+    private String sqlType(RuntimePersistentProperty<WideBook> property) {
+        Class<?> type = property.getType();
+        if (type == String.class) {
+            return oracle ? "VARCHAR2(255)" : "VARCHAR(255)";
+        }
+        if (type == Long.class || type == long.class) {
+            return oracle ? "NUMBER(19)" : "BIGINT";
+        }
+        return oracle ? "NUMBER(10)" : "INT";
+    }
+
+    /**
+     * A reader that hides the column index support of its delegate, reproducing the by-name reads the mapper
+     * performed before the column ordinals were cached.
+     */
+    private static final class NoColumnIndexReader extends AbstractDelegatingResultReader<ResultSet, String> {
+
+        NoColumnIndexReader(ResultReader<ResultSet, String> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public int findColumnIndex(ResultSet resultSet, String columnName) {
+            return -1;
+        }
+
+        @Override
+        public ResultReader<ResultSet, Integer> getColumnIndexReader() {
+            return null;
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(".*" + ResultSetMapping.class.getSimpleName() + ".*")
+            .warmupIterations(3)
+            .measurementIterations(4)
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/benchmarks/benchmark-micronaut-data-jdbc/src/jmh/java/benchmark/ResultSetMapping.java
+++ b/benchmarks/benchmark-micronaut-data-jdbc/src/jmh/java/benchmark/ResultSetMapping.java
@@ -102,7 +102,9 @@ public class ResultSetMapping {
             System.getProperty(USER_PROPERTY, "sa"),
             System.getProperty(PASSWORD_PROPERTY, ""));
         // Quote every identifier so the result set labels match the names the mapper asks for exactly
-        quote = connection.getMetaData().getIdentifierQuoteString();
+        // A single space means the database does not support quoted identifiers, so nothing is quoted
+        String identifierQuote = connection.getMetaData().getIdentifierQuoteString();
+        quote = identifierQuote == null ? "" : identifierQuote.trim();
         oracle = connection.getMetaData().getDatabaseProductName().toLowerCase().contains("oracle");
         createTable();
         insertRows();

--- a/benchmarks/benchmark-micronaut-data-jdbc/src/main/java/example/WideBook.java
+++ b/benchmarks/benchmark-micronaut-data-jdbc/src/main/java/example/WideBook.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+/**
+ * An entity with enough columns to represent a row of a joined query, used to benchmark result set mapping.
+ */
+@MappedEntity
+public class WideBook {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String title;
+    private String author;
+    private String publisher;
+    private String isbn;
+    private String language;
+    private String genre;
+    private String summary;
+    private String coverUrl;
+    private int pages;
+    private int edition;
+    private int rating;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public void setGenre(String genre) {
+        this.genre = genre;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getCoverUrl() {
+        return coverUrl;
+    }
+
+    public void setCoverUrl(String coverUrl) {
+        this.coverUrl = coverUrl;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+
+    public void setPages(int pages) {
+        this.pages = pages;
+    }
+
+    public int getEdition() {
+        return edition;
+    }
+
+    public void setEdition(int edition) {
+        this.edition = edition;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+}

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
@@ -64,12 +64,18 @@ public final class ColumnNameResultSetReader implements ResultReader<ResultSet, 
         return conversionService;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A failure to resolve the ordinal is not reported here: the caller falls back to reading the column by
+     * name, and a failure that is not a missing column, such as a closed result set, surfaces from that read with
+     * the message of the underlying driver rather than being swallowed.</p>
+     */
     @Override
     public int findColumnIndex(ResultSet resultSet, String columnName) {
         try {
             return resultSet.findColumn(columnName);
         } catch (SQLException e) {
-            // The column is missing or the driver cannot resolve it, the caller keeps reading by name
             return -1;
         }
     }

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
@@ -41,6 +41,7 @@ import java.util.Date;
  */
 public final class ColumnNameResultSetReader implements ResultReader<ResultSet, String> {
     private final ConversionService conversionService;
+    private final ColumnIndexResultSetReader columnIndexReader;
 
     public ColumnNameResultSetReader() {
         this(null);
@@ -55,11 +56,27 @@ public final class ColumnNameResultSetReader implements ResultReader<ResultSet, 
     public ColumnNameResultSetReader(@Nullable DataConversionService conversionService) {
         // Backwards compatibility should be removed in the next version
         this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
+        this.columnIndexReader = new ColumnIndexResultSetReader(conversionService);
     }
 
     @Override
     public ConversionService getConversionService() {
         return conversionService;
+    }
+
+    @Override
+    public int findColumnIndex(ResultSet resultSet, String columnName) {
+        try {
+            return resultSet.findColumn(columnName);
+        } catch (SQLException e) {
+            // The column is missing or the driver cannot resolve it, the caller keeps reading by name
+            return -1;
+        }
+    }
+
+    @Override
+    public ResultReader<ResultSet, Integer> getColumnIndexReader() {
+        return columnIndexReader;
     }
 
     @Nullable

--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReader.java
@@ -56,6 +56,8 @@ public final class ColumnNameResultSetReader implements ResultReader<ResultSet, 
     public ColumnNameResultSetReader(@Nullable DataConversionService conversionService) {
         // Backwards compatibility should be removed in the next version
         this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
+        // The index reader resolves a null conversion service the same way, so both read a column with the same
+        // conversions. ColumnNameResultSetReaderSpec holds them to that.
         this.columnIndexReader = new ColumnIndexResultSetReader(conversionService);
     }
 

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReaderSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReaderSpec.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.jdbc.mapper
+
+import io.micronaut.data.model.DataType
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.ResultSet
+import java.sql.Statement
+
+class ColumnNameResultSetReaderSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    Connection connection = DriverManager.getConnection("jdbc:h2:mem:columnnamereader;DB_CLOSE_DELAY=-1")
+
+    @Shared
+    ColumnNameResultSetReader reader = new ColumnNameResultSetReader()
+
+    void "resolves column ordinals of the result set"() {
+        given:
+        Statement statement = connection.createStatement()
+        ResultSet resultSet = statement.executeQuery("SELECT 'A' AS first_name, 42 AS age, TIMESTAMP '2024-01-02 03:04:05' AS last_updated")
+
+        expect:
+        reader.findColumnIndex(resultSet, "first_name") == 1
+        reader.findColumnIndex(resultSet, "age") == 2
+        reader.findColumnIndex(resultSet, "LAST_UPDATED") == 3
+        reader.findColumnIndex(resultSet, "missing") == -1
+
+        cleanup:
+        resultSet.close()
+        statement.close()
+    }
+
+    void "column index reader reads the same values as the column name reader"() {
+        given:
+        Statement statement = connection.createStatement()
+        ResultSet resultSet = statement.executeQuery("SELECT 'A' AS first_name, 42 AS age, NULL AS nickname, TIMESTAMP '2024-01-02 03:04:05' AS last_updated")
+        def indexReader = reader.getColumnIndexReader()
+
+        expect:
+        indexReader != null
+        resultSet.next()
+        indexReader.readDynamic(resultSet, reader.findColumnIndex(resultSet, "first_name"), DataType.STRING) == reader.readDynamic(resultSet, "first_name", DataType.STRING)
+        indexReader.readDynamic(resultSet, reader.findColumnIndex(resultSet, "age"), DataType.INTEGER) == reader.readDynamic(resultSet, "age", DataType.INTEGER)
+        indexReader.readDynamic(resultSet, reader.findColumnIndex(resultSet, "nickname"), DataType.STRING) == null
+        indexReader.readDynamic(resultSet, reader.findColumnIndex(resultSet, "last_updated"), DataType.TIMESTAMP) == reader.readDynamic(resultSet, "last_updated", DataType.TIMESTAMP)
+
+        cleanup:
+        resultSet.close()
+        statement.close()
+    }
+
+    void "existence aware reader delegates column ordinal resolution"() {
+        given:
+        Statement statement = connection.createStatement()
+        ResultSet resultSet = statement.executeQuery("SELECT 'A' AS first_name")
+        def existenceAwareReader = new ColumnNameExistenceAwareResultSetReader(reader)
+
+        expect:
+        existenceAwareReader.findColumnIndex(resultSet, "first_name") == 1
+        existenceAwareReader.findColumnIndex(resultSet, "missing") == -1
+        existenceAwareReader.getColumnIndexReader().is(reader.getColumnIndexReader())
+
+        cleanup:
+        resultSet.close()
+        statement.close()
+    }
+}

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReaderSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/mapper/ColumnNameResultSetReaderSpec.groovy
@@ -15,7 +15,9 @@
  */
 package io.micronaut.data.jdbc.mapper
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.data.model.DataType
+import io.micronaut.data.runtime.convert.DataConversionService
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -26,6 +28,10 @@ import java.sql.ResultSet
 import java.sql.Statement
 
 class ColumnNameResultSetReaderSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
 
     @Shared
     @AutoCleanup
@@ -83,5 +89,15 @@ class ColumnNameResultSetReaderSpec extends Specification {
         cleanup:
         resultSet.close()
         statement.close()
+    }
+
+    void "the index reader converts values with the same conversion service as the name reader"() {
+        given: "a reader built with an explicit conversion service, and one left to the default"
+        def configured = new ColumnNameResultSetReader(context.getBean(DataConversionService))
+        def defaulted = new ColumnNameResultSetReader(null)
+
+        expect: "both address a column with the same conversions, so a value reads the same either way"
+        configured.getColumnIndexReader().getConversionService().is(configured.getConversionService())
+        defaulted.getColumnIndexReader().getConversionService().is(defaulted.getConversionService())
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/AbstractDelegatingResultReader.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/AbstractDelegatingResultReader.java
@@ -71,6 +71,17 @@ public abstract class AbstractDelegatingResultReader<RS, ID> implements ResultRe
     }
 
     @Override
+    public int findColumnIndex(RS resultSet, String columnName) {
+        return delegate.findColumnIndex(resultSet, columnName);
+    }
+
+    @Override
+    @Nullable
+    public ResultReader<RS, Integer> getColumnIndexReader() {
+        return delegate.getColumnIndexReader();
+    }
+
+    @Override
     @Nullable
     public Object readDynamic(RS resultSet, ID index, DataType dataType) {
         return delegate.readDynamic(resultSet, index, dataType);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
@@ -106,6 +106,35 @@ public interface ResultReader<RS, IDX> {
     boolean next(RS resultSet);
 
     /**
+     * Resolves the ordinal of the column with the given name in the result set, so that callers can cache it
+     * and read the values of subsequent rows by index using {@link #getColumnIndexReader()} instead of resolving
+     * the column name for every row.
+     * <p>
+     * The returned ordinal is only valid for the given result set and uses the index convention of the underlying
+     * driver (for example 1-based for JDBC). Readers that cannot resolve column ordinals return {@code -1}, in which
+     * case callers must keep reading by name.
+     *
+     * @param resultSet  The result set
+     * @param columnName The column name
+     * @return The column index or {@code -1} if the column cannot be resolved
+     * @since 5.2.0
+     */
+    default int findColumnIndex(RS resultSet, String columnName) {
+        return -1;
+    }
+
+    /**
+     * The reader capable of reading values by the ordinals resolved by {@link #findColumnIndex(Object, String)}.
+     *
+     * @return The column index reader or {@code null} if reading by column index is not supported
+     * @since 5.2.0
+     */
+    @Nullable
+    default ResultReader<RS, Integer> getColumnIndexReader() {
+        return null;
+    }
+
+    /**
      * Read a value dynamically using the result set and the given name and data type.
      * @param resultSet The result set
      * @param index The name

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -87,6 +87,14 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
     private final DatabaseConversionContextFactory conversionContextFactory;
     @Nullable
     private final BiFunction<RuntimePersistentEntity<Object>, Object, Object> eventListener;
+    @Nullable
+    private final ResultReader<RS, Integer> columnIndexReader;
+    /**
+     * The column ordinals resolved for {@link #columnIndexesResultSet}, {@code -1} for columns that cannot be read by index.
+     */
+    private final Map<String, Integer> columnIndexes;
+    @Nullable
+    private RS columnIndexesResultSet;
     private boolean callNext = true;
 
     /**
@@ -186,6 +194,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         }
         this.startingPrefix = startingPrefix;
         this.conversionContextFactory = conversionContextFactory;
+        this.columnIndexReader = resultReader.getColumnIndexReader();
+        this.columnIndexes = columnIndexReader == null ? Collections.emptyMap() : new HashMap<>();
     }
 
     @Override
@@ -235,7 +245,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         }
         DataType dataType = property.getDataType();
         String columnName = property.getPersistedName();
-        return resultReader.readDynamic(resultSet, columnName, dataType);
+        return readDynamic(resultSet, columnName, dataType);
     }
 
     @Nullable
@@ -254,7 +264,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             dataType = property.getDataType();
             columnName = property.getPersistedName();
         }
-        return resultReader.readDynamic(resultSet, columnName, dataType);
+        return readDynamic(resultSet, columnName, dataType);
     }
 
     @Override
@@ -758,13 +768,43 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             JsonDataType jsonDataType = prop.getJsonDataType();
             result = jsonColumnReader.readJsonColumn(resultReader, rs, columnName, jsonDataType, prop.getArgument());
         } else {
-            result = resultReader.readDynamic(rs, columnName, dataType);
+            result = readDynamic(rs, columnName, dataType);
         }
 
         if (converter != null && conversionContextFactory != null) {
             return converter.convertToEntityValue(result, conversionContextFactory.forArgument(prop.getArgument()));
         }
         return result;
+    }
+
+    /**
+     * Reads the column value by its ordinal when the result reader can resolve one, otherwise by the column name.
+     * The ordinal is resolved once per result set and column, so the driver doesn't have to resolve the column
+     * name for every row.
+     */
+    @Nullable
+    private Object readDynamic(RS rs, String columnName, DataType dataType) {
+        if (columnIndexReader != null) {
+            Integer columnIndex = resolveColumnIndex(rs, columnName);
+            if (columnIndex >= 0) {
+                return columnIndexReader.readDynamic(rs, columnIndex, dataType);
+            }
+        }
+        return resultReader.readDynamic(rs, columnName, dataType);
+    }
+
+    private Integer resolveColumnIndex(RS rs, String columnName) {
+        if (rs != columnIndexesResultSet) {
+            // The ordinals are only valid for the result set they were resolved from
+            columnIndexes.clear();
+            columnIndexesResultSet = rs;
+        }
+        Integer columnIndex = columnIndexes.get(columnName);
+        if (columnIndex == null) {
+            columnIndex = resultReader.findColumnIndex(rs, columnName);
+            columnIndexes.put(columnName, columnIndex);
+        }
+        return columnIndex;
     }
 
     private <K> K triggerPostLoad(RuntimePersistentEntity<?> persistentEntity, K entity) {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -55,6 +55,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -67,6 +68,11 @@ import java.util.function.BiFunction;
 /**
  * A {@link io.micronaut.data.runtime.mapper.TypeMapper} that can take a {@link RuntimePersistentEntity} and a {@link ResultReader}
  * and materialize an instance using column naming conventions mapped by the entity.
+ *
+ * <p>Instances are stateful and are not thread safe: an instance caches the column name of every property it has
+ * read and the ordinals those columns have in the result set being mapped, and {@link #hasNext} keeps track of the
+ * cursor. Create one mapper per query execution, the way the repository operations do, and do not share an instance
+ * between threads or retain it after the result set has been consumed.</p>
  *
  * @param <RS> The result set type
  * @param <R>  The result type
@@ -90,11 +96,27 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
     @Nullable
     private final ResultReader<RS, Integer> columnIndexReader;
     /**
-     * The column ordinals resolved for {@link #columnIndexesResultSet}, {@code -1} for columns that cannot be read by index.
+     * The resolved column of every property, shared by the mapping contexts of the same shape. The mapping
+     * contexts are rebuilt for every row when JOINs are used, so the resolved columns are held here to compute
+     * each column name once instead of once per row.
      */
-    private final Map<String, Integer> columnIndexes;
+    private final ShapeCache rootShape = new ShapeCache();
+    /**
+     * The resolved columns of the {@link #read} methods, which address a column by name rather than by property.
+     */
+    private final Map<String, ColumnRef> columnRefsByName = new HashMap<>();
+    /**
+     * The result set the currently resolved column ordinals were resolved from, compared by identity so that a
+     * mapper handed a different result set resolves the ordinals again. The reference is held for as long as the
+     * mapper lives, which is one query execution; an identity hash code is deliberately not used instead, because
+     * two result sets sharing a hash code would silently read the columns of one with the ordinals of the other.
+     */
     @Nullable
-    private RS columnIndexesResultSet;
+    private RS resolvedResultSet;
+    /**
+     * Incremented whenever a different result set is mapped, which invalidates every resolved ordinal.
+     */
+    private int resolvedGeneration = 1;
     private boolean callNext = true;
 
     /**
@@ -195,7 +217,6 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         this.startingPrefix = startingPrefix;
         this.conversionContextFactory = conversionContextFactory;
         this.columnIndexReader = resultReader.getColumnIndexReader();
-        this.columnIndexes = columnIndexReader == null ? Collections.emptyMap() : new HashMap<>();
     }
 
     @Override
@@ -229,7 +250,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
      * @since 4.2.0
      */
     public R readEntity(RS rs) throws DataAccessException {
-        R entityInstance = readEntity(rs, MappingContext.of(entity, startingPrefix), null, null);
+        R entityInstance = readEntity(rs, MappingContext.of(entity, startingPrefix, rootShape), null, null);
         if (entityInstance == null) {
             throw new DataAccessException("Unable to map result to entity of type [" + entity.getIntrospection().getBeanType() + "]. Missing result data.");
         }
@@ -245,7 +266,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         }
         DataType dataType = property.getDataType();
         String columnName = property.getPersistedName();
-        return readDynamic(resultSet, columnName, dataType);
+        return readDynamic(resultSet, columnRefByName(columnName), dataType);
     }
 
     @Nullable
@@ -264,7 +285,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             dataType = property.getDataType();
             columnName = property.getPersistedName();
         }
-        return readDynamic(resultSet, columnName, dataType);
+        return readDynamic(resultSet, columnRefByName(columnName), dataType);
     }
 
     @Override
@@ -286,7 +307,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         if (hasJoins) {
             return new PushingMapper<>() {
 
-                final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix);
+                final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix, rootShape);
                 @Nullable
                 Object entityId;
                 @Nullable
@@ -322,7 +343,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         }
         return new PushingMapper<>() {
 
-            final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix);
+            final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix, rootShape);
             @Nullable
             R entityInstance;
 
@@ -360,7 +381,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
 
                 @Override
                 public void processRow(RS row) {
-                    MappingContext<R> ctx = MappingContext.of(entity, startingPrefix);
+                    MappingContext<R> ctx = MappingContext.of(entity, startingPrefix, rootShape);
                     Object id = readEntityId(row, ctx);
                     if (id == null) {
                         throw new IllegalStateException("Entity needs to have an ID when JOINs are used!");
@@ -398,7 +419,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         return new PushingMapper<>() {
 
             final List<R> allProcessed = new ArrayList<>(20);
-            final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix);
+            final MappingContext<R> ctx = MappingContext.of(entity, startingPrefix, rootShape);
 
             @Override
             public void processRow(RS row) {
@@ -751,13 +772,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
 
     @Nullable
     private <K> Object readProperty(RS rs, MappingContext<K> ctx, RuntimePersistentProperty<K> prop) {
-        String columnName = ctx.namingStrategy.mappedName(ctx.embeddedPath, prop);
-        String columnAlias = prop.getAlias();
-        if (StringUtils.isNotEmpty(columnAlias)) {
-            columnName = columnAlias;
-        } else if (ctx.prefix != null && !ctx.prefix.isEmpty()) {
-            columnName = ctx.prefix + columnName;
-        }
+        ColumnRef column = ctx.columnRef(prop);
+        String columnName = column.name;
         DataType dataType = prop.getDataType();
         Object result;
         AttributeConverter<Object, Object> converter = prop.getConverter();
@@ -768,7 +784,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             JsonDataType jsonDataType = prop.getJsonDataType();
             result = jsonColumnReader.readJsonColumn(resultReader, rs, columnName, jsonDataType, prop.getArgument());
         } else {
-            result = readDynamic(rs, columnName, dataType);
+            result = readDynamic(rs, column, dataType);
         }
 
         if (converter != null && conversionContextFactory != null) {
@@ -777,34 +793,43 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         return result;
     }
 
+    private ColumnRef columnRefByName(String columnName) {
+        return columnRefsByName.computeIfAbsent(columnName, ColumnRef::new);
+    }
+
     /**
      * Reads the column value by its ordinal when the result reader can resolve one, otherwise by the column name.
      * The ordinal is resolved once per result set and column, so the driver doesn't have to resolve the column
      * name for every row.
      */
     @Nullable
-    private Object readDynamic(RS rs, String columnName, DataType dataType) {
+    private Object readDynamic(RS rs, ColumnRef column, DataType dataType) {
         if (columnIndexReader != null) {
-            Integer columnIndex = resolveColumnIndex(rs, columnName);
-            if (columnIndex >= 0) {
+            Integer columnIndex = resolveColumnIndex(rs, column);
+            if (columnIndex != null) {
                 return columnIndexReader.readDynamic(rs, columnIndex, dataType);
             }
         }
-        return resultReader.readDynamic(rs, columnName, dataType);
+        return resultReader.readDynamic(rs, column.name, dataType);
     }
 
-    private Integer resolveColumnIndex(RS rs, String columnName) {
-        if (rs != columnIndexesResultSet) {
+    /**
+     * @return The ordinal of the column in the given result set, or {@code null} when it cannot be resolved and
+     * the column has to be read by name
+     */
+    @Nullable
+    private Integer resolveColumnIndex(RS rs, ColumnRef column) {
+        if (rs != resolvedResultSet) {
             // The ordinals are only valid for the result set they were resolved from
-            columnIndexes.clear();
-            columnIndexesResultSet = rs;
+            resolvedResultSet = rs;
+            resolvedGeneration++;
         }
-        Integer columnIndex = columnIndexes.get(columnName);
-        if (columnIndex == null) {
-            columnIndex = resultReader.findColumnIndex(rs, columnName);
-            columnIndexes.put(columnName, columnIndex);
+        if (column.generation != resolvedGeneration) {
+            int index = resultReader.findColumnIndex(rs, column.name);
+            column.index = index < 0 ? null : index;
+            column.generation = resolvedGeneration;
         }
-        return columnIndex;
+        return column.index;
     }
 
     private <K> K triggerPostLoad(RuntimePersistentEntity<?> persistentEntity, K entity) {
@@ -909,6 +934,10 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
         private final List<Association> embeddedPath;
         @Nullable
         private final Association association;
+        /**
+         * The resolved columns shared by every mapping context of this shape.
+         */
+        private final ShapeCache shape;
 
         @Nullable
         private Map<Object, MappingContext> manyAssociations;
@@ -928,7 +957,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                                List<Association> joinPath,
                                List<Association> embeddedPath,
                                @Nullable
-                               Association association) {
+                               Association association,
+                               ShapeCache shape) {
             this.rootPersistentEntity = rootPersistentEntity;
             this.persistentEntity = persistentEntity;
             this.namingStrategy = namingStrategy;
@@ -937,9 +967,12 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             this.joinPath = joinPath;
             this.embeddedPath = embeddedPath;
             this.association = association;
+            this.shape = shape;
         }
 
-        private static <K> MappingContext<K> of(RuntimePersistentEntity<K> persistentEntity, @Nullable String prefix) {
+        private static <K> MappingContext<K> of(RuntimePersistentEntity<K> persistentEntity,
+                                                @Nullable String prefix,
+                                                ShapeCache shape) {
             return new MappingContext<>(
                     persistentEntity,
                     persistentEntity,
@@ -948,7 +981,35 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     null,
                     Collections.emptyList(),
                     Collections.emptyList(),
-                    null);
+                    null,
+                    shape);
+        }
+
+        /**
+         * The column of the given property, computed once per shape and reused by every row.
+         *
+         * @param property The property
+         * @return The resolved column
+         */
+        private ColumnRef columnRef(RuntimePersistentProperty<?> property) {
+            ColumnRef columnRef = shape.columns.get(property);
+            if (columnRef == null) {
+                columnRef = new ColumnRef(columnName(property));
+                shape.columns.put(property, columnRef);
+            }
+            return columnRef;
+        }
+
+        private String columnName(RuntimePersistentProperty<?> property) {
+            String columnAlias = property.getAlias();
+            if (StringUtils.isNotEmpty(columnAlias)) {
+                return columnAlias;
+            }
+            String columnName = namingStrategy.mappedName(embeddedPath, property);
+            if (prefix != null && !prefix.isEmpty()) {
+                return prefix + columnName;
+            }
+            return columnName;
         }
 
         private <K> MappingContext<K> embedded(Embedded embedded) {
@@ -968,7 +1029,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     jp,
                     joinPath,
                     associated(embeddedPath, association),
-                    association
+                    association,
+                    shape.child(association)
             );
         }
 
@@ -997,7 +1059,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     jp,
                     joinPath,
                     embeddedPath,
-                    association
+                    association,
+                    shape
             );
         }
 
@@ -1012,7 +1075,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     jp,
                     associated(this.joinPath, association),
                     Collections.emptyList(), // Reset path,
-                    association
+                    association,
+                    shape.child(association)
             );
         }
 
@@ -1026,7 +1090,8 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
                     jp,
                     joinPath,
                     associated(embeddedPath, embedded),
-                    embedded
+                    embedded,
+                    shape.child(embedded)
             );
         }
 
@@ -1105,6 +1170,40 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
             return newAssociations;
         }
 
+    }
+
+    /**
+     * The resolved columns of every mapping context sharing the same shape, that is the same entity reached over
+     * the same association path. The mapping contexts themselves are rebuilt for every row when JOINs are used,
+     * so this tree lives on the mapper and is navigated when a context is created rather than when a value is read.
+     */
+    private static final class ShapeCache {
+
+        private final IdentityHashMap<Association, ShapeCache> children = new IdentityHashMap<>(4);
+        private final IdentityHashMap<RuntimePersistentProperty<?>, ColumnRef> columns = new IdentityHashMap<>(8);
+
+        private ShapeCache child(Association association) {
+            return children.computeIfAbsent(association, a -> new ShapeCache());
+        }
+    }
+
+    /**
+     * A column of the result set, holding the column name computed from the entity and, once resolved, the ordinal
+     * of that column in the result set being mapped.
+     */
+    private static final class ColumnRef {
+
+        private final String name;
+        /**
+         * The ordinal in the result set of {@link #generation}, {@code null} when the column has to be read by name.
+         */
+        @Nullable
+        private Integer index;
+        private int generation;
+
+        private ColumnRef(String name) {
+            this.name = name;
+        }
     }
 
     /**

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -992,12 +992,7 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
          * @return The resolved column
          */
         private ColumnRef columnRef(RuntimePersistentProperty<?> property) {
-            ColumnRef columnRef = shape.columns.get(property);
-            if (columnRef == null) {
-                columnRef = new ColumnRef(columnName(property));
-                shape.columns.put(property, columnRef);
-            }
-            return columnRef;
+            return shape.columns.computeIfAbsent(property, p -> new ColumnRef(columnName(p)));
         }
 
         private String columnName(RuntimePersistentProperty<?> property) {

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/MappedBook.java
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/MappedBook.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.mapper.sql;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class MappedBook {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String title;
+    private Integer pages;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getPages() {
+        return pages;
+    }
+
+    public void setPages(Integer pages) {
+        this.pages = pages;
+    }
+}

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapperSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapperSpec.groovy
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.runtime.mapper.sql
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.data.exceptions.DataAccessException
+import io.micronaut.data.model.runtime.RuntimePersistentEntity
+import io.micronaut.data.runtime.convert.DataConversionService
+import io.micronaut.data.runtime.mapper.ResultReader
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SqlResultEntityTypeMapperSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    @Shared
+    RuntimePersistentEntity<MappedBook> entity = new RuntimePersistentEntity<>(MappedBook)
+
+    void "column ordinals are resolved once per result set and reused for every row"() {
+        given:
+        def reader = new IndexAwareReader()
+        def resultSet = new FakeResultSet(["id", "title", "pages"], [
+                [1L, "Book 1", 100],
+                [2L, "Book 2", 200],
+                [3L, "Book 3", 300]
+        ])
+
+        when:
+        List<MappedBook> books = readAll(reader, resultSet)
+
+        then:
+        books*.id == [1L, 2L, 3L]
+        books*.title == ["Book 1", "Book 2", "Book 3"]
+        books*.pages == [100, 200, 300]
+        reader.resolvedColumns == ["id", "title", "pages"]
+        reader.indexReads == 9
+        reader.nameReads == 0
+    }
+
+    void "reads by name the columns whose ordinal cannot be resolved"() {
+        given:
+        def reader = new IndexAwareReader(unresolvableColumns: ["pages"])
+        def resultSet = new FakeResultSet(["id", "title", "pages"], [
+                [1L, "Book 1", 100],
+                [2L, "Book 2", 200]
+        ])
+
+        when:
+        List<MappedBook> books = readAll(reader, resultSet)
+
+        then:
+        books*.pages == [100, 200]
+        reader.resolvedColumns == ["id", "title", "pages"]
+        reader.indexReads == 4
+        reader.nameReads == 2
+    }
+
+    void "reads by name when the reader doesn't support column ordinals"() {
+        given:
+        def reader = new NameOnlyReader()
+        def resultSet = new FakeResultSet(["id", "title", "pages"], [
+                [1L, "Book 1", 100],
+                [2L, "Book 2", 200]
+        ])
+
+        when:
+        List<MappedBook> books = readAll(reader, resultSet)
+
+        then:
+        books*.title == ["Book 1", "Book 2"]
+        reader.nameReads == 6
+    }
+
+    void "column ordinals are resolved again for a different result set"() {
+        given:
+        def reader = new IndexAwareReader()
+        def mapper = createMapper(reader)
+        def resultSet1 = new FakeResultSet(["id", "title", "pages"], [[1L, "Book 1", 100]])
+        def resultSet2 = new FakeResultSet(["pages", "title", "id"], [[200, "Book 2", 2L]])
+
+        when:
+        MappedBook book1 = mapper.readEntity(resultSet1.next())
+        MappedBook book2 = mapper.readEntity(resultSet2.next())
+
+        then:
+        book1.id == 1L
+        book1.title == "Book 1"
+        book1.pages == 100
+        book2.id == 2L
+        book2.title == "Book 2"
+        book2.pages == 200
+        reader.resolvedColumns == ["id", "title", "pages", "id", "title", "pages"]
+        reader.nameReads == 0
+    }
+
+    private List<MappedBook> readAll(ResultReader<FakeResultSet, String> reader, FakeResultSet resultSet) {
+        def pushingMapper = createMapper(reader).readManyMapper()
+        while (resultSet.next()) {
+            pushingMapper.processRow(resultSet)
+        }
+        return pushingMapper.result
+    }
+
+    private SqlResultEntityTypeMapper<FakeResultSet, MappedBook> createMapper(ResultReader<FakeResultSet, String> reader) {
+        return new SqlResultEntityTypeMapper<FakeResultSet, MappedBook>(
+                entity,
+                reader,
+                Set.of(),
+                null,
+                context.getBean(DataConversionService)
+        )
+    }
+
+    /**
+     * A result set holding all rows, the same instance is used for every row like a JDBC result set.
+     */
+    static class FakeResultSet {
+        final List<String> columns
+        final List<List<Object>> rows
+        int cursor = -1
+
+        FakeResultSet(List<String> columns, List<List<Object>> rows) {
+            this.columns = columns
+            this.rows = rows
+        }
+
+        FakeResultSet next() {
+            cursor++
+            return cursor < rows.size() ? this : null
+        }
+
+        Object get(int index) {
+            return rows[cursor][index]
+        }
+
+        Object get(String column) {
+            int index = columns.indexOf(column)
+            if (index == -1) {
+                throw new DataAccessException("Unknown column: " + column)
+            }
+            return get(index)
+        }
+    }
+
+    static class NameOnlyReader implements ResultReader<FakeResultSet, String> {
+        int nameReads = 0
+
+        @Override
+        <T> T getRequiredValue(FakeResultSet resultSet, String name, Class<T> type) throws DataAccessException {
+            nameReads++
+            return (T) resultSet.get(name)
+        }
+
+        @Override
+        boolean next(FakeResultSet resultSet) {
+            return resultSet.next() != null
+        }
+    }
+
+    static class IndexAwareReader extends NameOnlyReader {
+        List<String> resolvedColumns = []
+        Set<String> unresolvableColumns = []
+        int indexReads = 0
+        private final ResultReader<FakeResultSet, Integer> indexReader = new ResultReader<FakeResultSet, Integer>() {
+            @Override
+            <T> T getRequiredValue(FakeResultSet resultSet, Integer index, Class<T> type) throws DataAccessException {
+                indexReads++
+                return (T) resultSet.get(index)
+            }
+
+            @Override
+            boolean next(FakeResultSet resultSet) {
+                return resultSet.next() != null
+            }
+        }
+
+        @Override
+        int findColumnIndex(FakeResultSet resultSet, String columnName) {
+            resolvedColumns.add(columnName)
+            if (unresolvableColumns.contains(columnName)) {
+                return -1
+            }
+            return resultSet.columns.indexOf(columnName)
+        }
+
+        @Override
+        ResultReader<FakeResultSet, Integer> getColumnIndexReader() {
+            return indexReader
+        }
+    }
+}


### PR DESCRIPTION
Closes #3978

`SqlResultEntityTypeMapper` read every mapped property by its column label, so the JDBC driver had to resolve that label to an ordinal for every column of every row. On Oracle that resolution (`OracleStatement.getColumnIndex` -> `enquoteIdentifier`) showed up as roughly a tenth of CPU when mapping joined entities.

Profiling the mapper with async-profiler showed a second, larger cost that the issue does not mention: the column name itself was rebuilt for every property of every row, through the naming strategy (`NameUtils.separateCamelCase`, a `StringBuilder`, `toLowerCase`). On PostgreSQL that was about 30% of the mapping CPU.

Both are fixed here.

### Changes

- `ResultReader` gains two compatible default methods: `findColumnIndex` resolves the ordinal of a column (or `-1`) and `getColumnIndexReader` exposes a reader that reads by ordinal (or `null`). Readers that do not override them keep the current by-name behaviour.
- `ColumnNameResultSetReader` implements them using `ResultSet.findColumn` and a `ColumnIndexResultSetReader` companion.
- `AbstractDelegatingResultReader` delegates both, so the DTO projection wrapper benefits too. A missing column resolves to `-1` and falls back to the by-name read.
- `SqlResultEntityTypeMapper` resolves the column of each property once and shares it between the mapping contexts of the same shape. Mapping contexts are rebuilt for every row when JOINs are used, so the resolved columns live on the mapper in a tree that mirrors the association path, navigated when a context is created rather than when a value is read. Each resolved column also holds its ordinal for the result set being mapped.

R2DBC readers are unchanged: `Row` instances differ per row, so the cache would need to key on `RowMetadata`. That can be a follow-up.

### Measurements

JMH, mapping 100 rows of a 12 column entity, one mapper per invocation, 2 forks x 10 iterations. Baseline is this branch's parent. Databases run in containers on the same machine, so absolute numbers are only comparable within a row.

| Driver | Baseline ops/s | This PR ops/s | Speedup |
| --- | --- | --- | --- |
| Oracle Free 23 | 2327 | 13340 | 5.7x |
| PostgreSQL 17 | 8271 | 30561 | 3.7x |
| H2 | 5819 | 30574 | 5.3x |
| MySQL 9 | 5496 | 16082 | 2.9x |

Splitting the two halves, by toggling ordinal caching off while keeping the cached names:

| Driver | Names cached only | Names + ordinals | Ordinal caching alone |
| --- | --- | --- | --- |
| Oracle Free 23 | 2943 | 13340 | 4.5x |
| PostgreSQL 17 | 20891 | 30561 | 1.5x |
| H2 | 15242 | 30574 | 2.0x |
| MySQL 9 | 15434 | 16082 | 1.0x, within error |

Ordinal caching is worth the most where the driver's label resolution is expensive, which is the Oracle case from the issue. Caching the names is what makes it a win rather than a regression everywhere else: with the name still rebuilt per row, PostgreSQL measured 37% slower with ordinal caching on.

The benchmark is added as `ResultSetMapping` in the JDBC benchmark module. It defaults to in-memory H2 and takes `-Dbench.jdbc.url`, `-Dbench.jdbc.user` and `-Dbench.jdbc.password` to run against another database.

### API impact

Additive and binary compatible: two new default methods on the public `ResultReader` interface (`@since 5.2.0`) and two new public methods on the final `ColumnNameResultSetReader`.

### Verification

- New `SqlResultEntityTypeMapperSpec` asserts ordinals are resolved once per column and result set, that unresolvable columns and readers without index support fall back to by-name reads, and that a different result set is resolved again.
- New `ColumnNameResultSetReaderSpec` checks ordinal resolution against H2, including a case-insensitive label, a missing column, a null value and delegation through the existence-aware wrapper.
- `data-jdbc` H2 and mapper suites: 725 tests, no failures. This covers the case an entity holds two embedded values of the same type, where the same property objects appear under two association paths.
- `checkstyleMain` clean for both modules.
- `data-runtime`: 369 tests, 2 failures in `DataConversionServiceSpec`. Both are `java.util.Date` cases off by one hour when the machine runs in CET, in date conversion code this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
