### PR TITLE
Resolve R2DBC column ordinals once per result

### DIFF
--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/AbstractR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/AbstractR2dbcResultReader.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mapper;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.data.exceptions.DataAccessException;
+import io.micronaut.data.model.DataType;
+import io.micronaut.data.runtime.convert.DataConversionService;
+import io.micronaut.data.runtime.mapper.ResultReader;
+import io.r2dbc.spi.Clob;
+import io.r2dbc.spi.R2dbcTransientResourceException;
+import io.r2dbc.spi.Row;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.sql.Time;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+/**
+ * The behaviour shared by the R2DBC readers that address a column by name and by ordinal.
+ *
+ * <p>Every value is read through {@link #getValue(Row, Object)} and {@link #getValue(Row, Object, Class)}, so both
+ * readers interpret a column the same way and only differ in how they address it.</p>
+ *
+ * @param <ID> The column identifier type, a name or an ordinal
+ * @since 5.2.0
+ */
+@Internal
+abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
+
+    protected final ConversionService conversionService;
+
+    protected AbstractR2dbcResultReader(@Nullable DataConversionService conversionService) {
+        // Backwards compatibility should be removed in the next version
+        this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
+    }
+
+    /**
+     * Reads the raw value of the column.
+     *
+     * @param row The row
+     * @param id  The column identifier
+     * @return The value, can be null
+     */
+    @Nullable
+    protected abstract Object getValue(Row row, ID id);
+
+    /**
+     * Reads the value of the column as the given type.
+     *
+     * @param row  The row
+     * @param id   The column identifier
+     * @param type The type
+     * @param <T>  The type
+     * @return The value, can be null
+     */
+    @Nullable
+    protected abstract <T> T getValue(Row row, ID id, Class<T> type);
+
+    /**
+     * Reads the raw value of the column for {@link #getRequiredValue}, which the reader addressing a column by name
+     * retries with an upper case name.
+     *
+     * @param row The row
+     * @param id  The column identifier
+     * @return The value, can be null
+     */
+    @Nullable
+    protected abstract Object getRequiredRawValue(Row row, ID id);
+
+    /**
+     * Reads the value of the column as the given type for {@link #getRequiredValue}, which the reader addressing a
+     * column by name retries with an upper case name.
+     *
+     * @param row  The row
+     * @param id   The column identifier
+     * @param type The type
+     * @param <T>  The type
+     * @return The value, can be null
+     */
+    @Nullable
+    protected abstract <T> T getRequiredTypedValue(Row row, ID id, Class<T> type);
+
+    /**
+     * @param id The column identifier
+     * @param e  The cause
+     * @return The exception describing a column that cannot be read
+     */
+    protected abstract DataAccessException exceptionForColumn(ID id, Exception e);
+
+    @Override
+    public ConversionService getConversionService() {
+        return conversionService;
+    }
+
+    @Nullable
+    @Override
+    public Object readDynamic(@NonNull Row resultSet, @NonNull ID index, @NonNull DataType dataType) {
+        switch (dataType) {
+            case UUID:
+                return readUUID(resultSet, index);
+            case STRING:
+            case JSON:
+                return readString(resultSet, index);
+            case LONG:
+                return getValue(resultSet, index, Long.class);
+            case INTEGER:
+                Object o = getValue(resultSet, index);
+                if (o == null) {
+                    return null;
+                }
+                if (o instanceof Integer) {
+                    return o;
+                }
+                if (o instanceof Number number) {
+                    return number.intValue();
+                }
+                return convertRequired(o, Integer.class);
+            case BOOLEAN:
+                return getValue(resultSet, index, Boolean.class);
+            case BYTE:
+                return getValue(resultSet, index, Byte.class);
+            case TIMESTAMP:
+                return readAs(resultSet, index, Instant.class);
+            case DATE:
+                return readAs(resultSet, index, LocalDate.class);
+            case TIME:
+                return readAs(resultSet, index, Time.class);
+            case CHARACTER:
+                return readAs(resultSet, index, Character.class);
+            case FLOAT:
+                return readAs(resultSet, index, Float.class);
+            case SHORT:
+                return readAs(resultSet, index, Short.class);
+            case DOUBLE:
+                return getValue(resultSet, index, Double.class);
+            case BYTE_ARRAY:
+                return readBytes(resultSet, index);
+            case BIGDECIMAL:
+                return getValue(resultSet, index, BigDecimal.class);
+            case OBJECT:
+            default:
+                return getRequiredValue(resultSet, index, Object.class);
+        }
+    }
+
+    @Nullable
+    private <T> T readAs(@NonNull Row resultSet, @NonNull ID index, Class<T> type) {
+        Object o = getValue(resultSet, index);
+        if (o == null) {
+            return null;
+        }
+        if (type.isInstance(o)) {
+            return (T) o;
+        }
+        return convertRequired(o, type);
+    }
+
+    @Override
+    public long readLong(Row resultSet, ID name) {
+        Long l = getValue(resultSet, name, Long.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public char readChar(Row resultSet, ID name) {
+        Character character = getValue(resultSet, name, Character.class);
+        if (character != null) {
+            return character;
+        }
+        return 0;
+    }
+
+    @Override
+    @Nullable
+    public Date readDate(Row resultSet, ID name) {
+        final LocalDate localDate = getValue(resultSet, name, LocalDate.class);
+        if (localDate != null) {
+            return java.sql.Date.valueOf(localDate);
+        }
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Date readTimestamp(Row resultSet, ID index) {
+        final LocalDateTime localDateTime = getValue(resultSet, index, LocalDateTime.class);
+        if (localDateTime != null) {
+            return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String readString(Row resultSet, ID name) {
+        Object o = getValue(resultSet, name);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof String string) {
+            return string;
+        }
+        if (o instanceof Clob clob) {
+            CharSequence charSequence = Mono.from(clob.stream()).block();
+            return charSequence == null ? null : charSequence.toString();
+        }
+        // Try to get it as a string otherwise Postgres can return an internal class
+        try {
+            return getValue(resultSet, name, String.class);
+        } catch (Exception e) {
+            // Ignore
+        }
+        return convertRequired(o, String.class);
+    }
+
+    @Override
+    public int readInt(Row resultSet, ID name) {
+        Integer l = getValue(resultSet, name, Integer.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public boolean readBoolean(Row resultSet, ID name) {
+        Boolean l = getValue(resultSet, name, Boolean.class);
+        if (l != null) {
+            return l;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public float readFloat(Row resultSet, ID name) {
+        Float l = getValue(resultSet, name, Float.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public byte readByte(Row resultSet, ID name) {
+        Byte l = getValue(resultSet, name, Byte.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public short readShort(Row resultSet, ID name) {
+        Short l = getValue(resultSet, name, Short.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public double readDouble(Row resultSet, ID name) {
+        Double l = getValue(resultSet, name, Double.class);
+        if (l != null) {
+            return l;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    @Nullable
+    public BigDecimal readBigDecimal(Row resultSet, ID name) {
+        return getValue(resultSet, name, BigDecimal.class);
+    }
+
+    @Override
+    public byte @Nullable [] readBytes(Row resultSet, ID name) {
+        try {
+            return getValue(resultSet, name, byte[].class);
+        } catch (Exception e) {
+            // Ignore and fallback to generic handling (Oracle, H2, etc.)
+        }
+        return R2dbcBytesReader.toBytes(getValue(resultSet, name), this);
+    }
+
+    @Nullable
+    @Override
+    public <T> T getRequiredValue(Row resultSet, ID name, Class<T> type) throws DataAccessException {
+        try {
+            T value = getRequiredTypedValue(resultSet, name, type);
+            if (value != null) {
+                return value;
+            }
+            Object raw = getRequiredRawValue(resultSet, name);
+            if (raw == null) {
+                return null;
+            }
+            if (type.isInstance(raw)) {
+                return type.cast(raw);
+            }
+            return conversionService.convert(raw, type).orElse(null);
+        } catch (IllegalArgumentException | ConversionErrorException |
+                 R2dbcTransientResourceException e) {
+            try {
+                return conversionService.convert(getValue(resultSet, name), type).orElse(null);
+            } catch (Exception exception) {
+                throw exceptionForColumn(name, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean next(Row resultSet) {
+        // not used
+        return false;
+    }
+}

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/AbstractR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/AbstractR2dbcResultReader.java
@@ -43,11 +43,11 @@ import java.util.Date;
  * <p>Every value is read through {@link #getValue(Row, Object)} and {@link #getValue(Row, Object, Class)}, so both
  * readers interpret a column the same way and only differ in how they address it.</p>
  *
- * @param <ID> The column identifier type, a name or an ordinal
+ * @param <I> The column identifier type, a name or an ordinal
  * @since 5.2.0
  */
 @Internal
-abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
+abstract class AbstractR2dbcResultReader<I> implements ResultReader<Row, I> {
 
     protected final ConversionService conversionService;
 
@@ -64,7 +64,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
      * @return The value, can be null
      */
     @Nullable
-    protected abstract Object getValue(Row row, ID id);
+    protected abstract Object getValue(Row row, I id);
 
     /**
      * Reads the value of the column as the given type.
@@ -76,7 +76,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
      * @return The value, can be null
      */
     @Nullable
-    protected abstract <T> T getValue(Row row, ID id, Class<T> type);
+    protected abstract <T> T getValue(Row row, I id, Class<T> type);
 
     /**
      * Reads the raw value of the column for {@link #getRequiredValue}, which the reader addressing a column by name
@@ -87,7 +87,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
      * @return The value, can be null
      */
     @Nullable
-    protected abstract Object getRequiredRawValue(Row row, ID id);
+    protected abstract Object getRequiredRawValue(Row row, I id);
 
     /**
      * Reads the value of the column as the given type for {@link #getRequiredValue}, which the reader addressing a
@@ -100,14 +100,14 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
      * @return The value, can be null
      */
     @Nullable
-    protected abstract <T> T getRequiredTypedValue(Row row, ID id, Class<T> type);
+    protected abstract <T> T getRequiredTypedValue(Row row, I id, Class<T> type);
 
     /**
      * @param id The column identifier
      * @param e  The cause
      * @return The exception describing a column that cannot be read
      */
-    protected abstract DataAccessException exceptionForColumn(ID id, Exception e);
+    protected abstract DataAccessException exceptionForColumn(I id, Exception e);
 
     @Override
     public ConversionService getConversionService() {
@@ -116,57 +116,44 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Nullable
     @Override
-    public Object readDynamic(@NonNull Row resultSet, @NonNull ID index, @NonNull DataType dataType) {
-        switch (dataType) {
-            case UUID:
-                return readUUID(resultSet, index);
-            case STRING:
-            case JSON:
-                return readString(resultSet, index);
-            case LONG:
-                return getValue(resultSet, index, Long.class);
-            case INTEGER:
-                Object o = getValue(resultSet, index);
-                if (o == null) {
-                    return null;
-                }
-                if (o instanceof Integer) {
-                    return o;
-                }
-                if (o instanceof Number number) {
-                    return number.intValue();
-                }
-                return convertRequired(o, Integer.class);
-            case BOOLEAN:
-                return getValue(resultSet, index, Boolean.class);
-            case BYTE:
-                return getValue(resultSet, index, Byte.class);
-            case TIMESTAMP:
-                return readAs(resultSet, index, Instant.class);
-            case DATE:
-                return readAs(resultSet, index, LocalDate.class);
-            case TIME:
-                return readAs(resultSet, index, Time.class);
-            case CHARACTER:
-                return readAs(resultSet, index, Character.class);
-            case FLOAT:
-                return readAs(resultSet, index, Float.class);
-            case SHORT:
-                return readAs(resultSet, index, Short.class);
-            case DOUBLE:
-                return getValue(resultSet, index, Double.class);
-            case BYTE_ARRAY:
-                return readBytes(resultSet, index);
-            case BIGDECIMAL:
-                return getValue(resultSet, index, BigDecimal.class);
-            case OBJECT:
-            default:
-                return getRequiredValue(resultSet, index, Object.class);
-        }
+    public Object readDynamic(@NonNull Row resultSet, @NonNull I index, @NonNull DataType dataType) {
+        return switch (dataType) {
+            case UUID -> readUUID(resultSet, index);
+            case STRING, JSON -> readString(resultSet, index);
+            case LONG -> getValue(resultSet, index, Long.class);
+            case INTEGER -> readInteger(resultSet, index);
+            case BOOLEAN -> getValue(resultSet, index, Boolean.class);
+            case BYTE -> getValue(resultSet, index, Byte.class);
+            case TIMESTAMP -> readAs(resultSet, index, Instant.class);
+            case DATE -> readAs(resultSet, index, LocalDate.class);
+            case TIME -> readAs(resultSet, index, Time.class);
+            case CHARACTER -> readAs(resultSet, index, Character.class);
+            case FLOAT -> readAs(resultSet, index, Float.class);
+            case SHORT -> readAs(resultSet, index, Short.class);
+            case DOUBLE -> getValue(resultSet, index, Double.class);
+            case BYTE_ARRAY -> readBytes(resultSet, index);
+            case BIGDECIMAL -> getValue(resultSet, index, BigDecimal.class);
+            default -> getRequiredValue(resultSet, index, Object.class);
+        };
     }
 
     @Nullable
-    private <T> T readAs(@NonNull Row resultSet, @NonNull ID index, Class<T> type) {
+    private Object readInteger(Row resultSet, I index) {
+        Object o = getValue(resultSet, index);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof Integer) {
+            return o;
+        }
+        if (o instanceof Number number) {
+            return number.intValue();
+        }
+        return convertRequired(o, Integer.class);
+    }
+
+    @Nullable
+    private <T> T readAs(@NonNull Row resultSet, @NonNull I index, Class<T> type) {
         Object o = getValue(resultSet, index);
         if (o == null) {
             return null;
@@ -178,7 +165,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public long readLong(Row resultSet, ID name) {
+    public long readLong(Row resultSet, I name) {
         Long l = getValue(resultSet, name, Long.class);
         if (l != null) {
             return l;
@@ -188,7 +175,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public char readChar(Row resultSet, ID name) {
+    public char readChar(Row resultSet, I name) {
         Character character = getValue(resultSet, name, Character.class);
         if (character != null) {
             return character;
@@ -198,7 +185,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Override
     @Nullable
-    public Date readDate(Row resultSet, ID name) {
+    public Date readDate(Row resultSet, I name) {
         final LocalDate localDate = getValue(resultSet, name, LocalDate.class);
         if (localDate != null) {
             return java.sql.Date.valueOf(localDate);
@@ -208,7 +195,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Override
     @Nullable
-    public Date readTimestamp(Row resultSet, ID index) {
+    public Date readTimestamp(Row resultSet, I index) {
         final LocalDateTime localDateTime = getValue(resultSet, index, LocalDateTime.class);
         if (localDateTime != null) {
             return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
@@ -218,7 +205,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Nullable
     @Override
-    public String readString(Row resultSet, ID name) {
+    public String readString(Row resultSet, I name) {
         Object o = getValue(resultSet, name);
         if (o == null) {
             return null;
@@ -233,14 +220,14 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
         // Try to get it as a string otherwise Postgres can return an internal class
         try {
             return getValue(resultSet, name, String.class);
-        } catch (Exception e) {
+        } catch (Exception _) {
             // Ignore
         }
         return convertRequired(o, String.class);
     }
 
     @Override
-    public int readInt(Row resultSet, ID name) {
+    public int readInt(Row resultSet, I name) {
         Integer l = getValue(resultSet, name, Integer.class);
         if (l != null) {
             return l;
@@ -250,7 +237,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public boolean readBoolean(Row resultSet, ID name) {
+    public boolean readBoolean(Row resultSet, I name) {
         Boolean l = getValue(resultSet, name, Boolean.class);
         if (l != null) {
             return l;
@@ -260,7 +247,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public float readFloat(Row resultSet, ID name) {
+    public float readFloat(Row resultSet, I name) {
         Float l = getValue(resultSet, name, Float.class);
         if (l != null) {
             return l;
@@ -270,7 +257,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public byte readByte(Row resultSet, ID name) {
+    public byte readByte(Row resultSet, I name) {
         Byte l = getValue(resultSet, name, Byte.class);
         if (l != null) {
             return l;
@@ -280,7 +267,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public short readShort(Row resultSet, ID name) {
+    public short readShort(Row resultSet, I name) {
         Short l = getValue(resultSet, name, Short.class);
         if (l != null) {
             return l;
@@ -290,7 +277,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
     }
 
     @Override
-    public double readDouble(Row resultSet, ID name) {
+    public double readDouble(Row resultSet, I name) {
         Double l = getValue(resultSet, name, Double.class);
         if (l != null) {
             return l;
@@ -301,15 +288,15 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Override
     @Nullable
-    public BigDecimal readBigDecimal(Row resultSet, ID name) {
+    public BigDecimal readBigDecimal(Row resultSet, I name) {
         return getValue(resultSet, name, BigDecimal.class);
     }
 
     @Override
-    public byte @Nullable [] readBytes(Row resultSet, ID name) {
+    public byte @Nullable [] readBytes(Row resultSet, I name) {
         try {
             return getValue(resultSet, name, byte[].class);
-        } catch (Exception e) {
+        } catch (Exception _) {
             // Ignore and fallback to generic handling (Oracle, H2, etc.)
         }
         return R2dbcBytesReader.toBytes(getValue(resultSet, name), this);
@@ -317,7 +304,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
 
     @Nullable
     @Override
-    public <T> T getRequiredValue(Row resultSet, ID name, Class<T> type) throws DataAccessException {
+    public <T> T getRequiredValue(Row resultSet, I name, Class<T> type) throws DataAccessException {
         try {
             T value = getRequiredTypedValue(resultSet, name, type);
             if (value != null) {
@@ -335,7 +322,7 @@ abstract class AbstractR2dbcResultReader<ID> implements ResultReader<Row, ID> {
                  R2dbcTransientResourceException e) {
             try {
                 return conversionService.convert(getValue(resultSet, name), type).orElse(null);
-            } catch (Exception exception) {
+            } catch (Exception _) {
                 throw exceptionForColumn(name, e);
             }
         }

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReader.java
@@ -15,26 +15,15 @@
  */
 package io.micronaut.data.r2dbc.mapper;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.data.exceptions.DataAccessException;
-import io.micronaut.data.model.DataType;
 import io.micronaut.data.runtime.convert.DataConversionService;
 import io.micronaut.data.runtime.mapper.ResultReader;
-import io.r2dbc.spi.Clob;
-import io.r2dbc.spi.R2dbcTransientResourceException;
+import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Row;
-import reactor.core.publisher.Mono;
+import io.r2dbc.spi.RowMetadata;
+import org.jspecify.annotations.Nullable;
 
-import java.math.BigDecimal;
-import java.sql.Time;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -43,8 +32,9 @@ import java.util.Locale;
  * @author graemerocher
  * @since 1.0.0
  */
-public class ColumnNameR2dbcResultReader implements ResultReader<Row, String> {
-    private final ConversionService conversionService;
+public class ColumnNameR2dbcResultReader extends AbstractR2dbcResultReader<String> {
+
+    private final ColumnOrdinalR2dbcResultReader columnOrdinalReader;
 
     public ColumnNameR2dbcResultReader() {
         this(null);
@@ -57,246 +47,28 @@ public class ColumnNameR2dbcResultReader implements ResultReader<Row, String> {
      * @since 3.1
      */
     public ColumnNameR2dbcResultReader(@Nullable DataConversionService conversionService) {
-        // Backwards compatibility should be removed in the next version
-        this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
-    }
-
-    @Override
-    public ConversionService getConversionService() {
-        return conversionService;
-    }
-
-    @Nullable
-    @Override
-    public Object readDynamic(@NonNull Row resultSet, @NonNull String index, @NonNull DataType dataType) {
-        switch (dataType) {
-            case UUID:
-                return readUUID(resultSet, index);
-            case STRING:
-            case JSON:
-                return readString(resultSet, index);
-            case LONG:
-                return resultSet.get(index, Long.class);
-            case INTEGER:
-                Object o = resultSet.get(index);
-                if (o == null) {
-                    return null;
-                }
-                if (o instanceof Integer) {
-                    return o;
-                }
-                if (o instanceof Number number) {
-                    return number.intValue();
-                }
-                return convertRequired(o, Integer.class);
-            case BOOLEAN:
-                return resultSet.get(index, Boolean.class);
-            case BYTE:
-                return resultSet.get(index, Byte.class);
-            case TIMESTAMP:
-                return readDynamic(resultSet, index, Instant.class);
-            case DATE:
-                return readDynamic(resultSet, index, LocalDate.class);
-            case TIME:
-                return readDynamic(resultSet, index, Time.class);
-            case CHARACTER:
-                return readDynamic(resultSet, index, Character.class);
-            case FLOAT:
-                return readDynamic(resultSet, index, Float.class);
-            case SHORT:
-                return readDynamic(resultSet, index, Short.class);
-            case DOUBLE:
-                return resultSet.get(index, Double.class);
-            case BYTE_ARRAY:
-                return readBytes(resultSet, index);
-            case BIGDECIMAL:
-                return resultSet.get(index, BigDecimal.class);
-            case OBJECT:
-            default:
-                return getRequiredValue(resultSet, index, Object.class);
-        }
-    }
-
-    @Nullable
-    private <T> T readDynamic(@NonNull Row resultSet, @NonNull String index, Class<T> type) {
-        Object o = resultSet.get(index);
-        if (o == null) {
-            return null;
-        }
-        if (type.isInstance(o)) {
-            return (T) o;
-        }
-        return convertRequired(o, type);
-    }
-
-    @Override
-    public long readLong(Row resultSet, String name) {
-        Long l = resultSet.get(name, Long.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public char readChar(Row resultSet, String name) {
-        Character character = resultSet.get(name, Character.class);
-        if (character != null) {
-            return character;
-        }
-        return 0;
+        super(conversionService);
+        this.columnOrdinalReader = new ColumnOrdinalR2dbcResultReader(conversionService);
     }
 
     @Override
     @Nullable
-    public Date readDate(Row resultSet, String name) {
-        final LocalDate localDate = resultSet.get(name, LocalDate.class);
-        if (localDate != null) {
-            return java.sql.Date.valueOf(localDate);
-        }
-        return null;
+    protected Object getValue(Row row, String name) {
+        return row.get(name);
     }
 
     @Override
     @Nullable
-    public Date readTimestamp(Row resultSet, String index) {
-        final LocalDateTime localDateTime = resultSet.get(index, LocalDateTime.class);
-        if (localDateTime != null) {
-            return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
-        }
-        return null;
+    protected <T> T getValue(Row row, String name, Class<T> type) {
+        return row.get(name, type);
     }
 
+    @Override
     @Nullable
-    @Override
-    public String readString(Row resultSet, String name) {
-        Object o = resultSet.get(name);
-        if (o == null) {
-            return null;
-        }
-        if (o instanceof String string) {
-            return string;
-        }
-        if (o instanceof Clob clob) {
-            CharSequence charSequence = Mono.from(clob.stream()).block();
-            return charSequence == null ? null : charSequence.toString();
-        }
-        // Try to get it as a string otherwise Postgres can return an internal class
-        try {
-            return resultSet.get(name, String.class);
-        } catch (Exception e) {
-            // Ignore
-        }
-        return convertRequired(o, String.class);
-    }
-
-    @Override
-    public int readInt(Row resultSet, String name) {
-        Integer l = resultSet.get(name, Integer.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public boolean readBoolean(Row resultSet, String name) {
-        Boolean l = resultSet.get(name, Boolean.class);
-        if (l != null) {
-            return l;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public float readFloat(Row resultSet, String name) {
-        Float l = resultSet.get(name, Float.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public byte readByte(Row resultSet, String name) {
-        Byte l = resultSet.get(name, Byte.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public short readShort(Row resultSet, String name) {
-        Short l = resultSet.get(name, Short.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public double readDouble(Row resultSet, String name) {
-        Double l = resultSet.get(name, Double.class);
-        if (l != null) {
-            return l;
-        } else {
-            return 0;
-        }
-    }
-
-    @Override
-    public BigDecimal readBigDecimal(Row resultSet, String name) {
-        return resultSet.get(name, BigDecimal.class);
-    }
-
-    @Override
-    public byte @Nullable [] readBytes(Row resultSet, String name) {
-        try {
-            return resultSet.get(name, byte[].class);
-        } catch (Exception e) {
-            // Ignore and fallback to generic handling (Oracle, H2, etc.)
-        }
-        return R2dbcBytesReader.toBytes(resultSet.get(name), this);
-    }
-
-    @Nullable
-    @Override
-    public <T> T getRequiredValue(Row resultSet, String name, Class<T> type) throws DataAccessException {
-        try {
-            T value = getTypedValue(resultSet, name, type);
-            if (value != null) {
-                return value;
-            }
-            Object raw = getRawValue(resultSet, name);
-            if (raw == null) {
-                return null;
-            }
-            if (type.isInstance(raw)) {
-                return type.cast(raw);
-            }
-            return conversionService.convert(raw, type).orElse(null);
-        } catch (IllegalArgumentException | ConversionErrorException |
-                 R2dbcTransientResourceException e) {
-            try {
-                return conversionService.convert(resultSet.get(name), type).orElse(null);
-            } catch (Exception exception) {
-                throw exceptionForColumn(name, e);
-            }
-        }
-    }
-
-    @Nullable
-    private static <T> T getTypedValue(Row resultSet, String name, Class<T> type) {
+    protected <T> T getRequiredTypedValue(Row row, String name, Class<T> type) {
         IllegalArgumentException lowerCaseFailure = null;
         try {
-            return resultSet.get(name, type);
+            return row.get(name, type);
         } catch (IllegalArgumentException e) {
             lowerCaseFailure = e;
         }
@@ -305,18 +77,19 @@ public class ColumnNameR2dbcResultReader implements ResultReader<Row, String> {
             throw lowerCaseFailure;
         }
         try {
-            return resultSet.get(upperName, type);
+            return row.get(upperName, type);
         } catch (IllegalArgumentException e) {
             e.addSuppressed(lowerCaseFailure);
             throw e;
         }
     }
 
+    @Override
     @Nullable
-    private static Object getRawValue(Row resultSet, String name) {
+    protected Object getRequiredRawValue(Row row, String name) {
         IllegalArgumentException lowerCaseFailure = null;
         try {
-            return resultSet.get(name);
+            return row.get(name);
         } catch (IllegalArgumentException e) {
             lowerCaseFailure = e;
         }
@@ -325,20 +98,57 @@ public class ColumnNameR2dbcResultReader implements ResultReader<Row, String> {
             throw lowerCaseFailure;
         }
         try {
-            return resultSet.get(upperName);
+            return row.get(upperName);
         } catch (IllegalArgumentException e) {
             e.addSuppressed(lowerCaseFailure);
             throw e;
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The ordinal is resolved from the row metadata, matching the column name the way the drivers do, ignoring
+     * case. A column that cannot be matched is reported as {@code -1} so that the caller keeps reading it by name.</p>
+     */
     @Override
-    public boolean next(Row resultSet) {
-        // not used
-        return false;
+    public int findColumnIndex(Row resultSet, String columnName) {
+        try {
+            List<? extends ColumnMetadata> columns = resultSet.getMetadata().getColumnMetadatas();
+            for (int i = 0; i < columns.size(); i++) {
+                if (columns.get(i).getName().equalsIgnoreCase(columnName)) {
+                    return i;
+                }
+            }
+        } catch (Exception e) {
+            // The metadata is unavailable, the caller keeps reading by name
+        }
+        return -1;
     }
 
-    private DataAccessException exceptionForColumn(String name, Exception e) {
+    @Override
+    public ResultReader<Row, Integer> getColumnIndexReader() {
+        return columnOrdinalReader;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>An R2DBC {@link Row} is only valid for the row being consumed, so the resolved ordinals are tied to the
+     * {@link RowMetadata} instead, which the drivers share between the rows of one result. A driver that returns
+     * fresh metadata per row simply causes the ordinals to be resolved again for each row.</p>
+     */
+    @Override
+    public Object columnResolutionKey(Row resultSet) {
+        try {
+            return resultSet.getMetadata();
+        } catch (Exception e) {
+            return resultSet;
+        }
+    }
+
+    @Override
+    protected DataAccessException exceptionForColumn(String name, Exception e) {
         return new DataAccessException("Error reading object for name [" + name + "] from result set: " + e.getMessage(), e);
     }
 }

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReader.java
@@ -120,7 +120,7 @@ public class ColumnNameR2dbcResultReader extends AbstractR2dbcResultReader<Strin
                     return i;
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception _) {
             // The metadata is unavailable, the caller keeps reading by name
         }
         return -1;
@@ -142,7 +142,7 @@ public class ColumnNameR2dbcResultReader extends AbstractR2dbcResultReader<Strin
     public Object columnResolutionKey(Row resultSet) {
         try {
             return resultSet.getMetadata();
-        } catch (Exception e) {
+        } catch (Exception _) {
             return resultSet;
         }
     }

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnOrdinalR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnOrdinalR2dbcResultReader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mapper;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.data.exceptions.DataAccessException;
+import io.micronaut.data.runtime.convert.DataConversionService;
+import io.r2dbc.spi.Row;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The R2DBC reader that addresses a column by its zero based ordinal, interpreting the value exactly as
+ * {@link ColumnNameR2dbcResultReader} does.
+ *
+ * <p>It is used to read the rows after the column name has been resolved to an ordinal once, so the driver does not
+ * have to resolve the name again for every row.</p>
+ *
+ * @since 5.2.0
+ */
+@Internal
+final class ColumnOrdinalR2dbcResultReader extends AbstractR2dbcResultReader<Integer> {
+
+    ColumnOrdinalR2dbcResultReader(@Nullable DataConversionService conversionService) {
+        super(conversionService);
+    }
+
+    @Override
+    @Nullable
+    protected Object getValue(Row row, Integer index) {
+        return row.get((int) index);
+    }
+
+    @Override
+    @Nullable
+    protected <T> T getValue(Row row, Integer index, Class<T> type) {
+        return row.get((int) index, type);
+    }
+
+    @Override
+    @Nullable
+    protected Object getRequiredRawValue(Row row, Integer index) {
+        return getValue(row, index);
+    }
+
+    @Override
+    @Nullable
+    protected <T> T getRequiredTypedValue(Row row, Integer index, Class<T> type) {
+        return getValue(row, index, type);
+    }
+
+    @Override
+    protected DataAccessException exceptionForColumn(Integer index, Exception e) {
+        return new DataAccessException("Error reading object for index [" + index + "] from result set: " + e.getMessage(), e);
+    }
+}

--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnOrdinalR2dbcResultReader.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/ColumnOrdinalR2dbcResultReader.java
@@ -40,13 +40,13 @@ final class ColumnOrdinalR2dbcResultReader extends AbstractR2dbcResultReader<Int
     @Override
     @Nullable
     protected Object getValue(Row row, Integer index) {
-        return row.get((int) index);
+        return row.get(index);
     }
 
     @Override
     @Nullable
     protected <T> T getValue(Row row, Integer index, Class<T> type) {
-        return row.get((int) index, type);
+        return row.get(index, type);
     }
 
     @Override

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReaderSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReaderSpec.groovy
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.data.r2dbc.mapper
+
+import io.micronaut.data.model.DataType
+import io.r2dbc.spi.ColumnMetadata
+import io.r2dbc.spi.Row
+import io.r2dbc.spi.RowMetadata
+import io.r2dbc.spi.Type
+import spock.lang.Specification
+
+class ColumnNameR2dbcResultReaderSpec extends Specification {
+
+    static final List<String> COLUMNS = ["id", "title", "pages"]
+
+    void "resolves the ordinal of a column from the row metadata"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([1L, "Book", 100])
+
+        expect:
+        reader.findColumnIndex(row, "id") == 0
+        reader.findColumnIndex(row, "title") == 1
+        reader.findColumnIndex(row, "pages") == 2
+    }
+
+    void "matches the column name ignoring case, like the drivers do"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([1L, "Book", 100])
+
+        expect:
+        reader.findColumnIndex(row, "TITLE") == 1
+    }
+
+    void "reports an unknown column so the caller keeps reading by name"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([1L, "Book", 100])
+
+        expect:
+        reader.findColumnIndex(row, "missing") == -1
+    }
+
+    void "ties the resolved ordinals to the row metadata, which is shared by the rows of one result"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def metadata = new StubRowMetadata()
+        def first = new StubRow([1L, "Book 1", 100], metadata)
+        def second = new StubRow([2L, "Book 2", 200], metadata)
+
+        expect: "the rows differ but share the key, so the ordinals survive from one row to the next"
+        !first.is(second)
+        reader.columnResolutionKey(first).is(reader.columnResolutionKey(second))
+    }
+
+    void "reading by the resolved ordinal returns what reading by name returns"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def indexReader = reader.getColumnIndexReader()
+        def row = new StubRow([1L, "Book", 100])
+
+        expect:
+        indexReader != null
+        indexReader.readDynamic(row, reader.findColumnIndex(row, "id"), DataType.LONG) ==
+                reader.readDynamic(row, "id", DataType.LONG)
+        indexReader.readDynamic(row, reader.findColumnIndex(row, "title"), DataType.STRING) ==
+                reader.readDynamic(row, "title", DataType.STRING)
+        indexReader.readDynamic(row, reader.findColumnIndex(row, "pages"), DataType.INTEGER) ==
+                reader.readDynamic(row, "pages", DataType.INTEGER)
+    }
+
+    static class StubColumnMetadata implements ColumnMetadata {
+        final String name
+
+        StubColumnMetadata(String name) {
+            this.name = name
+        }
+
+        @Override
+        String getName() {
+            return name
+        }
+
+        @Override
+        Type getType() {
+            throw new UnsupportedOperationException()
+        }
+    }
+
+    static class StubRowMetadata implements RowMetadata {
+        @Override
+        ColumnMetadata getColumnMetadata(int index) {
+            return new StubColumnMetadata(COLUMNS[index])
+        }
+
+        @Override
+        ColumnMetadata getColumnMetadata(String name) {
+            return new StubColumnMetadata(name)
+        }
+
+        @Override
+        List<? extends ColumnMetadata> getColumnMetadatas() {
+            return COLUMNS.collect { new StubColumnMetadata(it) }
+        }
+    }
+
+    static class StubRow implements Row {
+        final List<Object> values
+        final RowMetadata metadata
+
+        StubRow(List<Object> values, RowMetadata metadata = new StubRowMetadata()) {
+            this.values = values
+            this.metadata = metadata
+        }
+
+        @Override
+        RowMetadata getMetadata() {
+            return metadata
+        }
+
+        @Override
+        <T> T get(int index, Class<T> type) {
+            return convert(values[index], type)
+        }
+
+        @Override
+        <T> T get(String name, Class<T> type) {
+            return convert(values[indexOf(name)], type)
+        }
+
+        @Override
+        Object get(int index) {
+            return values[index]
+        }
+
+        @Override
+        Object get(String name) {
+            return values[indexOf(name)]
+        }
+
+        private static <T> T convert(Object value, Class<T> type) {
+            if (value == null) {
+                return null
+            }
+            return (T) (type.isInstance(value) ? value : value.asType(type))
+        }
+
+        private static int indexOf(String name) {
+            int index = COLUMNS.indexOf(name.toLowerCase())
+            if (index == -1) {
+                throw new NoSuchElementException(name)
+            }
+            return index
+        }
+    }
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReaderSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/mapper/ColumnNameR2dbcResultReaderSpec.groovy
@@ -15,21 +15,66 @@
  */
 package io.micronaut.data.r2dbc.mapper
 
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.data.exceptions.DataAccessException
 import io.micronaut.data.model.DataType
+import io.micronaut.data.runtime.convert.DataConversionService
+import io.r2dbc.spi.Clob
 import io.r2dbc.spi.ColumnMetadata
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.RowMetadata
 import io.r2dbc.spi.Type
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.ByteBuffer
+import java.sql.Time
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class ColumnNameR2dbcResultReaderSpec extends Specification {
 
-    static final List<String> COLUMNS = ["id", "title", "pages"]
+    static final List<String> MODES = ["name", "ordinal"]
+
+    static final List<List<Object>> TYPED_READS = [
+            ["readLong", 5L, 0L],
+            ["readInt", 5, 0],
+            ["readShort", (short) 5, (short) 0],
+            ["readByte", (byte) 5, (byte) 0],
+            ["readDouble", 5.5d, 0d],
+            ["readFloat", 5.5f, 0f],
+            ["readBoolean", true, false],
+            ["readChar", 'x' as char, (char) 0],
+            ["readBigDecimal", 5.5G, null],
+    ]
+
+    static final byte[] BYTES = [1, 2, 3] as byte[]
+
+    static final List<List<Object>> DYNAMIC_READS = [
+            [DataType.UUID, UUID.fromString("00000000-0000-0000-0000-000000000001"), UUID.fromString("00000000-0000-0000-0000-000000000001")],
+            [DataType.BOOLEAN, true, true],
+            [DataType.BYTE, (byte) 3, (byte) 3],
+            [DataType.DOUBLE, 2.5d, 2.5d],
+            [DataType.BIGDECIMAL, 2.5G, 2.5G],
+            [DataType.TIMESTAMP, Instant.parse("2024-01-02T03:04:05Z"), Instant.parse("2024-01-02T03:04:05Z")],
+            [DataType.DATE, LocalDate.of(2024, 1, 2), LocalDate.of(2024, 1, 2)],
+            [DataType.TIME, Time.valueOf("10:11:12"), Time.valueOf("10:11:12")],
+            [DataType.CHARACTER, 'c' as char, 'c' as char],
+            [DataType.FLOAT, "2.5", 2.5f],
+            [DataType.SHORT, null, null],
+            [DataType.BYTE_ARRAY, BYTES, BYTES],
+            [DataType.OBJECT, "anything", "anything"],
+    ]
 
     void "resolves the ordinal of a column from the row metadata"() {
         given:
         def reader = new ColumnNameR2dbcResultReader()
-        def row = new StubRow([1L, "Book", 100])
+        def row = new StubRow([id: 1L, title: "Book", pages: 100])
 
         expect:
         reader.findColumnIndex(row, "id") == 0
@@ -40,7 +85,7 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
     void "matches the column name ignoring case, like the drivers do"() {
         given:
         def reader = new ColumnNameR2dbcResultReader()
-        def row = new StubRow([1L, "Book", 100])
+        def row = new StubRow([id: 1L, title: "Book", pages: 100])
 
         expect:
         reader.findColumnIndex(row, "TITLE") == 1
@@ -49,18 +94,28 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
     void "reports an unknown column so the caller keeps reading by name"() {
         given:
         def reader = new ColumnNameR2dbcResultReader()
-        def row = new StubRow([1L, "Book", 100])
+        def row = new StubRow([id: 1L, title: "Book", pages: 100])
 
         expect:
         reader.findColumnIndex(row, "missing") == -1
     }
 
+    void "keeps reading by name when the row metadata is unavailable"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([id: 1L], null, false)
+
+        expect: "no ordinal, and the row itself as the key so nothing is shared between rows"
+        reader.findColumnIndex(row, "id") == -1
+        reader.columnResolutionKey(row).is(row)
+    }
+
     void "ties the resolved ordinals to the row metadata, which is shared by the rows of one result"() {
         given:
         def reader = new ColumnNameR2dbcResultReader()
-        def metadata = new StubRowMetadata()
-        def first = new StubRow([1L, "Book 1", 100], metadata)
-        def second = new StubRow([2L, "Book 2", 200], metadata)
+        def metadata = new StubRowMetadata(["id", "title", "pages"])
+        def first = new StubRow([id: 1L, title: "Book 1", pages: 100], metadata)
+        def second = new StubRow([id: 2L, title: "Book 2", pages: 200], metadata)
 
         expect: "the rows differ but share the key, so the ordinals survive from one row to the next"
         !first.is(second)
@@ -71,7 +126,7 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
         given:
         def reader = new ColumnNameR2dbcResultReader()
         def indexReader = reader.getColumnIndexReader()
-        def row = new StubRow([1L, "Book", 100])
+        def row = new StubRow([id: 1L, title: "Book", pages: 100])
 
         expect:
         indexReader != null
@@ -81,6 +136,256 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
                 reader.readDynamic(row, "title", DataType.STRING)
         indexReader.readDynamic(row, reader.findColumnIndex(row, "pages"), DataType.INTEGER) ==
                 reader.readDynamic(row, "pages", DataType.INTEGER)
+    }
+
+    @Unroll
+    void "#readMethod reads the value, and the default for a null, by #mode"() {
+        given:
+        def row = new StubRow([present: value, absent: null])
+
+        expect:
+        read(mode, row, "present") { r, c -> r."$readMethod"(row, c) } == value
+        read(mode, row, "absent") { r, c -> r."$readMethod"(row, c) } == defaultValue
+
+        where:
+        [mode, entry] << [MODES, TYPED_READS].combinations()
+        readMethod = entry[0]
+        value = entry[1]
+        defaultValue = entry[2]
+    }
+
+    @Unroll
+    void "reads dates and timestamps as java.util.Date, by #mode"() {
+        given:
+        def date = LocalDate.of(2024, 1, 2)
+        def timestamp = LocalDateTime.of(2024, 1, 2, 3, 4, 5)
+        def row = new StubRow([date: date, timestamp: timestamp, none: null])
+
+        expect:
+        read(mode, row, "date") { r, c -> r.readDate(row, c) } == java.sql.Date.valueOf(date)
+        read(mode, row, "timestamp") { r, c -> r.readTimestamp(row, c) } ==
+                Date.from(timestamp.atZone(ZoneId.systemDefault()).toInstant())
+        read(mode, row, "none") { r, c -> r.readDate(row, c) } == null
+        read(mode, row, "none") { r, c -> r.readTimestamp(row, c) } == null
+
+        where:
+        mode << MODES
+    }
+
+    @Unroll
+    void "reads a string from a string, a clob, or a value the driver will not hand out as a string, by #mode"() {
+        given:
+        def row = new StubRow([
+                text  : "plain",
+                clob  : new StubClob("from clob"),
+                empty : new StubClob(null),
+                number: 42,
+                internal: new Typed(new StringBuilder("pg"), [(String): "rendered"]),
+                none  : null,
+        ])
+
+        expect:
+        read(mode, row, "text") { r, c -> r.readString(row, c) } == "plain"
+        read(mode, row, "clob") { r, c -> r.readString(row, c) } == "from clob"
+        read(mode, row, "empty") { r, c -> r.readString(row, c) } == null
+        read(mode, row, "number") { r, c -> r.readString(row, c) } == "42"
+        read(mode, row, "internal") { r, c -> r.readString(row, c) } == "rendered"
+        read(mode, row, "none") { r, c -> r.readString(row, c) } == null
+
+        where:
+        mode << MODES
+    }
+
+    @Unroll
+    void "reads bytes directly, or from a value the driver will not hand out as bytes, by #mode"() {
+        given:
+        byte[] bytes = [1, 2, 3] as byte[]
+        def row = new StubRow([raw: bytes, buffer: ByteBuffer.wrap(bytes)])
+
+        expect:
+        Arrays.equals((byte[]) read(mode, row, "raw") { r, c -> r.readBytes(row, c) }, bytes)
+        Arrays.equals((byte[]) read(mode, row, "buffer") { r, c -> r.readBytes(row, c) }, bytes)
+
+        where:
+        mode << MODES
+    }
+
+    @Unroll
+    void "reads an integer from an integer, another number, or a convertible value, by #mode"() {
+        given:
+        def row = new StubRow([integer: 7, wider: 7L, text: "7", none: null])
+
+        expect:
+        read(mode, row, "integer") { r, c -> r.readDynamic(row, c, DataType.INTEGER) } == 7
+        read(mode, row, "wider") { r, c -> r.readDynamic(row, c, DataType.INTEGER) } instanceof Integer
+        read(mode, row, "wider") { r, c -> r.readDynamic(row, c, DataType.INTEGER) } == 7
+        read(mode, row, "text") { r, c -> r.readDynamic(row, c, DataType.INTEGER) } == 7
+        read(mode, row, "none") { r, c -> r.readDynamic(row, c, DataType.INTEGER) } == null
+
+        where:
+        mode << MODES
+    }
+
+    @Unroll
+    void "getRequiredValue falls back from the typed value to the raw value, by #mode"() {
+        given:
+        def row = new StubRow([
+                typed       : "direct",
+                rawSameType : new Typed("raw", [(String): null]),
+                rawConverted: new Typed(5, [(String): null]),
+                rawNull     : new Typed(null, [(String): null]),
+                incompatible: 9,
+        ])
+
+        expect: "the typed value when the driver hands it out"
+        read(mode, row, "typed") { r, c -> r.getRequiredValue(row, c, String) } == "direct"
+
+        and: "the raw value, converted if needed, when the typed value is null"
+        read(mode, row, "rawSameType") { r, c -> r.getRequiredValue(row, c, String) } == "raw"
+        read(mode, row, "rawConverted") { r, c -> r.getRequiredValue(row, c, String) } == "5"
+        read(mode, row, "rawNull") { r, c -> r.getRequiredValue(row, c, String) } == null
+
+        and: "the converted raw value when the driver rejects the type"
+        read(mode, row, "incompatible") { r, c -> r.getRequiredValue(row, c, String) } == "9"
+
+        where:
+        mode << MODES
+    }
+
+    @Unroll
+    void "getRequiredValue reports a column that cannot be read at all, by #mode"() {
+        given:
+        def row = new StubRow([broken: new Typed(1, [:], true)])
+
+        when:
+        read(mode, row, "broken") { r, c -> r.getRequiredValue(row, c, String) }
+
+        then:
+        def e = thrown(DataAccessException)
+        e.message.contains(identifier)
+
+        where:
+        mode      | identifier
+        "name"    | "name [broken]"
+        "ordinal" | "index [0]"
+    }
+
+    void "the name reader retries a column in upper case, the way some drivers report it"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([TITLE: new Typed("Book", [(Object): null])])
+
+        expect:
+        reader.getRequiredValue(row, "title", Object) == "Book"
+    }
+
+    @Unroll
+    void "readDynamic reads a #dataType column, by #mode"() {
+        given:
+        def row = new StubRow([value: stored])
+
+        expect:
+        read(mode, row, "value") { r, c -> r.readDynamic(row, c, dataType) } == expected
+
+        where:
+        [mode, entry] << [MODES, DYNAMIC_READS].combinations()
+        dataType = entry[0]
+        stored = entry[1]
+        expected = entry[2]
+    }
+
+    void "uses the conversion service it is given, and the shared one otherwise"() {
+        given:
+        def conversionService = Mock(DataConversionService)
+        def configured = new ColumnNameR2dbcResultReader(conversionService)
+
+        expect:
+        configured.getConversionService().is(conversionService)
+        configured.getColumnIndexReader().getConversionService().is(conversionService)
+        new ColumnNameR2dbcResultReader().getConversionService().is(ConversionService.SHARED)
+    }
+
+    void "next is not used for R2DBC rows"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([id: 1L])
+
+        expect:
+        !reader.next(row)
+        !reader.getColumnIndexReader().next(row)
+    }
+
+    void "the name reader reports a column it cannot read in either case"() {
+        given:
+        def reader = new ColumnNameR2dbcResultReader()
+        def row = new StubRow([TITLE: new Typed("Book", [(Object): null], false, true)])
+
+        when: "the name is already upper case, so there is nothing to retry"
+        reader.getRequiredValue(row, "MISSING", String)
+
+        then:
+        thrown(DataAccessException)
+
+        when: "the typed read is null and the raw read is rejected, with nothing to retry"
+        reader.getRequiredValue(row, "TITLE", Object)
+
+        then:
+        thrown(DataAccessException)
+
+        when: "the raw read is rejected in lower case and again in upper case"
+        reader.getRequiredValue(row, "title", Object)
+
+        then: "the lower case failure is kept alongside the upper case one"
+        def e = thrown(DataAccessException)
+        e.cause.suppressed.length == 1
+    }
+
+    /**
+     * Reads a column with the reader addressing it by name, or with the ordinal reader addressing it by the ordinal
+     * resolved from the row metadata, so that every case runs against both readers.
+     */
+    private static Object read(String mode, Row row, String column, Closure call) {
+        def reader = new ColumnNameR2dbcResultReader()
+        if (mode == "name") {
+            return call.call(reader, column)
+        }
+        return call.call(reader.getColumnIndexReader(), reader.findColumnIndex(row, column))
+    }
+
+    /**
+     * A column whose typed read returns what {@code typed} maps the requested type to, null included. All of its
+     * reads fail when it is {@code broken}, and only its raw read is rejected when it is {@code rawRejected}.
+     */
+    static class Typed {
+        final Object raw
+        final Map<Class, Object> typed
+        final boolean broken
+        final boolean rawRejected
+
+        Typed(Object raw, Map<Class, Object> typed, boolean broken = false, boolean rawRejected = false) {
+            this.raw = raw
+            this.typed = typed
+            this.broken = broken
+            this.rawRejected = rawRejected
+        }
+    }
+
+    static class StubClob implements Clob {
+        final String text
+
+        StubClob(String text) {
+            this.text = text
+        }
+
+        @Override
+        Publisher<CharSequence> stream() {
+            return text == null ? Flux.empty() : Flux.just(text)
+        }
+
+        @Override
+        Publisher<Void> discard() {
+            return Mono.empty()
+        }
     }
 
     static class StubColumnMetadata implements ColumnMetadata {
@@ -102,9 +407,15 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
     }
 
     static class StubRowMetadata implements RowMetadata {
+        final List<String> names
+
+        StubRowMetadata(List<String> names) {
+            this.names = names
+        }
+
         @Override
         ColumnMetadata getColumnMetadata(int index) {
-            return new StubColumnMetadata(COLUMNS[index])
+            return new StubColumnMetadata(names[index])
         }
 
         @Override
@@ -114,57 +425,92 @@ class ColumnNameR2dbcResultReaderSpec extends Specification {
 
         @Override
         List<? extends ColumnMetadata> getColumnMetadatas() {
-            return COLUMNS.collect { new StubColumnMetadata(it) }
+            return names.collect { new StubColumnMetadata(it) }
         }
     }
 
+    /**
+     * A row that looks columns up by exact name, rejecting an unknown name or a value of another type with an
+     * {@link IllegalArgumentException} the way drivers do.
+     */
     static class StubRow implements Row {
-        final List<Object> values
+        final Map<String, Object> columns
+        final List<String> names
         final RowMetadata metadata
+        final boolean metadataAvailable
 
-        StubRow(List<Object> values, RowMetadata metadata = new StubRowMetadata()) {
-            this.values = values
-            this.metadata = metadata
+        StubRow(Map<String, Object> columns, RowMetadata metadata = null, boolean metadataAvailable = true) {
+            this.columns = columns
+            this.names = new ArrayList<>(columns.keySet())
+            this.metadata = metadata ?: new StubRowMetadata(this.names)
+            this.metadataAvailable = metadataAvailable
         }
 
         @Override
         RowMetadata getMetadata() {
+            if (!metadataAvailable) {
+                throw new IllegalStateException("Row metadata is unavailable")
+            }
             return metadata
         }
 
         @Override
         <T> T get(int index, Class<T> type) {
-            return convert(values[index], type)
+            return typedValue(columns.get(names[index]), type)
         }
 
         @Override
         <T> T get(String name, Class<T> type) {
-            return convert(values[indexOf(name)], type)
+            return typedValue(column(name), type)
         }
 
         @Override
         Object get(int index) {
-            return values[index]
+            return rawValue(columns.get(names[index]))
         }
 
         @Override
         Object get(String name) {
-            return values[indexOf(name)]
+            return rawValue(column(name))
         }
 
-        private static <T> T convert(Object value, Class<T> type) {
+        private Object column(String name) {
+            if (!columns.containsKey(name)) {
+                throw new IllegalArgumentException("Unknown column: " + name)
+            }
+            return columns.get(name)
+        }
+
+        private static Object rawValue(Object value) {
+            if (value instanceof Typed) {
+                if (value.broken) {
+                    throw new IllegalStateException("Unreadable column")
+                }
+                if (value.rawRejected) {
+                    throw new IllegalArgumentException("Raw read rejected")
+                }
+                return value.raw
+            }
+            return value
+        }
+
+        private static <T> T typedValue(Object value, Class<T> type) {
+            if (value instanceof Typed) {
+                if (value.broken) {
+                    throw new IllegalArgumentException("Unreadable column")
+                }
+                if (value.typed.containsKey(type)) {
+                    return (T) value.typed.get(type)
+                }
+                value = value.raw
+            }
             if (value == null) {
                 return null
             }
-            return (T) (type.isInstance(value) ? value : value.asType(type))
-        }
-
-        private static int indexOf(String name) {
-            int index = COLUMNS.indexOf(name.toLowerCase())
-            if (index == -1) {
-                throw new NoSuchElementException(name)
+            if (type.isInstance(value)) {
+                return (T) value
             }
-            return index
+            throw new IllegalArgumentException("Cannot read " + value.getClass().simpleName + " as " + type.simpleName)
         }
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/AbstractDelegatingResultReader.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/AbstractDelegatingResultReader.java
@@ -82,6 +82,11 @@ public abstract class AbstractDelegatingResultReader<RS, ID> implements ResultRe
     }
 
     @Override
+    public Object columnResolutionKey(RS resultSet) {
+        return delegate.columnResolutionKey(resultSet);
+    }
+
+    @Override
     @Nullable
     public Object readDynamic(RS resultSet, ID index, DataType dataType) {
         return delegate.readDynamic(resultSet, index, dataType);

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/ResultReader.java
@@ -135,6 +135,22 @@ public interface ResultReader<RS, IDX> {
     }
 
     /**
+     * The object the resolved column ordinals belong to, compared by identity by callers that cache them. It is the
+     * result set itself when the result set spans every row, which is the case for JDBC. Readers whose result set
+     * object is a single row, which is the case for R2DBC, return something shared by the rows of one result, such
+     * as the row metadata, so that the ordinals survive from one row to the next.
+     * <p>
+     * Returning a different object per row is safe: the ordinals are then resolved again for each row.
+     *
+     * @param resultSet The result set
+     * @return The object the resolved ordinals belong to
+     * @since 5.2.0
+     */
+    default Object columnResolutionKey(RS resultSet) {
+        return resultSet;
+    }
+
+    /**
      * Read a value dynamically using the result set and the given name and data type.
      * @param resultSet The result set
      * @param index The name

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/sql/SqlResultEntityTypeMapper.java
@@ -106,13 +106,20 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
      */
     private final Map<String, ColumnRef> columnRefsByName = new HashMap<>();
     /**
-     * The result set the currently resolved column ordinals were resolved from, compared by identity so that a
-     * mapper handed a different result set resolves the ordinals again. The reference is held for as long as the
-     * mapper lives, which is one query execution; an identity hash code is deliberately not used instead, because
-     * two result sets sharing a hash code would silently read the columns of one with the ordinals of the other.
+     * What the currently resolved column ordinals belong to, from {@link ResultReader#columnResolutionKey}, compared
+     * by identity so that a mapper handed a different result set resolves the ordinals again. The reference is held
+     * for as long as the mapper lives, which is one query execution; an identity hash code is deliberately not used
+     * instead, because two result sets sharing a hash code would silently read the columns of one with the ordinals
+     * of the other.
      */
     @Nullable
-    private RS resolvedResultSet;
+    private Object resolvedKey;
+    /**
+     * The result set the {@link #resolvedKey} was last taken from. For JDBC it never changes, and for R2DBC it
+     * changes once per row, so the key is asked for once per row rather than once per column read.
+     */
+    @Nullable
+    private RS resolvedKeySource;
     /**
      * Incremented whenever a different result set is mapped, which invalidates every resolved ordinal.
      */
@@ -819,10 +826,14 @@ public final class SqlResultEntityTypeMapper<RS, R> implements SqlTypeMapper<RS,
      */
     @Nullable
     private Integer resolveColumnIndex(RS rs, ColumnRef column) {
-        if (rs != resolvedResultSet) {
-            // The ordinals are only valid for the result set they were resolved from
-            resolvedResultSet = rs;
-            resolvedGeneration++;
+        if (rs != resolvedKeySource) {
+            resolvedKeySource = rs;
+            Object key = resultReader.columnResolutionKey(rs);
+            if (key != resolvedKey) {
+                // The ordinals are only valid for the result set they were resolved from
+                resolvedKey = key;
+                resolvedGeneration++;
+            }
         }
         if (column.generation != resolvedGeneration) {
             int index = resultReader.findColumnIndex(rs, column.name);


### PR DESCRIPTION
Stacked on #4018, which this targets. It is the R2DBC follow-up that PR deferred.

#4018 already helps R2DBC, because caching the mapped column name per property happens in the shared `SqlResultEntityTypeMapper`. What it left out was reading a column by its ordinal, because an R2DBC `Row` is a different object for every row, so ordinals cached against the result set object would be thrown away on each row.

### Changes

- `ResultReader` gains one more compatible default method, `columnResolutionKey`, which returns what the resolved ordinals belong to. It is the result set itself by default, which is right for JDBC. The R2DBC reader returns the `RowMetadata`, which the drivers share between the rows of one result.
- `SqlResultEntityTypeMapper` asks for that key once per row rather than once per column read. This matters: with the key resolved per read, mapping measured 17% slower than not caching ordinals at all, because `Row.getMetadata()` was being called for every column of every row.
- The logic of `ColumnNameR2dbcResultReader` moves to a package private base class, `AbstractR2dbcResultReader`, which reads every value through two accessors. The new `ColumnOrdinalR2dbcResultReader` binds those accessors to the ordinal overloads. Both readers therefore interpret a column with the same code rather than a copy of it.

The last point is the reason for the diff size. The existing `ColumnIndexR2dbcResultReader` could not be reused: it interprets `TIMESTAMP` as a `Timestamp` where the name reader converts to an `Instant`, `DATE` as a `Date` where the name reader uses a `LocalDate`, and its `readString` does not unwrap a `Clob`. Reusing it would have changed values.

### Measurements

Mapping 2000 rows of a 12 column entity through `SqlResultEntityTypeMapper` against PostgreSQL 17 with r2dbc-postgresql 1.1.2, timing only the row mapping and excluding query execution. Ordinal caching is toggled with a reader that hides the index reader, so both arms run the same binary.

| Run | Ordinals off | Ordinals on | Speedup |
| --- | --- | --- | --- |
| 1 | 15835us | 8964us | 1.77x |
| 2 | 17420us | 8029us | 2.17x |
| 3 | 16669us | 8095us | 2.06x |

Including query execution and the network the same comparison lands between 1.06x and 1.66x across runs, too noisy to quote a single figure, but positive in every run.

For context on why this is worth less than it is on Oracle JDBC: both r2dbc-postgresql and oracle-r2dbc resolve a column name with a map lookup, not with the identifier quoting that made the Oracle JDBC driver so expensive in #3978. Reading one column by ordinal rather than by name measured 61ns against 75ns, about 1.24x, so the gain here comes from doing that on every column of every row rather than from any single lookup being pathological.

### Verification

| Suite | Result |
| --- | --- |
| data-r2dbc H2 and mapper specs | 260 tests, no failures |
| data-r2dbc PostgreSQL | 393 tests, no failures |
| data-r2dbc MySQL and MariaDB | 732 tests, no failures |
| data-jdbc H2 and mapper specs | 724 tests, no failures |
| `checkstyleMain`, data-r2dbc and data-runtime | clean |

New `ColumnNameR2dbcResultReaderSpec` covers ordinal resolution, case insensitive matching, an unknown column falling back to a by-name read, the resolution key being shared by rows of one result, and an ordinal read returning what a name read returns.

The Oracle R2DBC suite reports 15 failures on this branch, but it reports the same 15 on the parent commit: they are all `ORA-12516` listener errors from the container on this machine, not mapping failures. Worth a look on CI.

### Residual risk worth a reviewer's attention

`RowMetadata` being shared between the rows of a result is driver behaviour, not something the R2DBC SPI guarantees. I verified it holds for r2dbc-postgresql, where the metadata identity is stable across rows while the row identity is not. A driver that returned fresh metadata per row would stay correct, since the ordinals would simply be resolved again for each row, but it would lose the benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
