### PR TITLE
Association property path resolution, Expression.in, and implicit association joins

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
@@ -46,7 +46,22 @@ public final class PersistentEntityUtils {
     }
 
     /**
-     * Check if the property is an association ID that can be accessed without join. In a case it's not an ID stored outside the associated table.
+     * Check if the association's property is stored on the owning side, and so can be read without joining
+     * to the associated table.
+     *
+     * <p>The answer has to agree with what {@link #traversePersistentProperties(List, PersistentProperty, boolean, BiConsumer)}
+     * emits for the same association, because a caller that resolves a property path uses this method to decide
+     * whether the leaf that traversal produced belongs to the owning table or to the join alias. The three
+     * association target shapes are therefore mirrored here:</p>
+     * <ul>
+     *     <li>a single identity - only that identity is on the owning side;</li>
+     *     <li>a composite identity - every identity property maps a column on the owning side;</li>
+     *     <li>no identity - the target is stored inline, so all of its properties are on the owning side.</li>
+     * </ul>
+     *
+     * <p>Traversal descends through embedded properties, so the leaf it produces can be nested several
+     * embeddeds deep; matching is recursive to reach it.</p>
+     *
      * @param association The association
      * @param persistentProperty The association's property
      * @return true if can be accessed
@@ -56,21 +71,39 @@ public final class PersistentEntityUtils {
         if (association instanceof Embedded) {
             return true;
         }
-        PersistentEntity associatedEntity = association.getAssociatedEntity();
-        if (!associatedEntity.hasIdentity()) {
-            // Some strange case of document DB
+        if (association.isForeignKey()) {
             return false;
         }
-        PersistentProperty identity = associatedEntity.getIdentity();
-        if (identity instanceof Embedded embedded) {
-            for (PersistentProperty property : embedded.getAssociatedEntity().getPersistentProperties()) {
-                if (property == persistentProperty) {
-                    return !association.isForeignKey();
-                }
-            }
-
+        PersistentEntity associatedEntity = association.getAssociatedEntity();
+        List<PersistentProperty> identityProperties = associatedEntity.getIdentityProperties();
+        if (identityProperties.isEmpty()) {
+            // An identity-less association is stored embedded in the owning document
+            return contains(associatedEntity.getPersistentProperties(), persistentProperty);
         }
-        return identity == persistentProperty && !association.isForeignKey();
+        for (PersistentProperty identity : identityProperties) {
+            if (identity == persistentProperty) {
+                return true;
+            }
+            if (identity instanceof Embedded embedded && contains(embedded.getAssociatedEntity().getPersistentProperties(), persistentProperty)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean contains(Collection<? extends PersistentProperty> properties, PersistentProperty persistentProperty) {
+        for (PersistentProperty property : properties) {
+            if (property == persistentProperty) {
+                return true;
+            }
+            // Traversal descends through embedded properties, so the leaf it reaches can be nested
+            // several embeddeds deep; matching only the top level would report a needless join
+            if (property instanceof Embedded embedded
+                && contains(embedded.getAssociatedEntity().getPersistentProperties(), persistentProperty)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -170,6 +203,30 @@ public final class PersistentEntityUtils {
         traversePersistentProperties(propertyPath.getAssociations(), propertyPath.getProperty(), traverseEmbedded, consumerProperty);
     }
 
+    /**
+     * Traverses the properties that should be persisted for the given property, descending through embedded
+     * properties and through the owning side of non-foreign-key associations until a leaf is reached.
+     *
+     * <p>An association contributes the columns that the owning side stores for it, which depends on the
+     * shape of the association's target:</p>
+     * <ul>
+     *     <li><b>single identity</b> - that identity, or the column named by a single {@code @JoinColumn}
+     *     when one is declared on the property;</li>
+     *     <li><b>composite identity</b> - one leaf per identity property. A single referenced column cannot
+     *     stand in for several, so {@code @JoinColumn} substitution does not apply;</li>
+     *     <li><b>no identity</b> - the target is a value object stored inline in the owning record, so its
+     *     properties are traversed as if it were embedded. Traversal stops if the value object refers back
+     *     to an entity already on the path, which would otherwise never terminate.</li>
+     * </ul>
+     *
+     * <p>The latter two shapes only arise in document stores; a relational mapping declares an identity on
+     * every association target.</p>
+     *
+     * @param associations      The associations traversed so far, prefixed to every emitted leaf
+     * @param property          The property to traverse
+     * @param traverseEmbedded  Whether to descend into an embedded property or emit it whole
+     * @param consumerProperty  The function to invoke on every leaf property
+     */
     public static void traversePersistentProperties(List<Association> associations,
                                                     PersistentProperty property,
                                                     boolean traverseEmbedded,
@@ -191,22 +248,34 @@ public final class PersistentEntityUtils {
                 return;
             }
             List<Association> newAssociations = new ArrayList<>(associations);
-            newAssociations.add((Association) property);
+            newAssociations.add(association);
             PersistentEntity associatedEntity = association.getAssociatedEntity();
-            if (!associatedEntity.hasIdentity()) {
-                throw new IllegalStateException("Identity cannot be missing for: " + associatedEntity);
+            Collection<? extends PersistentProperty> identityProperties = associatedEntity.getIdentityProperties();
+            if (identityProperties.isEmpty()) {
+                // Identity-less associations behave like embedded value objects.
+                for (Association traversedAssociation : associations) {
+                    if (traversedAssociation.getAssociatedEntity() == associatedEntity) {
+                        // The value object refers back to itself, traversing it would never terminate
+                        return;
+                    }
+                }
+                for (PersistentProperty associatedProperty : associatedEntity.getPersistentProperties()) {
+                    traversePersistentProperties(newAssociations, associatedProperty, consumerProperty);
+                }
+                return;
             }
-            PersistentProperty assocIdentity = associatedEntity.getIdentity();
-            if (assocIdentity instanceof Association) {
-                traversePersistentProperties(newAssociations, assocIdentity, consumerProperty);
-            } else {
-                // In case there is JoinColumn defined on property, we might use specified column
-                // instead of association id
-                PersistentProperty joinColumnAssocIdentity = getJoinColumnAssocIdentity(property, associatedEntity);
-                if (joinColumnAssocIdentity != null) {
-                    consumerProperty.accept(newAssociations, joinColumnAssocIdentity);
+            // In case there is a single JoinColumn defined on the property, we might use the specified
+            // column instead of the association id. A composite identity maps a column each, so the
+            // single referenced column cannot stand in for all of them.
+            PersistentProperty joinColumnIdentity = identityProperties.size() == 1
+                ? getJoinColumnAssocIdentity(property, associatedEntity)
+                : null;
+            for (PersistentProperty identityProperty : identityProperties) {
+                if (identityProperty instanceof Association) {
+                    traversePersistentProperties(newAssociations, identityProperty, consumerProperty);
                 } else {
-                    consumerProperty.accept(newAssociations, assocIdentity);
+                    consumerProperty.accept(newAssociations,
+                        joinColumnIdentity != null ? joinColumnIdentity : identityProperty);
                 }
             }
         } else {

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/AbstractExpression.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/AbstractExpression.java
@@ -18,6 +18,14 @@ package io.micronaut.data.model.jpa.criteria.impl.expression;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.jpa.criteria.ExpressionType;
 import io.micronaut.data.model.jpa.criteria.IExpression;
+import io.micronaut.data.model.jpa.criteria.impl.predicate.InPredicate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The abstract expression.
@@ -43,5 +51,31 @@ public abstract class AbstractExpression<E> implements IExpression<E> {
     @Override
     public final ExpressionType<E> getExpressionType() {
         return expressionType;
+    }
+
+    @Override
+    public Predicate in(Object... values) {
+        return in(Arrays.asList(Objects.requireNonNull(values)));
+    }
+
+    @Override
+    public Predicate in(Expression<?>... values) {
+        return new InPredicate<>(this, Arrays.asList(values), null);
+    }
+
+    @Override
+    public Predicate in(Collection<?> values) {
+        List<Expression<?>> expressions = Objects.requireNonNull(values).stream().map(value -> {
+            if (value instanceof Expression<?> expression) {
+                return expression;
+            }
+            return new LiteralExpression<>(value);
+        }).toList();
+        return new InPredicate<>(this, expressions, null);
+    }
+
+    @Override
+    public Predicate in(Expression<Collection<?>> values) {
+        return new InPredicate<>(this, List.of(Objects.requireNonNull(values)), null);
     }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/predicate/InPredicate.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/predicate/InPredicate.java
@@ -17,8 +17,10 @@ package io.micronaut.data.model.jpa.criteria.impl.predicate;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.jpa.criteria.impl.PredicateVisitor;
+import io.micronaut.data.model.jpa.criteria.impl.expression.LiteralExpression;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,13 +39,13 @@ public final class InPredicate<T> extends AbstractPredicate implements CriteriaB
 
     private final Expression<T> expression;
     private final List<Expression<?>> values;
-    private final CriteriaBuilder criteriaBuilder;
+    private final @Nullable CriteriaBuilder criteriaBuilder;
 
     public InPredicate(Expression<T> expression, CriteriaBuilder criteriaBuilder) {
         this(expression, Collections.emptyList(), criteriaBuilder);
     }
 
-    public InPredicate(Expression<T> expression, Collection<Expression<?>> values, CriteriaBuilder criteriaBuilder) {
+    public InPredicate(Expression<T> expression, Collection<Expression<?>> values, @Nullable CriteriaBuilder criteriaBuilder) {
         this.expression = expression;
         this.values = new ArrayList<>(values);
         this.criteriaBuilder = criteriaBuilder;
@@ -60,7 +62,7 @@ public final class InPredicate<T> extends AbstractPredicate implements CriteriaB
 
     @Override
     public InPredicate<T> value(T value) {
-        values.add(criteriaBuilder.literal(value));
+        values.add(criteriaBuilder == null ? new LiteralExpression<>(value) : criteriaBuilder.literal(value));
         return this;
     }
 

--- a/data-model/src/test/java/io/micronaut/data/model/PersistentEntityUtilsTest.java
+++ b/data-model/src/test/java/io/micronaut/data/model/PersistentEntityUtilsTest.java
@@ -1,0 +1,488 @@
+package io.micronaut.data.model;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.data.annotation.sql.JoinColumn;
+import io.micronaut.data.annotation.sql.JoinColumns;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersistentEntityUtilsTest {
+
+    private record Visit(List<Association> associations, PersistentProperty property) {
+    }
+
+    private static List<Visit> traverse(PersistentProperty property) {
+        List<Visit> visits = new ArrayList<>();
+        PersistentEntityUtils.traversePersistentProperties(property,
+            (associations, p) -> visits.add(new Visit(List.copyOf(associations), p)));
+        return visits;
+    }
+
+    @Test
+    void visitsPlainProperty() {
+        TestEntity entity = new TestEntity("Entity", null, null, new TestProperty("id"), new TestProperty("name"));
+        TestProperty name = (TestProperty) entity.getPropertyByName("name");
+
+        List<Visit> visits = traverse(name);
+
+        assertEquals(1, visits.size());
+        assertSame(name, visits.get(0).property());
+        assertTrue(visits.get(0).associations().isEmpty());
+    }
+
+    @Test
+    void traversesEmbeddedProperties() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"), new TestProperty("e2"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        List<Visit> visits = traverse(embedded);
+
+        assertEquals(Set.of("e1", "e2"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(embedded), visit.associations());
+        }
+    }
+
+    @Test
+    void keepsEmbeddedPropertyWhenNotTraversingEmbedded() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        List<Visit> visits = new ArrayList<>();
+        PersistentEntityUtils.traversePersistentProperties(Collections.emptyList(), embedded, false,
+            (associations, p) -> visits.add(new Visit(List.copyOf(associations), p)));
+
+        assertEquals(1, visits.size());
+        assertSame(embedded, visits.get(0).property());
+        assertTrue(visits.get(0).associations().isEmpty());
+    }
+
+    @Test
+    void skipsForeignKeyAssociations() {
+        TestEntity childEntity = new TestEntity("Child", null, null, new TestProperty("id"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("children", childEntity, true));
+        TestAssociation children = (TestAssociation) entity.getPropertyByName("children");
+
+        List<Visit> visits = traverse(children);
+
+        assertTrue(visits.isEmpty());
+    }
+
+    @Test
+    void visitsSingleIdentityOfAssociation() {
+        TestProperty parentId = new TestProperty("id");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, new TestProperty("name"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(parentId, visits.get(0).property());
+        assertEquals(List.of(parentAssociation), visits.get(0).associations());
+    }
+
+    @Test
+    void recursesIntoAssociationIdentity() {
+        TestProperty idValue = new TestProperty("value");
+        TestEntity idEntity = new TestEntity("Id", idValue, null, idValue);
+        TestEntity parent = new TestEntity("Parent", null, null, new TestEmbedded("id", idEntity));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+        TestEmbedded embeddedId = (TestEmbedded) parent.getPropertyByName("id");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(idValue, visits.get(0).property());
+        assertEquals(List.of(parentAssociation, embeddedId), visits.get(0).associations());
+    }
+
+    @Test
+    void visitsEachCompositeIdentityProperty() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(Set.of("tenantId", "refId"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(parentAssociation), visit.associations());
+        }
+    }
+
+    @Test
+    void traversesPropertiesOfIdentityLessAssociation() {
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestProperty("key"), new TestProperty("data"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        List<Visit> visits = traverse(valueAssociation);
+
+        assertEquals(Set.of("key", "data"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(valueAssociation), visit.associations());
+        }
+    }
+
+    @Test
+    void stopsAtSelfReferencingIdentityLessAssociation() {
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestProperty("data"));
+        valueObject.addProperty(new TestAssociation("self", valueObject, false));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        List<Visit> visits = traverse(valueAssociation);
+
+        assertEquals(List.of("data"), visits.stream().map(v -> v.property().getName()).toList());
+    }
+
+    @Test
+    void usesJoinColumnInsteadOfSingleIdentity() {
+        TestProperty parentId = new TestProperty("id");
+        TestProperty code = new TestProperty("code");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, code);
+        TestEntity entity = new TestEntity("Entity", null, null,
+            new TestAssociation("parent", parent, false, joinColumns("code")));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(code, visits.get(0).property());
+    }
+
+    @Test
+    void ignoresJoinColumnForCompositeIdentity() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId);
+        TestEntity entity = new TestEntity("Entity", null, null,
+            new TestAssociation("parent", parent, false, joinColumns("tenantId")));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(List.of(tenantId, refId), visits.stream().map(Visit::property).toList());
+    }
+
+    @Test
+    void embeddedAssociationIsAccessibleWithoutJoin() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(embedded, embeddedEntity.getPropertyByName("e1")));
+    }
+
+    @Test
+    void foreignKeyAssociationIsNotAccessibleWithoutJoin() {
+        TestProperty childId = new TestProperty("id");
+        TestEntity child = new TestEntity("Child", childId, null, childId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("children", child, true));
+        TestAssociation children = (TestAssociation) entity.getPropertyByName("children");
+
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(children, childId));
+    }
+
+    @Test
+    void onlyIdentityIsAccessibleWithoutJoin() {
+        TestProperty parentId = new TestProperty("id");
+        TestProperty name = new TestProperty("name");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, name);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, parentId));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, name));
+    }
+
+    @Test
+    void embeddedIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty idValue = new TestProperty("value");
+        TestEntity idEntity = new TestEntity("Id", idValue, null, idValue);
+        TestEmbedded embeddedId = new TestEmbedded("id", idEntity);
+        TestEntity parent = new TestEntity("Parent", embeddedId, null, embeddedId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, idValue));
+    }
+
+    @Test
+    void eachCompositeIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestProperty name = new TestProperty("name");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId, name);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, tenantId));
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, refId));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, name));
+    }
+
+    @Test
+    void identityLessAssociationPropertiesAreAccessibleWithoutJoin() {
+        TestProperty data = new TestProperty("data");
+        TestEntity valueObject = new TestEntity("Value", null, null, data);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, data));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, new TestProperty("other")));
+    }
+
+    @Test
+    void nestedEmbeddedPropertyOfIdentityLessAssociationIsAccessibleWithoutJoin() {
+        TestProperty street = new TestProperty("street");
+        TestEntity addressEntity = new TestEntity("Address", null, null, street);
+        TestEmbedded address = new TestEmbedded("address", addressEntity);
+        TestEntity valueObject = new TestEntity("Value", null, null, address);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        // traversal reaches the nested leaf, so accessibility has to agree with it
+        assertEquals(List.of(street), traverse(valueAssociation).stream().map(Visit::property).toList());
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, street));
+    }
+
+    @Test
+    void nestedEmbeddedIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty value = new TestProperty("value");
+        TestEntity innerEntity = new TestEntity("Inner", null, null, value);
+        TestEmbedded inner = new TestEmbedded("inner", innerEntity);
+        TestEntity idEntity = new TestEntity("Id", null, null, inner);
+        TestEmbedded embeddedId = new TestEmbedded("id", idEntity);
+        TestEntity parent = new TestEntity("Parent", embeddedId, null, embeddedId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertEquals(List.of(value), traverse(parentAssociation).stream().map(Visit::property).toList());
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, value));
+    }
+
+    private static AnnotationMetadata joinColumns(String... referencedColumnNames) {
+        List<AnnotationValue<JoinColumn>> joinColumns = Arrays.stream(referencedColumnNames)
+            .map(columnName -> AnnotationValue.builder(JoinColumn.class)
+                .member("referencedColumnName", columnName)
+                .build())
+            .toList();
+        Map<String, Map<CharSequence, Object>> annotations =
+            Map.of(JoinColumns.class.getName(), Map.of(AnnotationMetadata.VALUE_MEMBER, joinColumns));
+        return new DefaultAnnotationMetadata(annotations, Collections.emptyMap(), Collections.emptyMap(),
+            annotations, Collections.emptyMap());
+    }
+
+    static final class TestEntity extends AbstractPersistentEntity {
+
+        private final String name;
+        private final PersistentProperty identity;
+        private final PersistentProperty[] compositeIdentity;
+        private final List<PersistentProperty> properties;
+
+        TestEntity(String name, PersistentProperty identity, PersistentProperty[] compositeIdentity, PersistentProperty... properties) {
+            super(new AnnotationMetadataProvider() {
+                @Override
+                public AnnotationMetadata getAnnotationMetadata() {
+                    return AnnotationMetadata.EMPTY_METADATA;
+                }
+            });
+            this.name = name;
+            this.identity = identity;
+            this.compositeIdentity = compositeIdentity;
+            this.properties = new ArrayList<>(List.of(properties));
+            for (PersistentProperty property : properties) {
+                own(property);
+            }
+        }
+
+        TestEntity addProperty(PersistentProperty property) {
+            properties.add(property);
+            own(property);
+            return this;
+        }
+
+        private void own(PersistentProperty property) {
+            if (property instanceof TestProperty testProperty) {
+                testProperty.owner = this;
+            }
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean hasCompositeIdentity() {
+            return compositeIdentity != null;
+        }
+
+        @Override
+        public boolean hasIdentity() {
+            return identity != null;
+        }
+
+        @Override
+        public PersistentProperty getIdentity() {
+            return identity;
+        }
+
+        @Override
+        public PersistentProperty[] getCompositeIdentity() {
+            return compositeIdentity;
+        }
+
+        @Override
+        public PersistentProperty getVersion() {
+            return null;
+        }
+
+        @Override
+        public boolean hasVersion() {
+            return false;
+        }
+
+        @Override
+        public Collection<? extends PersistentProperty> getPersistentProperties() {
+            return properties;
+        }
+
+        @Override
+        public PersistentProperty getPropertyByName(String propertyName) {
+            for (PersistentProperty property : properties) {
+                if (property.getName().equals(propertyName)) {
+                    return property;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public PersistentProperty getPropertyByNameIgnoreCase(String propertyName) {
+            for (PersistentProperty property : properties) {
+                if (property.getName().equalsIgnoreCase(propertyName)) {
+                    return property;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Collection<String> getPersistentPropertyNames() {
+            return properties.stream().map(PersistentProperty::getName).toList();
+        }
+
+        @Override
+        public boolean isOwningEntity(PersistentEntity owner) {
+            return false;
+        }
+
+        @Override
+        public PersistentEntity getParentEntity() {
+            return null;
+        }
+    }
+
+    static class TestProperty implements PersistentProperty {
+
+        private final String name;
+        private final AnnotationMetadata annotationMetadata;
+        private TestEntity owner;
+
+        TestProperty(String name) {
+            this(name, AnnotationMetadata.EMPTY_METADATA);
+        }
+
+        TestProperty(String name, AnnotationMetadata annotationMetadata) {
+            this.name = name;
+            this.annotationMetadata = annotationMetadata;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getTypeName() {
+            return String.class.getName();
+        }
+
+        @Override
+        public PersistentEntity getOwner() {
+            return owner;
+        }
+
+        @Override
+        public boolean isAssignable(String type) {
+            return String.class.getName().equals(type);
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return annotationMetadata;
+        }
+
+        @Override
+        public String getPersistedName() {
+            return name;
+        }
+    }
+
+    static class TestAssociation extends TestProperty implements Association {
+
+        private final TestEntity associatedEntity;
+        private final boolean foreignKey;
+
+        TestAssociation(String name, TestEntity associatedEntity, boolean foreignKey) {
+            this(name, associatedEntity, foreignKey, AnnotationMetadata.EMPTY_METADATA);
+        }
+
+        TestAssociation(String name, TestEntity associatedEntity, boolean foreignKey, AnnotationMetadata annotationMetadata) {
+            super(name, annotationMetadata);
+            this.associatedEntity = associatedEntity;
+            this.foreignKey = foreignKey;
+        }
+
+        @Override
+        public PersistentEntity getAssociatedEntity() {
+            return associatedEntity;
+        }
+
+        @Override
+        public boolean isForeignKey() {
+            return foreignKey;
+        }
+    }
+
+    static final class TestEmbedded extends TestAssociation implements Embedded {
+
+        TestEmbedded(String name, TestEntity associatedEntity) {
+            super(name, associatedEntity, false);
+        }
+    }
+}

--- a/data-model/src/test/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaInTest.java
+++ b/data-model/src/test/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaInTest.java
@@ -1,0 +1,98 @@
+package io.micronaut.data.model.jpa.criteria.impl;
+
+import io.micronaut.data.model.jpa.criteria.impl.expression.AbstractExpression;
+import io.micronaut.data.model.jpa.criteria.impl.expression.LiteralExpression;
+import io.micronaut.data.model.jpa.criteria.impl.predicate.InPredicate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CriteriaInTest {
+
+    private static AbstractExpression<Long> expression() {
+        return new LiteralExpression<>(Long.class);
+    }
+
+    private static List<?> literalValues(InPredicate<?> in) {
+        return in.getValues().stream().map(v -> ((LiteralExpression<?>) v).getValue()).toList();
+    }
+
+    @Test
+    void inObjectVarargsWrapsValuesAsLiterals() {
+        AbstractExpression<Long> expression = expression();
+
+        Predicate predicate = expression.in(1L, 2L);
+
+        assertInstanceOf(InPredicate.class, predicate);
+        InPredicate<?> in = (InPredicate<?>) predicate;
+        assertSame(expression, in.getExpression());
+        assertEquals(List.of(1L, 2L), literalValues(in));
+    }
+
+    @Test
+    void inNullObjectVarargsIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Object[]) null));
+    }
+
+    @Test
+    void inExpressionVarargsKeepsExpressions() {
+        AbstractExpression<Long> expression = expression();
+        LiteralExpression<Long> value = new LiteralExpression<>(5L);
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(value);
+
+        assertEquals(List.of(value), in.getValues());
+    }
+
+    @Test
+    void inCollectionWrapsLiteralsAndKeepsExpressions() {
+        AbstractExpression<Long> expression = expression();
+        LiteralExpression<Long> expressionValue = new LiteralExpression<>(5L);
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(List.of(1L, expressionValue));
+
+        List<Expression<?>> values = in.getValues();
+        assertEquals(2, values.size());
+        assertEquals(1L, ((LiteralExpression<?>) values.get(0)).getValue());
+        assertSame(expressionValue, values.get(1));
+    }
+
+    @Test
+    void inNullCollectionIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Collection<?>) null));
+    }
+
+    @Test
+    void inSubqueryExpressionIsWrappedAsSingleValue() {
+        AbstractExpression<Long> expression = expression();
+        Expression<Collection<?>> subquery = new LiteralExpression<>(Collections.<Object>emptyList());
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(subquery);
+
+        assertEquals(List.of(subquery), in.getValues());
+    }
+
+    @Test
+    void inNullSubqueryExpressionIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Expression<Collection<?>>) null));
+    }
+
+    @Test
+    void inPredicateValueWithoutCriteriaBuilderWrapsAsLiteral() {
+        AbstractExpression<Long> expression = expression();
+
+        InPredicate<Long> in = new InPredicate<>(expression, List.of(), null);
+        in.value(42L);
+
+        assertEquals(List.of(42L), literalValues(in));
+    }
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
@@ -259,4 +259,117 @@ interface EntityWithIdClassRepository extends CrudRepository<EntityWithIdClass, 
         then:
         sql2.startsWith('SELECT project_."department_id",project_."project_id"')
     }
+
+    void "test nested embedded id property of an association resolves to the owning table"() {
+        given:"an association whose target has an embedded id containing a further embedded"
+        def repository = buildRepository('test.ParcelRepository', """
+import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+class Shipment {
+    @EmbeddedId
+    private ShipmentId shipmentId;
+    private String name;
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+
+    public void setShipmentId(ShipmentId shipmentId) {
+        this.shipmentId = shipmentId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+@Embeddable
+class ShipmentId {
+    @Embedded
+    private ShipmentRegion region;
+    private int number;
+
+    public ShipmentRegion getRegion() {
+        return region;
+    }
+
+    public void setRegion(ShipmentRegion region) {
+        this.region = region;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+}
+
+@Embeddable
+class ShipmentRegion {
+    private String country;
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+}
+
+@Entity
+class Parcel {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @ManyToOne
+    private Shipment shipment;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Shipment getShipment() {
+        return shipment;
+    }
+
+    public void setShipment(Shipment shipment) {
+        this.shipment = shipment;
+    }
+}
+
+@Repository
+@RepositoryConfiguration(queryBuilder=SqlQueryBuilder.class, implicitQueries = false, namedParameters = false)
+@io.micronaut.context.annotation.Executable
+interface ParcelRepository extends GenericRepository<Parcel, Long> {
+
+    List<Parcel> findByShipmentShipmentIdRegionCountry(String country);
+}
+""")
+
+        when:"the query filters on the nested leaf of that embedded id"
+        def method = repository.findPossibleMethods("findByShipmentShipmentIdRegionCountry").findFirst().get()
+        def query = getQuery(method)
+
+        then:"the leaf resolves to the foreign key column on the owning table, not to the join alias"
+        // Accessibility has to agree with traversal, which descends the whole embedded chain.
+        // Matching only the identity's top level made the predicate read parcel_shipment_."country".
+        query == 'SELECT parcel_."id",parcel_."shipment_country",parcel_."shipment_number" FROM "parcel" parcel_ INNER JOIN "shipment" parcel_shipment_ ON parcel_."shipment_country"=parcel_shipment_."country" AND parcel_."shipment_number"=parcel_shipment_."number" WHERE (parcel_."shipment_country" = ?)'
+    }
 }

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/RuntimePersistentPropertyPathImpl.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/RuntimePersistentPropertyPathImpl.java
@@ -17,7 +17,11 @@ package io.micronaut.data.runtime.criteria;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.Association;
+import io.micronaut.data.model.jpa.criteria.PersistentAssociationPath;
+import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
+import io.micronaut.data.model.jpa.criteria.impl.AbstractPersistentEntityFrom;
 import io.micronaut.data.model.jpa.criteria.impl.DefaultPersistentPropertyPath;
+import io.micronaut.data.model.runtime.RuntimeAssociation;
 import io.micronaut.data.model.runtime.RuntimePersistentProperty;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
@@ -50,6 +54,16 @@ final class RuntimePersistentPropertyPathImpl<I, T> extends DefaultPersistentPro
     @Override
     public Path<?> getParentPath() {
         return parentPath;
+    }
+
+    @Override
+    public <Y> PersistentPropertyPath<Y> get(String attributeName) {
+        if (runtimePersistentProperty instanceof RuntimeAssociation<?> association
+            && parentPath instanceof AbstractPersistentEntityFrom<?, ?> from) {
+            PersistentAssociationPath<?, ?> join = from.join(association.getName());
+            return join.get(attributeName);
+        }
+        return super.get(attributeName);
     }
 
     @Override

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/convert/DataConversionServiceSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/convert/DataConversionServiceSpec.groovy
@@ -22,6 +22,9 @@ import org.jspecify.annotations.NonNull
 import io.micronaut.core.convert.DefaultMutableConversionService
 import io.micronaut.core.convert.MutableConversionService
 import io.micronaut.inject.BeanDefinitionReference
+import org.spockframework.runtime.model.parallel.Resources
+import spock.lang.ResourceLock
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -29,10 +32,28 @@ import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.time.*
 
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
 class DataConversionServiceSpec extends Specification {
 
-    static def DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd")
+    private static final ZoneId TEST_ZONE = ZoneOffset.UTC
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd")
+    static {
+        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(TEST_ZONE))
+    }
+
+    @Shared
+    private TimeZone defaultTimeZone
+
     static Date now = new Date()
+
+    def setupSpec() {
+        defaultTimeZone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone(TEST_ZONE))
+    }
+
+    def cleanupSpec() {
+        TimeZone.setDefault(defaultTimeZone)
+    }
 
     @Unroll
     def "test date conversion #obj to #targetType"() {
@@ -48,18 +69,18 @@ class DataConversionServiceSpec extends Specification {
             obj                                          || targetType     || result
             DATE_FORMAT.parse("1970-01-02")              || LocalDate      || LocalDate.parse("1970-01-02")
             DATE_FORMAT.parse("1970-01-02")              || LocalDateTime  || LocalDate.parse("1970-01-02").atStartOfDay()
-            DATE_FORMAT.parse("1970-01-02")              || OffsetDateTime || LocalDate.parse("1970-01-02").atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime()
-            LocalDate.parse("1970-01-02")                || Date           || DATE_FORMAT.parse("1970-01-02")
-            LocalDate.parse("1970-01-02").atStartOfDay() || Date           || DATE_FORMAT.parse("1970-01-02")
+            DATE_FORMAT.parse("1970-01-02")              || OffsetDateTime || LocalDate.parse("1970-01-02").atStartOfDay().atZone(TEST_ZONE).toOffsetDateTime()
+            LocalDate.parse("1970-01-02")                || Date           || Date.from(LocalDate.parse("1970-01-02").atStartOfDay(TEST_ZONE).toInstant())
+            LocalDate.parse("1970-01-02").atStartOfDay() || Date           || Date.from(LocalDate.parse("1970-01-02").atStartOfDay().atZone(TEST_ZONE).toInstant())
             new Date(now.getTime())                      || Instant        || Instant.ofEpochMilli(now.getTime())
             Instant.ofEpochMilli(now.getTime())          || Date           || new Date(now.getTime())
 
             new java.sql.Date(now.getTime())             || Instant        || Instant.ofEpochMilli(now.getTime())
             Instant.ofEpochMilli(now.getTime())          || java.sql.Date  || new Date(now.getTime())
 
-            new java.sql.Date(now.getTime())             || LocalDate      || Instant.ofEpochMilli(now.getTime()).atZone(ZoneId.systemDefault()).toLocalDate()
-            new java.sql.Date(now.getTime())             || LocalDateTime  || Instant.ofEpochMilli(now.getTime()).atZone(ZoneId.systemDefault()).toLocalDateTime()
-            new java.sql.Date(now.getTime())             || OffsetDateTime || Instant.ofEpochMilli(now.getTime()).atZone(ZoneId.systemDefault()).toOffsetDateTime()
+            new java.sql.Date(now.getTime())             || LocalDate      || Instant.ofEpochMilli(now.getTime()).atZone(TEST_ZONE).toLocalDate()
+            new java.sql.Date(now.getTime())             || LocalDateTime  || Instant.ofEpochMilli(now.getTime()).atZone(TEST_ZONE).toLocalDateTime()
+            new java.sql.Date(now.getTime())             || OffsetDateTime || Instant.ofEpochMilli(now.getTime()).atZone(TEST_ZONE).toOffsetDateTime()
 
             LocalDate.parse("1970-01-02")
                     .atTime( LocalTime.of(2,0))

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
@@ -397,4 +397,56 @@ class CriteriaSpec extends AbstractCriteriaSpec {
             "amount"  | BigDecimal.valueOf(100) | "le"                   | '(NOT(test_."amount" <= ?))'
     }
 
+    void "test criteria navigation across MANY_TO_ONE association"() {
+        given:
+            def criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            def otherEntityRoot = criteriaQuery.from(OtherEntity)
+
+        when: "Navigate across MANY_TO_ONE association using get()"
+            def testAssociationPath = otherEntityRoot.get("test")
+            def testNamePath = testAssociationPath.get("name")
+            criteriaQuery.where(criteriaBuilder.equal(testNamePath, "testValue"))
+            String query = getSqlQuery(criteriaQuery)
+
+        then:
+            query.contains('INNER JOIN "test"')
+            query.contains('test_."name"')
+
+        when: "Navigate using string property paths"
+            criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            otherEntityRoot = criteriaQuery.from(OtherEntity)
+            criteriaQuery.where(criteriaBuilder.equal(otherEntityRoot.get("test").get("name"), "testValue"))
+            String query2 = getSqlQuery(criteriaQuery)
+
+        then:
+            query2.contains('INNER JOIN "test"')
+            query2.contains('test_."name"')
+    }
+
+    void "RuntimePersistentPropertyPathImpl.get auto-creates implicit join for RuntimeAssociation"() {
+        given:
+            def criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            def root = criteriaQuery.from(OtherEntity)
+
+        when: "accessing a property through a MANY_TO_ONE association path"
+            def path = root.get("test").get("name")
+            criteriaQuery.where(criteriaBuilder.equal(path, "value"))
+            String query = getSqlQuery(criteriaQuery)
+
+        then:
+            query.contains('INNER JOIN "test"')
+            query.contains('test_."name"')
+
+        when: "nested association path via static metamodel"
+            criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            root = criteriaQuery.from(OtherEntity)
+            def nestedPath = root.get(OtherEntity_.test).get(Test_.name)
+            criteriaQuery.where(criteriaBuilder.equal(nestedPath, "value"))
+            String query2 = getSqlQuery(criteriaQuery)
+
+        then:
+            query2.contains('INNER JOIN "test"')
+            query2.contains('test_."name"')
+    }
+
 }


### PR DESCRIPTION
Four independent changes to the criteria and property-path machinery, kept as separate commits so they can be reviewed one at a time. Each carries its own tests.

### `PersistentEntityUtils`: association targets with a composite or absent identity

`traversePersistentProperties` assumed every association target declares exactly one identity. A composite-identity target threw `IllegalStateException`, and an identity-less target could not be traversed at all. It now emits one leaf per identity property, treats an identity-less target as an inline value object, and stops descending if that value object refers back to an entity already on the path.

`isAccessibleWithoutJoin` mirrors the same three shapes, because a caller resolving a property path uses it to decide whether the leaf traversal produced belongs to the owning table or to a join alias. Matching is recursive, so a leaf nested several embeddeds deep is reported as owning-side instead of provoking a needless join — covered by a new nested-embedded-id case in `CompositePrimaryKeySpec`.

`@JoinColumn` substitution is now limited to the single-identity case: one referenced column cannot stand in for several.

### `AbstractExpression`: implement `Expression.in`

`AbstractExpression` inherited no implementation of the four JPA `Expression.in` overloads, so `in(...)` on an expression that was not a property path failed instead of building a predicate. Each overload now builds an `InPredicate`, wrapping plain values as literal expressions. `InPredicate` accepts a null `CriteriaBuilder` for that case and falls back to `LiteralExpression` when a value is added, since an expression built this way has no builder to ask for one.

### `RuntimePersistentPropertyPathImpl`: implicit join when navigating an association

`root.get("association").get("property")` resolved the leaf against the owning entity, so the generated query referenced a column the owning table does not have rather than joining. Navigating from a path whose property is an association now creates the join on the parent and resolves the attribute against it — what the JPA path API specifies, and what the same navigation already did when the association was reached through `join()`.

### `DataConversionServiceSpec`: pin to a fixed time zone

The expectations mixed `SimpleDateFormat`, which parses in the default zone, with conversions asserted against `ZoneId.systemDefault()`, so they agreed only in zones whose offset keeps both on the same calendar day. The spec now fixes the default zone for its duration, formats in that zone, and takes a lock on the system-properties resource so a parallel spec does not observe the change. Test-only.

### Verification

`:micronaut-data-model:test`, `:micronaut-data-runtime:test` and `:micronaut-data-processor:test` all pass (processor: 1234 tests, 4 skipped).
