### PR TITLE
Kotlin 2.4: keep CoroutineTransactionOperations.execute result type unbounded

### DIFF
--- a/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/CoroutineJpaSpecificationExecutor.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/jpa/kotlin/CoroutineJpaSpecificationExecutor.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.2
  */
-interface CoroutineJpaSpecificationExecutor<T> {
+interface CoroutineJpaSpecificationExecutor<T : Any> {
 
     /**
      * Returns a single entity matching the given [QuerySpecification].

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutineCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutineCrudRepository.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.1.0
  */
-interface CoroutineCrudRepository<E, ID> : GenericRepository<E, ID> {
+interface CoroutineCrudRepository<E : Any, ID : Any> : GenericRepository<E, ID> {
 
     /**
      * Saves the given valid entity, returning a possibly new entity representing the saved state.

--- a/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
+++ b/data-model/src/main/kotlin/io/micronaut/data/repository/kotlin/CoroutinePageableCrudRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
  * @author Denis Stepanov
  * @since 3.4.0
  */
-interface CoroutinePageableCrudRepository<E, ID> : CoroutineCrudRepository<E, ID> {
+interface CoroutinePageableCrudRepository<E : Any, ID : Any> : CoroutineCrudRepository<E, ID> {
 
     /**
      * Find all results for the given sort order.

--- a/data-tx/build.gradle
+++ b/data-tx/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation mnSql.micronaut.jdbc
     testImplementation mnReactor.micronaut.reactor
     testImplementation mnTest.micronaut.test.junit5
+    testImplementation(mn.kotlinx.coroutines.reactor)
     testImplementation "javax.transaction:javax.transaction-api:1.3"
 
     testRuntimeOnly mnSql.h2

--- a/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperations.kt
+++ b/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperations.kt
@@ -43,12 +43,14 @@ import kotlin.coroutines.CoroutineContext
 @EachBean(ReactorReactiveTransactionOperations::class)
 @Singleton
 @Internal
-class DefaultCoroutineTransactionOperations<C>(private val reactiveTransactionOperations: ReactorReactiveTransactionOperations<C>) : CoroutineTransactionOperations<C> {
+class DefaultCoroutineTransactionOperations<C : Any>(private val reactiveTransactionOperations: ReactorReactiveTransactionOperations<C>) : CoroutineTransactionOperations<C> {
 
+    @Suppress("UNCHECKED_CAST")
     override suspend fun <R> execute(definition: TransactionDefinition,
                                      handler: suspend (CoroutineTransactionStatus<C>) -> R): R {
-        return reactiveTransactionOperations.withTransaction(definition) {
-            mono<R> {
+        // The reactive TX manager cannot carry a `null` result, so it's represented by a sentinel value
+        val result = reactiveTransactionOperations.withTransaction(definition) {
+            mono<Any> {
                 val reactorContext = coroutineContext[ReactorContext.Key]
                 if (reactorContext != null) {
                     val micronautPropagatedContext =
@@ -60,12 +62,13 @@ class DefaultCoroutineTransactionOperations<C>(private val reactiveTransactionOp
                         )
                         return@mono withContext(newCoroutineContext) {
                             handler(DefaultCoroutineTransactionStatus(it))
-                        }
+                        } ?: NULL_RESULT
                     }
                 }
-                handler(DefaultCoroutineTransactionStatus(it))
+                handler(DefaultCoroutineTransactionStatus(it)) ?: NULL_RESULT
             }
         }.awaitSingle()
+        return (if (result === NULL_RESULT) null else result) as R
     }
 
     override fun findTransactionStatus(coroutineContext: CoroutineContext): CoroutineTransactionStatus<C>? {
@@ -78,4 +81,12 @@ class DefaultCoroutineTransactionOperations<C>(private val reactiveTransactionOp
         }
         return null
     }
+
+    private companion object {
+        /**
+         * Sentinel representing a `null` value returned by the handler.
+         */
+        private val NULL_RESULT = Any()
+    }
+
 }

--- a/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionStatus.kt
+++ b/data-tx/src/main/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionStatus.kt
@@ -27,7 +27,7 @@ import io.micronaut.transaction.reactive.ReactiveTransactionStatus
  * @since 4.2.0
  */
 @Internal
-class DefaultCoroutineTransactionStatus<T>(var status: ReactiveTransactionStatus<T>) :
+class DefaultCoroutineTransactionStatus<T : Any>(var status: ReactiveTransactionStatus<T>) :
     CoroutineTransactionStatus<T> {
 
     override val connection: T

--- a/data-tx/src/test/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperationsTest.kt
+++ b/data-tx/src/test/kotlin/io/micronaut/transaction/kotlin/DefaultCoroutineTransactionOperationsTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.transaction.kotlin
+
+import io.micronaut.data.connection.ConnectionDefinition
+import io.micronaut.data.connection.ConnectionStatus
+import io.micronaut.data.connection.ConnectionSynchronization
+import io.micronaut.transaction.TransactionDefinition
+import io.micronaut.transaction.reactive.ReactiveTransactionOperations
+import io.micronaut.transaction.reactive.ReactiveTransactionStatus
+import io.micronaut.transaction.reactive.ReactorReactiveTransactionOperations
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.util.context.ContextView
+import java.util.Optional
+
+/**
+ * Verifies that the result type parameter of [CoroutineTransactionOperations.execute] stays unbounded,
+ * so that handlers returning a nullable value keep compiling and a `null` result is propagated.
+ */
+class DefaultCoroutineTransactionOperationsTest {
+
+    private val operations: CoroutineTransactionOperations<String> =
+        DefaultCoroutineTransactionOperations(StubReactorTransactionOperations())
+
+    @Test
+    fun `null result is propagated`() = runBlocking<Unit> {
+        val result: String? = operations.execute { null }
+        assertNull(result)
+    }
+
+    @Test
+    fun `non-null result of a nullable type is propagated`() = runBlocking<Unit> {
+        val result: String? = operations.execute { "result" }
+        assertEquals("result", result)
+    }
+
+    @Test
+    fun `the connection is exposed to the handler`() = runBlocking<Unit> {
+        val result: String? = operations.execute { it.connection }
+        assertEquals(CONNECTION, result)
+    }
+
+    private companion object {
+        private const val CONNECTION = "connection"
+    }
+
+    private class StubReactorTransactionOperations : ReactorReactiveTransactionOperations<String> {
+
+        override fun findTransactionStatus(contextView: ContextView): Optional<ReactiveTransactionStatus<String>> =
+            Optional.empty()
+
+        override fun getTransactionDefinition(contextView: ContextView): TransactionDefinition? = null
+
+        override fun managesTransaction(transactionStatus: ReactiveTransactionStatus<String>) = true
+
+        override fun <T : Any> withTransaction(
+            definition: TransactionDefinition,
+            handler: ReactiveTransactionOperations.TransactionalCallback<String, T>
+        ): Flux<T> = Flux.from(handler.doInTransaction(StubReactiveTransactionStatus()))
+    }
+
+    private class StubReactiveTransactionStatus : ReactiveTransactionStatus<String> {
+
+        override fun getConnectionStatus(): ConnectionStatus<String> = StubConnectionStatus()
+
+        override fun isNewTransaction() = true
+
+        override fun setRollbackOnly() = Unit
+
+        override fun isRollbackOnly() = false
+
+        override fun isCompleted() = false
+
+        override fun getTransactionDefinition(): TransactionDefinition = TransactionDefinition.DEFAULT
+    }
+
+    private class StubConnectionStatus : ConnectionStatus<String> {
+
+        override fun getConnection() = CONNECTION
+
+        override fun isNew() = true
+
+        override fun getDefinition(): ConnectionDefinition = ConnectionDefinition.DEFAULT
+
+        override fun registerSynchronization(synchronization: ConnectionSynchronization) = Unit
+    }
+}

--- a/doc-examples/r2dbc-example-kotlin/src/test/kotlin/example/NullValueCoroutinesTest.kt
+++ b/doc-examples/r2dbc-example-kotlin/src/test/kotlin/example/NullValueCoroutinesTest.kt
@@ -33,6 +33,15 @@ class NullValueCoroutinesTest : AbstractTest(false) {
     }
 
     @Test
+    fun `'execute' accepts a nullable result type and propagates a null result`() = runBlocking {
+        // The type parameter of `execute` must stay unbounded so that nullable results keep compiling
+        val bookTitle: String? = transactionOperations.execute {
+            bookRepository.findTitleById(-1L)
+        }
+        assert(bookTitle == null)
+    }
+
+    @Test
     fun `'suspend fun' nullable 'String' return type, record present, value returned when fetching property by entity ID`() = runBlocking {
         transactionOperations.execute {
             val author = Author("Huxley")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ h2gis = "2.2.5"
 # Gradle plugins
 
 ksp-gradle-plugin = "2.3.11"
-kotlin-gradle-plugin = "2.3.21"
+kotlin-gradle-plugin = "2.4.10"
 jmh-gradle-plugin = "0.7.3"
 spring-boot-gradle-plugin = "4.1.1"
 spring-dependency-management-gradle-plugin = "1.1.7"


### PR DESCRIPTION
Supersedes / builds on #3958 (Kotlin 2.4.10 bump). This branch contains the renovate bump, the original generics fix, plus one commit that makes the change backwards compatible for users.

## Root cause

Kotlin 2.4 applies JSpecify semantics to `@NullMarked` Java declarations: an unbounded Java type parameter `<E>` in a null-marked package is now seen from Kotlin as `<E : Any>`. Several Java types the coroutine APIs build on live in `@NullMarked` packages — `GenericRepository`, `Page`, `ReactiveTransactionStatus`, `ReactorReactiveTransactionOperations` — so the Kotlin interfaces that forwarded their own unbounded parameters stopped compiling:

```
e: CoroutineCrudRepository.kt:30 Type argument is not within its bounds:
   'E#2 (of interface GenericRepository<E : Any, ID : Any>)' must be subtype of 'Any',
   but actual: 'E#1 (of interface CoroutineCrudRepository<E, ID>)'.
```

## What changed

`: Any` is **kept** on `CoroutineCrudRepository`, `CoroutinePageableCrudRepository`, `CoroutineJpaSpecificationExecutor` and the two `@Internal` tx classes. Those entities/IDs/connections are never null, the Java siblings (`CrudRepository`) already declare them non-null under `@NullMarked`, and the bound erases to `Object` — so this is binary compatible and compiled applications keep working.

`<R : Any>` on `CoroutineTransactionOperations.execute` is **reverted**. A transaction result is legitimately nullable, so that bound would break ordinary code such as `execute { repository.findTitleById(id) }` at compile time. The public signature stays `suspend fun <R> execute(...)`; `DefaultCoroutineTransactionOperations` now runs the handler through `mono<Any>` with a `NULL_RESULT` sentinel and unwraps it.

That also fixes a pre-existing bug: the previous `mono<R> { handler(...) }.awaitSingle()` completed the `Mono` empty when the handler returned `null`, and `awaitSingle()` then threw `NoSuchElementException`. Null results now work.

A rejected alternative: `@file:Suppress("UPPER_BOUND_VIOLATED")` avoids any API change and compiles `data-model`, but Kotlin warns that *"the compiler behavior is UNSPECIFIED and WILL NOT BE PRESERVED"*, and it does not fix `data-tx` at all.

## Testing

- All Kotlin modules and all 11 Kotlin doc-examples compile against Kotlin 2.4.10.
- New `DefaultCoroutineTransactionOperationsTest` in `data-tx` (3 tests) covers a null result, a non-null result of a nullable type, and connection access, against a stub reactive TX manager. This required adding `testImplementation(mn.kotlinx.coroutines.reactor)` to `data-tx/build.gradle`.
- New case in `NullValueCoroutinesTest` (r2dbc-example-kotlin) — passes against a real Postgres container.
- Full `r2dbc-example-kotlin` suite: 35/38. The three failures (`TxTest`, `TxTest2`, `TxTest3`) are `FATAL: sorry, too many clients already` from running the whole suite in one JVM; all three pass in isolation and are unrelated to this change.

## Note for reviewers

Downstream Kotlin users with a *generic* base repository — `interface Base<E, ID> : CoroutineCrudRepository<E, ID>` — will still need to add `: Any` themselves. This is unavoidable Kotlin 2.4 fallout rather than something introduced here: they hit the identical error extending the Java `CrudRepository`. Probably worth a release-note line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)