### PR TITLE
Make DataConversionServiceSpec date assertions time zone independent

### DIFF
--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/convert/DataConversionServiceSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/convert/DataConversionServiceSpec.groovy
@@ -34,6 +34,14 @@ class DataConversionServiceSpec extends Specification {
     static def DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd")
     static Date now = new Date()
 
+    /**
+     * The instant a {@code LocalDate} converts to, which is midnight UTC rather than midnight in the default
+     * time zone. Spelling it out keeps the expectation the same in every time zone the test runs in.
+     */
+    static Date utcMidnight(String date) {
+        Date.from(LocalDate.parse(date).atStartOfDay(ZoneOffset.UTC).toInstant())
+    }
+
     @Unroll
     def "test date conversion #obj to #targetType"() {
         given:
@@ -49,8 +57,8 @@ class DataConversionServiceSpec extends Specification {
             DATE_FORMAT.parse("1970-01-02")              || LocalDate      || LocalDate.parse("1970-01-02")
             DATE_FORMAT.parse("1970-01-02")              || LocalDateTime  || LocalDate.parse("1970-01-02").atStartOfDay()
             DATE_FORMAT.parse("1970-01-02")              || OffsetDateTime || LocalDate.parse("1970-01-02").atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime()
-            LocalDate.parse("1970-01-02")                || Date           || DATE_FORMAT.parse("1970-01-02")
-            LocalDate.parse("1970-01-02").atStartOfDay() || Date           || DATE_FORMAT.parse("1970-01-02")
+            LocalDate.parse("1970-01-02")                || Date           || utcMidnight("1970-01-02")
+            LocalDate.parse("1970-01-02").atStartOfDay() || Date           || utcMidnight("1970-01-02")
             new Date(now.getTime())                      || Instant        || Instant.ofEpochMilli(now.getTime())
             Instant.ofEpochMilli(now.getTime())          || Date           || new Date(now.getTime())
 


### PR DESCRIPTION
`DataConversionServiceSpec` fails on any machine that is not set to UTC. Two rows of the date conversion table assert on a value that depends on the default time zone:

```groovy
LocalDate.parse("1970-01-02")                || Date || DATE_FORMAT.parse("1970-01-02")
LocalDate.parse("1970-01-02").atStartOfDay() || Date || DATE_FORMAT.parse("1970-01-02")
```

`DATE_FORMAT` is a `SimpleDateFormat`, so the expected value is midnight in the default time zone. The conversion actually returns midnight UTC, epoch milli 86400000. The two agree only when the JVM runs in UTC, which is why CI is green and a developer in CET sees two failures one hour out.

This expresses the expectation as the instant the conversion really produces, so the assertion holds everywhere.

### Verification

The spec was run under four time zones, before and after, by forcing `user.timezone` on the test JVM.

| Time zone | Before | After |
| --- | --- | --- |
| UTC | 17 tests, 0 failures | 17 tests, 0 failures |
| Europe/Prague | 17 tests, 2 failures | 17 tests, 0 failures |
| America/New_York | not run | 17 tests, 0 failures |
| Pacific/Midway | not run | 17 tests, 0 failures |

### One thing worth a maintainer's eye

This change records the current behaviour rather than changing it, but that behaviour looks inconsistent and the test was hiding it.

`DataConversionServiceFactory` registers `ChronoLocalDate -> Date` and `LocalDateTime -> Date` converters that both use `ZoneId.systemDefault()`. Neither appears to be the converter that runs: converting `LocalDate.parse("1970-01-02")` to `java.util.Date` yields epoch milli 86400000, which is midnight UTC, where those converters would give 82800000 in CET. Something registered elsewhere takes precedence, so the two declared converters look like dead code.

That matters because the reverse direction, `Date -> LocalDate`, does use `ZoneId.systemDefault()`. The pair only round trips in zones at or ahead of UTC. In `Pacific/Midway`, UTC-11, `LocalDate 1970-01-02` converts to a `Date` that converts back to `LocalDate 1970-01-01`.

I have deliberately not changed the conversion semantics here, since that would shift values for every application converting a `LocalDate` outside UTC. Happy to follow up if you want the declared `systemDefault` behaviour to win instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
