### PR TITLE
Avoid instantiating embedded entities without auto-populated fields

### DIFF
--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/autopopulate/AutoPopulateEmbeddedSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/autopopulate/AutoPopulateEmbeddedSpec.groovy
@@ -53,10 +53,32 @@ class AutoPopulateEmbeddedSpec extends Specification implements H2TestPropertyPr
         loaded.nestedOnlyAuditFields.innerFields
         loaded.nestedOnlyAuditFields.innerFields.nestedCreatedAt
         loaded.nestedOnlyAuditFields.innerFields.nestedGuid
+        !saved.nestedOnlyAuditFields.nonAutoPopulatedFields
+        !saved.nestedOnlyAuditFields.noDefaultAuditFields
         !saved.nonAutoPopulatedFields
         // Currently embedded entity without default constructor cannot be created
         // in order to populate fields in timestamp and uuid entity event listeners
         !loaded.otherAuditFields
+    }
+
+    def "test existing embeddable fields auto populated"() {
+        given:
+        def auditFields = new AuditFields(innerFields: new InnerFields())
+
+        when:
+        def saved = myAuditableEntityRepository.insert(new MyAuditableEntity(
+            id: "id2",
+            firstName: "Peter",
+            auditFields: auditFields
+        ))
+
+        then:
+        saved.auditFields.is(auditFields)
+        saved.auditFields.innerCreatedAt
+        saved.auditFields.innerUpdatedAt
+        saved.auditFields.innerGuid
+        saved.auditFields.innerFields.subInnerCreatedAt
+        saved.auditFields.innerFields.subInnerGuid
     }
 
 }
@@ -100,6 +122,12 @@ class OtherAuditFields {
 class NestedOnlyAuditFields {
     @Relation(value = Relation.Kind.EMBEDDED)
     NestedOnlyInnerFields innerFields
+
+    @Relation(value = Relation.Kind.EMBEDDED)
+    NestedNonAutoPopulatedFields nonAutoPopulatedFields
+
+    @Relation(value = Relation.Kind.EMBEDDED)
+    NestedNoDefaultAuditFields noDefaultAuditFields
 }
 
 @Embeddable
@@ -145,6 +173,26 @@ class MyAuditableEntity {
 class NonAutoPopulatedFields {
     @Nullable
     String value
+}
+
+@Embeddable
+class NestedNonAutoPopulatedFields {
+    @Nullable
+    String nestedValue
+}
+
+@Embeddable
+class NestedNoDefaultAuditFields {
+    @DateCreated
+    LocalDateTime nestedOtherCreatedAt
+
+    @AutoPopulated
+    UUID nestedOtherGuid
+
+    NestedNoDefaultAuditFields(LocalDateTime nestedOtherCreatedAt, UUID nestedOtherGuid) {
+        this.nestedOtherCreatedAt = nestedOtherCreatedAt
+        this.nestedOtherGuid = nestedOtherGuid
+    }
 }
 
 @JdbcRepository(dialect = Dialect.H2)

--- a/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/autopopulate/AutoPopulateEmbeddedSpec.groovy
+++ b/data-jdbc/src/test/groovy/io/micronaut/data/jdbc/h2/autopopulate/AutoPopulateEmbeddedSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.data.jdbc.h2.autopopulate
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.annotation.AutoPopulated
 import io.micronaut.data.annotation.DateCreated
 import io.micronaut.data.annotation.DateUpdated
@@ -48,6 +49,11 @@ class AutoPopulateEmbeddedSpec extends Specification implements H2TestPropertyPr
         loaded.auditFields.innerFields
         loaded.auditFields.innerFields.subInnerCreatedAt
         loaded.auditFields.innerFields.subInnerGuid
+        loaded.nestedOnlyAuditFields
+        loaded.nestedOnlyAuditFields.innerFields
+        loaded.nestedOnlyAuditFields.innerFields.nestedCreatedAt
+        loaded.nestedOnlyAuditFields.innerFields.nestedGuid
+        !saved.nonAutoPopulatedFields
         // Currently embedded entity without default constructor cannot be created
         // in order to populate fields in timestamp and uuid entity event listeners
         !loaded.otherAuditFields
@@ -90,6 +96,21 @@ class OtherAuditFields {
     }
 }
 
+@Embeddable
+class NestedOnlyAuditFields {
+    @Relation(value = Relation.Kind.EMBEDDED)
+    NestedOnlyInnerFields innerFields
+}
+
+@Embeddable
+class NestedOnlyInnerFields {
+    @DateCreated
+    LocalDateTime nestedCreatedAt
+
+    @AutoPopulated
+    UUID nestedGuid
+}
+
 @Serdeable
 @MappedEntity(value = "my_auditable_entity")
 class MyAuditableEntity {
@@ -112,6 +133,18 @@ class MyAuditableEntity {
 
     @Relation(value = Relation.Kind.EMBEDDED)
     OtherAuditFields otherAuditFields
+
+    @Relation(value = Relation.Kind.EMBEDDED)
+    NestedOnlyAuditFields nestedOnlyAuditFields
+
+    @Relation(value = Relation.Kind.EMBEDDED)
+    NonAutoPopulatedFields nonAutoPopulatedFields
+}
+
+@Embeddable
+class NonAutoPopulatedFields {
+    @Nullable
+    String value
 }
 
 @JdbcRepository(dialect = Dialect.H2)

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
@@ -129,28 +129,40 @@ final class AutoPopulateUtil {
             current = propertySetter.apply(p, current);
         }
 
-        // Recurse into nested embedded associations
+        return populateNestedEmbedded(embeddedEntity, current, propertySetter);
+    }
+
+    private static Object populateNestedEmbedded(@NonNull RuntimePersistentEntity<?> embeddedEntity,
+                                                 @NonNull Object instance,
+                                                 BiFunction<RuntimePersistentProperty<Object>, Object, Object> propertySetter) {
+        Object current = instance;
         for (RuntimeAssociation<?> nested : embeddedEntity.getAssociations()) {
             if (nested.isEmbedded() && nested.getAssociatedEntity().hasAutoPopulatedProperties()) {
-                BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
-                Object child = ep.get(current);
-                if (child == null) {
-                    try {
-                        child = nested.getAssociatedEntity().getIntrospection().instantiate();
-                    } catch (Exception e) {
-                        LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
-                        continue;
-                    }
-                }
-                Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
-                if (ep.isReadOnly()) {
-                    current = ep.withValue(current, updatedChild);
-                } else {
-                    ep.set(current, updatedChild);
-                }
+                current = populateNestedEmbedded(current, nested, propertySetter);
             }
         }
+        return current;
+    }
 
+    @SuppressWarnings("unchecked")
+    private static Object populateNestedEmbedded(@NonNull Object current,
+                                                 RuntimeAssociation<?> nested,
+                                                 BiFunction<RuntimePersistentProperty<Object>, Object, Object> propertySetter) {
+        BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
+        Object child = ep.get(current);
+        if (child == null) {
+            try {
+                child = nested.getAssociatedEntity().getIntrospection().instantiate();
+            } catch (Exception e) {
+                LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
+                return current;
+            }
+        }
+        Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
+        if (ep.isReadOnly()) {
+            return ep.withValue(current, updatedChild);
+        }
+        ep.set(current, updatedChild);
         return current;
     }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
@@ -88,22 +88,21 @@ final class AutoPopulateUtil {
         final RuntimePersistentEntity<Object> persistentEntity = context.getPersistentEntity();
         final Object rootEntity = context.getEntity();
         for (RuntimeAssociation<?> association : persistentEntity.getAssociations()) {
-            if (!association.isEmbedded() || !association.getAssociatedEntity().hasAutoPopulatedProperties()) {
-                continue;
-            }
-            @SuppressWarnings("unchecked")
-            BeanProperty<Object, Object> embeddedProperty = (BeanProperty<Object, Object>) association.getProperty();
-            Object embedded = embeddedProperty.get(rootEntity);
-            if (embedded == null) {
-                try {
-                    embedded = association.getAssociatedEntity().getIntrospection().instantiate();
-                } catch (Exception e) {
-                    LOG.warn("Unable to instantiate embedded property: {}", embeddedProperty.getName(), e);
-                    continue;
+            if (association.isEmbedded() && association.getAssociatedEntity().hasAutoPopulatedProperties()) {
+                @SuppressWarnings("unchecked")
+                BeanProperty<Object, Object> embeddedProperty = (BeanProperty<Object, Object>) association.getProperty();
+                Object embedded = embeddedProperty.get(rootEntity);
+                if (embedded == null) {
+                    try {
+                        embedded = association.getAssociatedEntity().getIntrospection().instantiate();
+                    } catch (Exception e) {
+                        LOG.warn("Unable to instantiate embedded property: {}", embeddedProperty.getName(), e);
+                        continue;
+                    }
                 }
+                Object updated = populateEmbedded(association.getAssociatedEntity(), embedded, propertySetter);
+                context.setProperty(embeddedProperty, updated);
             }
-            Object updated = populateEmbedded(association.getAssociatedEntity(), embedded, propertySetter);
-            context.setProperty(embeddedProperty, updated);
         }
     }
 
@@ -127,24 +126,23 @@ final class AutoPopulateUtil {
 
         // Recurse into nested embedded associations
         for (RuntimeAssociation<?> nested : embeddedEntity.getAssociations()) {
-            if (!nested.isEmbedded() || !nested.getAssociatedEntity().hasAutoPopulatedProperties()) {
-                continue;
-            }
-            BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
-            Object child = ep.get(current);
-            if (child == null) {
-                try {
-                    child = nested.getAssociatedEntity().getIntrospection().instantiate();
-                } catch (Exception e) {
-                    LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
-                    continue;
+            if (nested.isEmbedded() && nested.getAssociatedEntity().hasAutoPopulatedProperties()) {
+                BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
+                Object child = ep.get(current);
+                if (child == null) {
+                    try {
+                        child = nested.getAssociatedEntity().getIntrospection().instantiate();
+                    } catch (Exception e) {
+                        LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
+                        continue;
+                    }
                 }
-            }
-            Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
-            if (ep.isReadOnly()) {
-                current = ep.withValue(current, updatedChild);
-            } else {
-                ep.set(current, updatedChild);
+                Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
+                if (ep.isReadOnly()) {
+                    current = ep.withValue(current, updatedChild);
+                } else {
+                    ep.set(current, updatedChild);
+                }
             }
         }
 

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
@@ -37,6 +37,11 @@ import org.slf4j.LoggerFactory;
  * Centralizes the traversal of embedded associations and applies a provided
  * property population strategy. It returns the possibly new instance of the processed object,
  * which allows callers to reattach immutable objects at the root.
+ *
+ * Embedded population is best effort. Existing immutable embedded instances can be updated using
+ * {@link BeanProperty#withValue(Object, Object)}, but a null embedded association can only be
+ * populated when its introspection supports no-argument instantiation. Constructor-only immutable
+ * embedded types are therefore left unchanged when no instance is available.
  */
 @Internal
 final class AutoPopulateUtil {

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/event/listeners/AutoPopulateUtil.java
@@ -66,12 +66,13 @@ final class AutoPopulateUtil {
     }
 
     /**
-     * Traverse all embedded associations at the root level of the given context, instantiate missing
-     * embedded instances if necessary, delegate recursive population to {@link #populateEmbedded(RuntimePersistentEntity, Object, BiFunction)},
-     * and reattach the resulting instance via {@link EntityEventContext#setProperty(BeanProperty, Object)}.
+     * Traverse embedded associations at the root level of the given context that contain auto-populated
+     * properties, instantiate missing embedded instances if necessary, and delegate recursive population
+     * to {@link #populateEmbedded(RuntimePersistentEntity, Object, BiFunction)}, then reattach the resulting
+     * instance via {@link EntityEventContext#setProperty(BeanProperty, Object)}.
      *
      * This method centralizes the boilerplate to:
-     * - find embedded associations of the root entity
+     * - find embedded associations of the root entity with auto-populated properties
      * - lazily instantiate null embedded instances
      * - apply the provided propertySetter within the embedded graph (recursively)
      * - support immutable entities by reattaching the updated instance through the context
@@ -87,21 +88,22 @@ final class AutoPopulateUtil {
         final RuntimePersistentEntity<Object> persistentEntity = context.getPersistentEntity();
         final Object rootEntity = context.getEntity();
         for (RuntimeAssociation<?> association : persistentEntity.getAssociations()) {
-            if (association.isEmbedded()) {
-                @SuppressWarnings("unchecked")
-                BeanProperty<Object, Object> embeddedProperty = (BeanProperty<Object, Object>) association.getProperty();
-                Object embedded = embeddedProperty.get(rootEntity);
-                if (embedded == null) {
-                    try {
-                        embedded = association.getAssociatedEntity().getIntrospection().instantiate();
-                    } catch (Exception e) {
-                        LOG.warn("Unable to instantiate embedded property: {}", embeddedProperty.getName(), e);
-                        continue;
-                    }
-                }
-                Object updated = populateEmbedded(association.getAssociatedEntity(), embedded, propertySetter);
-                context.setProperty(embeddedProperty, updated);
+            if (!association.isEmbedded() || !association.getAssociatedEntity().hasAutoPopulatedProperties()) {
+                continue;
             }
+            @SuppressWarnings("unchecked")
+            BeanProperty<Object, Object> embeddedProperty = (BeanProperty<Object, Object>) association.getProperty();
+            Object embedded = embeddedProperty.get(rootEntity);
+            if (embedded == null) {
+                try {
+                    embedded = association.getAssociatedEntity().getIntrospection().instantiate();
+                } catch (Exception e) {
+                    LOG.warn("Unable to instantiate embedded property: {}", embeddedProperty.getName(), e);
+                    continue;
+                }
+            }
+            Object updated = populateEmbedded(association.getAssociatedEntity(), embedded, propertySetter);
+            context.setProperty(embeddedProperty, updated);
         }
     }
 
@@ -125,23 +127,24 @@ final class AutoPopulateUtil {
 
         // Recurse into nested embedded associations
         for (RuntimeAssociation<?> nested : embeddedEntity.getAssociations()) {
-            if (nested.isEmbedded()) {
-                BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
-                Object child = ep.get(current);
-                if (child == null) {
-                    try {
-                        child = nested.getAssociatedEntity().getIntrospection().instantiate();
-                    } catch (Exception e) {
-                        LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
-                        continue;
-                    }
+            if (!nested.isEmbedded() || !nested.getAssociatedEntity().hasAutoPopulatedProperties()) {
+                continue;
+            }
+            BeanProperty<Object, Object> ep = (BeanProperty<Object, Object>) nested.getProperty();
+            Object child = ep.get(current);
+            if (child == null) {
+                try {
+                    child = nested.getAssociatedEntity().getIntrospection().instantiate();
+                } catch (Exception e) {
+                    LOG.warn("Unable to instantiate embedded property: {}", ep.getName(), e);
+                    continue;
                 }
-                Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
-                if (ep.isReadOnly()) {
-                    current = ep.withValue(current, updatedChild);
-                } else {
-                    ep.set(current, updatedChild);
-                }
+            }
+            Object updatedChild = populateEmbedded(nested.getAssociatedEntity(), child, propertySetter);
+            if (ep.isReadOnly()) {
+                current = ep.withValue(current, updatedChild);
+            } else {
+                ep.set(current, updatedChild);
             }
         }
 

--- a/src/main/docs/guide/dbc/sqlMapping/sqlAnnotations.adoc
+++ b/src/main/docs/guide/dbc/sqlMapping/sqlAnnotations.adoc
@@ -53,6 +53,8 @@ The following table summarizes the different annotations and what they enable. I
 
 |===
 
+NOTE: Auto-population of embedded properties is best effort. If an embedded property is `null` when an entity is written, the embedded type must support no-argument construction for Micronaut Data to create it and populate its `@AutoPopulated`, `@DateCreated`, or `@DateUpdated` properties. Existing immutable embedded instances can be updated when the bean introspection supports `BeanProperty.withValue`; constructor-only immutable embedded types without a no-argument constructor are left unchanged when no instance is available.
+
 In the case of using JPA only a subset of annotations are supported including the following:
 
 * Basic: `@Table` `@Id` `@Version` `@Column` `@Transient` `@Enumerated`


### PR DESCRIPTION
Issue reported in #4024. This is more improvement for #3607 than a bug fix: Update `AutoPopulateUtil` to check recursively for auto-populated properties before creating embedded objects. Embedded objects without timestamp/UUID fields remain `null`, avoiding unnecessary instantiation and warning logs. Added coverage for direct, nested, and non-auto-populated embedded fields.