### PR TITLE
Resolve association property paths for composite and identity-less targets

### DIFF
--- a/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
+++ b/data-model/src/main/java/io/micronaut/data/model/PersistentEntityUtils.java
@@ -26,8 +26,10 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -46,7 +48,11 @@ public final class PersistentEntityUtils {
     }
 
     /**
-     * Check if the property is an association ID that can be accessed without join. In a case it's not an ID stored outside the associated table.
+     * Check if the property is stored on the owning side, and so can be accessed without a join.
+     * This does not mirror {@link #traversePersistentProperties(List, PersistentProperty, boolean, BiConsumer)},
+     * which also descends through non-foreign-key associations: a leaf several associations deep has to be
+     * checked one association at a time.
+     *
      * @param association The association
      * @param persistentProperty The association's property
      * @return true if can be accessed
@@ -56,21 +62,40 @@ public final class PersistentEntityUtils {
         if (association instanceof Embedded) {
             return true;
         }
-        PersistentEntity associatedEntity = association.getAssociatedEntity();
-        if (!associatedEntity.hasIdentity()) {
-            // Some strange case of document DB
+        if (association.isForeignKey()) {
             return false;
         }
-        PersistentProperty identity = associatedEntity.getIdentity();
-        if (identity instanceof Embedded embedded) {
-            for (PersistentProperty property : embedded.getAssociatedEntity().getPersistentProperties()) {
-                if (property == persistentProperty) {
-                    return !association.isForeignKey();
+        PersistentEntity associatedEntity = association.getAssociatedEntity();
+        List<PersistentProperty> identityProperties = associatedEntity.getIdentityProperties();
+        if (identityProperties.isEmpty()) {
+            // An identity-less association is stored embedded in the owning document
+            return contains(associatedEntity.getPersistentProperties(), persistentProperty, new HashSet<>());
+        }
+        for (PersistentProperty identity : identityProperties) {
+            if (identity == persistentProperty) {
+                return true;
+            }
+            if (identity instanceof Embedded embedded && contains(embedded.getAssociatedEntity().getPersistentProperties(), persistentProperty, new HashSet<>())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean contains(Collection<? extends PersistentProperty> properties, PersistentProperty persistentProperty, Set<PersistentEntity> visited) {
+        for (PersistentProperty property : properties) {
+            if (property == persistentProperty) {
+                return true;
+            }
+            // The leaf can be nested several embeddeds deep
+            if (property instanceof Embedded embedded) {
+                PersistentEntity embeddedEntity = embedded.getAssociatedEntity();
+                if (visited.add(embeddedEntity) && contains(embeddedEntity.getPersistentProperties(), persistentProperty, visited)) {
+                    return true;
                 }
             }
-
         }
-        return identity == persistentProperty && !association.isForeignKey();
+        return false;
     }
 
     /**
@@ -170,6 +195,16 @@ public final class PersistentEntityUtils {
         traversePersistentProperties(propertyPath.getAssociations(), propertyPath.getProperty(), traverseEmbedded, consumerProperty);
     }
 
+    /**
+     * Traverses the properties that should be persisted for the given property. An association contributes
+     * the columns the owning side stores for it: its identity properties, or, when the target has no
+     * identity, its own properties, as a document store stores such a target inline.
+     *
+     * @param associations      The associations traversed so far, prefixed to every emitted leaf
+     * @param property          The property to traverse
+     * @param traverseEmbedded  Whether to descend into an embedded property or emit it whole
+     * @param consumerProperty  The function to invoke on every leaf property
+     */
     public static void traversePersistentProperties(List<Association> associations,
                                                     PersistentProperty property,
                                                     boolean traverseEmbedded,
@@ -191,22 +226,33 @@ public final class PersistentEntityUtils {
                 return;
             }
             List<Association> newAssociations = new ArrayList<>(associations);
-            newAssociations.add((Association) property);
+            newAssociations.add(association);
             PersistentEntity associatedEntity = association.getAssociatedEntity();
-            if (!associatedEntity.hasIdentity()) {
-                throw new IllegalStateException("Identity cannot be missing for: " + associatedEntity);
+            Collection<? extends PersistentProperty> identityProperties = associatedEntity.getIdentityProperties();
+            if (identityProperties.isEmpty()) {
+                // Identity-less associations behave like embedded value objects.
+                for (Association traversedAssociation : associations) {
+                    if (traversedAssociation.getAssociatedEntity() == associatedEntity) {
+                        // The value object refers back to itself, traversing it would never terminate
+                        return;
+                    }
+                }
+                for (PersistentProperty associatedProperty : associatedEntity.getPersistentProperties()) {
+                    traversePersistentProperties(newAssociations, associatedProperty, traverseEmbedded, consumerProperty);
+                }
+                return;
             }
-            PersistentProperty assocIdentity = associatedEntity.getIdentity();
-            if (assocIdentity instanceof Association) {
-                traversePersistentProperties(newAssociations, assocIdentity, consumerProperty);
-            } else {
-                // In case there is JoinColumn defined on property, we might use specified column
-                // instead of association id
-                PersistentProperty joinColumnAssocIdentity = getJoinColumnAssocIdentity(property, associatedEntity);
-                if (joinColumnAssocIdentity != null) {
-                    consumerProperty.accept(newAssociations, joinColumnAssocIdentity);
+            // A single JoinColumn can name the column to use instead of the association id, but it
+            // cannot stand in for a composite identity, which maps a column each.
+            PersistentProperty joinColumnIdentity = identityProperties.size() == 1
+                ? getJoinColumnAssocIdentity(property, associatedEntity)
+                : null;
+            for (PersistentProperty identityProperty : identityProperties) {
+                if (identityProperty instanceof Association) {
+                    traversePersistentProperties(newAssociations, identityProperty, traverseEmbedded, consumerProperty);
                 } else {
-                    consumerProperty.accept(newAssociations, assocIdentity);
+                    consumerProperty.accept(newAssociations,
+                        joinColumnIdentity != null ? joinColumnIdentity : identityProperty);
                 }
             }
         } else {

--- a/data-model/src/test/java/io/micronaut/data/model/PersistentEntityUtilsTest.java
+++ b/data-model/src/test/java/io/micronaut/data/model/PersistentEntityUtilsTest.java
@@ -1,0 +1,535 @@
+package io.micronaut.data.model;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.data.annotation.sql.JoinColumn;
+import io.micronaut.data.annotation.sql.JoinColumns;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersistentEntityUtilsTest {
+
+    private record Visit(List<Association> associations, PersistentProperty property) {
+    }
+
+    private static List<Visit> traverse(PersistentProperty property) {
+        List<Visit> visits = new ArrayList<>();
+        PersistentEntityUtils.traversePersistentProperties(property,
+            (associations, p) -> visits.add(new Visit(List.copyOf(associations), p)));
+        return visits;
+    }
+
+    private static List<Visit> traverse(PersistentProperty property, boolean traverseEmbedded) {
+        List<Visit> visits = new ArrayList<>();
+        PersistentEntityUtils.traversePersistentProperties(Collections.emptyList(), property, traverseEmbedded,
+            (associations, p) -> visits.add(new Visit(List.copyOf(associations), p)));
+        return visits;
+    }
+
+    @Test
+    void visitsPlainProperty() {
+        TestEntity entity = new TestEntity("Entity", null, null, new TestProperty("id"), new TestProperty("name"));
+        TestProperty name = (TestProperty) entity.getPropertyByName("name");
+
+        List<Visit> visits = traverse(name);
+
+        assertEquals(1, visits.size());
+        assertSame(name, visits.get(0).property());
+        assertTrue(visits.get(0).associations().isEmpty());
+    }
+
+    @Test
+    void traversesEmbeddedProperties() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"), new TestProperty("e2"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        List<Visit> visits = traverse(embedded);
+
+        assertEquals(Set.of("e1", "e2"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(embedded), visit.associations());
+        }
+    }
+
+    @Test
+    void keepsEmbeddedPropertyWhenNotTraversingEmbedded() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        List<Visit> visits = traverse(embedded, false);
+
+        assertEquals(1, visits.size());
+        assertSame(embedded, visits.get(0).property());
+        assertTrue(visits.get(0).associations().isEmpty());
+    }
+
+    @Test
+    void keepsEmbeddedIdentityOfAssociationWhenNotTraversingEmbedded() {
+        TestProperty idValue = new TestProperty("value");
+        TestEntity idEntity = new TestEntity("Id", idValue, null, idValue);
+        TestEntity parent = new TestEntity("Parent", null, null, new TestEmbedded("id", idEntity));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+        TestEmbedded embeddedId = (TestEmbedded) parent.getPropertyByName("id");
+
+        List<Visit> visits = traverse(parentAssociation, false);
+
+        assertEquals(1, visits.size());
+        assertSame(embeddedId, visits.get(0).property());
+        assertEquals(List.of(parentAssociation), visits.get(0).associations());
+    }
+
+    @Test
+    void keepsEmbeddedPropertyOfIdentityLessAssociationWhenNotTraversingEmbedded() {
+        TestEntity addressEntity = new TestEntity("Address", null, null, new TestProperty("street"));
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestEmbedded("address", addressEntity));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+        TestEmbedded address = (TestEmbedded) valueObject.getPropertyByName("address");
+
+        List<Visit> visits = traverse(valueAssociation, false);
+
+        assertEquals(1, visits.size());
+        assertSame(address, visits.get(0).property());
+        assertEquals(List.of(valueAssociation), visits.get(0).associations());
+    }
+
+    @Test
+    void skipsForeignKeyAssociations() {
+        TestEntity childEntity = new TestEntity("Child", null, null, new TestProperty("id"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("children", childEntity, true));
+        TestAssociation children = (TestAssociation) entity.getPropertyByName("children");
+
+        List<Visit> visits = traverse(children);
+
+        assertTrue(visits.isEmpty());
+    }
+
+    @Test
+    void visitsSingleIdentityOfAssociation() {
+        TestProperty parentId = new TestProperty("id");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, new TestProperty("name"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(parentId, visits.get(0).property());
+        assertEquals(List.of(parentAssociation), visits.get(0).associations());
+    }
+
+    @Test
+    void recursesIntoAssociationIdentity() {
+        TestProperty idValue = new TestProperty("value");
+        TestEntity idEntity = new TestEntity("Id", idValue, null, idValue);
+        TestEntity parent = new TestEntity("Parent", null, null, new TestEmbedded("id", idEntity));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+        TestEmbedded embeddedId = (TestEmbedded) parent.getPropertyByName("id");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(idValue, visits.get(0).property());
+        assertEquals(List.of(parentAssociation, embeddedId), visits.get(0).associations());
+    }
+
+    @Test
+    void visitsEachCompositeIdentityProperty() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(Set.of("tenantId", "refId"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(parentAssociation), visit.associations());
+        }
+    }
+
+    @Test
+    void traversesPropertiesOfIdentityLessAssociation() {
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestProperty("key"), new TestProperty("data"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        List<Visit> visits = traverse(valueAssociation);
+
+        assertEquals(Set.of("key", "data"), visits.stream().map(v -> v.property().getName()).collect(toSet()));
+        for (Visit visit : visits) {
+            assertEquals(List.of(valueAssociation), visit.associations());
+        }
+    }
+
+    @Test
+    void stopsAtSelfReferencingIdentityLessAssociation() {
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestProperty("data"));
+        valueObject.addProperty(new TestAssociation("self", valueObject, false));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        List<Visit> visits = traverse(valueAssociation);
+
+        assertEquals(List.of("data"), visits.stream().map(v -> v.property().getName()).toList());
+    }
+
+    @Test
+    void usesJoinColumnInsteadOfSingleIdentity() {
+        TestProperty parentId = new TestProperty("id");
+        TestProperty code = new TestProperty("code");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, code);
+        TestEntity entity = new TestEntity("Entity", null, null,
+            new TestAssociation("parent", parent, false, joinColumns("code")));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(1, visits.size());
+        assertSame(code, visits.get(0).property());
+    }
+
+    @Test
+    void ignoresJoinColumnForCompositeIdentity() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId);
+        TestEntity entity = new TestEntity("Entity", null, null,
+            new TestAssociation("parent", parent, false, joinColumns("tenantId")));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        List<Visit> visits = traverse(parentAssociation);
+
+        assertEquals(List.of(tenantId, refId), visits.stream().map(Visit::property).toList());
+    }
+
+    @Test
+    void embeddedAssociationIsAccessibleWithoutJoin() {
+        TestEntity embeddedEntity = new TestEntity("Embedded", null, null, new TestProperty("e1"));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestEmbedded("embedded", embeddedEntity));
+        TestEmbedded embedded = (TestEmbedded) entity.getPropertyByName("embedded");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(embedded, embeddedEntity.getPropertyByName("e1")));
+    }
+
+    @Test
+    void foreignKeyAssociationIsNotAccessibleWithoutJoin() {
+        TestProperty childId = new TestProperty("id");
+        TestEntity child = new TestEntity("Child", childId, null, childId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("children", child, true));
+        TestAssociation children = (TestAssociation) entity.getPropertyByName("children");
+
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(children, childId));
+    }
+
+    @Test
+    void onlyIdentityIsAccessibleWithoutJoin() {
+        TestProperty parentId = new TestProperty("id");
+        TestProperty name = new TestProperty("name");
+        TestEntity parent = new TestEntity("Parent", parentId, null, parentId, name);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, parentId));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, name));
+    }
+
+    @Test
+    void embeddedIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty idValue = new TestProperty("value");
+        TestEntity idEntity = new TestEntity("Id", idValue, null, idValue);
+        TestEmbedded embeddedId = new TestEmbedded("id", idEntity);
+        TestEntity parent = new TestEntity("Parent", embeddedId, null, embeddedId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, idValue));
+    }
+
+    @Test
+    void eachCompositeIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty tenantId = new TestProperty("tenantId");
+        TestProperty refId = new TestProperty("refId");
+        TestProperty name = new TestProperty("name");
+        TestEntity parent = new TestEntity("Parent", null, new PersistentProperty[]{tenantId, refId}, tenantId, refId, name);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, tenantId));
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, refId));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, name));
+    }
+
+    @Test
+    void selfReferencingIdentityLessAssociationDoesNotStackOverflowWhenCheckingAccessibility() {
+        TestEntity valueObject = new TestEntity("Value", null, null, new TestProperty("data"));
+        valueObject.addProperty(new TestAssociation("self", valueObject, false));
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+        TestProperty data = (TestProperty) valueObject.getPropertyByName("data");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, data));
+    }
+
+    @Test
+    void identityLessAssociationPropertiesAreAccessibleWithoutJoin() {
+        TestProperty data = new TestProperty("data");
+        TestEntity valueObject = new TestEntity("Value", null, null, data);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, data));
+        assertFalse(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, new TestProperty("other")));
+    }
+
+    @Test
+    void nestedEmbeddedPropertyOfIdentityLessAssociationIsAccessibleWithoutJoin() {
+        TestProperty street = new TestProperty("street");
+        TestEntity addressEntity = new TestEntity("Address", null, null, street);
+        TestEmbedded address = new TestEmbedded("address", addressEntity);
+        TestEntity valueObject = new TestEntity("Value", null, null, address);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("value", valueObject, false));
+        TestAssociation valueAssociation = (TestAssociation) entity.getPropertyByName("value");
+
+        // traversal reaches the nested leaf, so accessibility has to agree with it
+        assertEquals(List.of(street), traverse(valueAssociation).stream().map(Visit::property).toList());
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(valueAssociation, street));
+    }
+
+    @Test
+    void nestedEmbeddedIdentityPropertyIsAccessibleWithoutJoin() {
+        TestProperty value = new TestProperty("value");
+        TestEntity innerEntity = new TestEntity("Inner", null, null, value);
+        TestEmbedded inner = new TestEmbedded("inner", innerEntity);
+        TestEntity idEntity = new TestEntity("Id", null, null, inner);
+        TestEmbedded embeddedId = new TestEmbedded("id", idEntity);
+        TestEntity parent = new TestEntity("Parent", embeddedId, null, embeddedId);
+        TestEntity entity = new TestEntity("Entity", null, null, new TestAssociation("parent", parent, false));
+        TestAssociation parentAssociation = (TestAssociation) entity.getPropertyByName("parent");
+
+        assertEquals(List.of(value), traverse(parentAssociation).stream().map(Visit::property).toList());
+        assertTrue(PersistentEntityUtils.isAccessibleWithoutJoin(parentAssociation, value));
+    }
+
+    private static AnnotationMetadata joinColumns(String... referencedColumnNames) {
+        List<AnnotationValue<JoinColumn>> joinColumns = Arrays.stream(referencedColumnNames)
+            .map(columnName -> AnnotationValue.builder(JoinColumn.class)
+                .member("referencedColumnName", columnName)
+                .build())
+            .toList();
+        Map<String, Map<CharSequence, Object>> annotations =
+            Map.of(JoinColumns.class.getName(), Map.of(AnnotationMetadata.VALUE_MEMBER, joinColumns));
+        return new DefaultAnnotationMetadata(annotations, Collections.emptyMap(), Collections.emptyMap(),
+            annotations, Collections.emptyMap());
+    }
+
+    static final class TestEntity extends AbstractPersistentEntity {
+
+        private final String name;
+        private final PersistentProperty identity;
+        private final PersistentProperty[] compositeIdentity;
+        private final List<PersistentProperty> properties;
+
+        TestEntity(String name, PersistentProperty identity, PersistentProperty[] compositeIdentity, PersistentProperty... properties) {
+            super(new AnnotationMetadataProvider() {
+                @Override
+                public AnnotationMetadata getAnnotationMetadata() {
+                    return AnnotationMetadata.EMPTY_METADATA;
+                }
+            });
+            this.name = name;
+            this.identity = identity;
+            this.compositeIdentity = compositeIdentity;
+            this.properties = new ArrayList<>(List.of(properties));
+            for (PersistentProperty property : properties) {
+                own(property);
+            }
+        }
+
+        TestEntity addProperty(PersistentProperty property) {
+            properties.add(property);
+            own(property);
+            return this;
+        }
+
+        private void own(PersistentProperty property) {
+            if (property instanceof TestProperty testProperty) {
+                testProperty.owner = this;
+            }
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean hasCompositeIdentity() {
+            return compositeIdentity != null;
+        }
+
+        @Override
+        public boolean hasIdentity() {
+            return identity != null;
+        }
+
+        @Override
+        public PersistentProperty getIdentity() {
+            return identity;
+        }
+
+        @Override
+        public PersistentProperty[] getCompositeIdentity() {
+            return compositeIdentity;
+        }
+
+        @Override
+        public PersistentProperty getVersion() {
+            return null;
+        }
+
+        @Override
+        public boolean hasVersion() {
+            return false;
+        }
+
+        @Override
+        public Collection<? extends PersistentProperty> getPersistentProperties() {
+            return properties;
+        }
+
+        @Override
+        public PersistentProperty getPropertyByName(String propertyName) {
+            for (PersistentProperty property : properties) {
+                if (property.getName().equals(propertyName)) {
+                    return property;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public PersistentProperty getPropertyByNameIgnoreCase(String propertyName) {
+            for (PersistentProperty property : properties) {
+                if (property.getName().equalsIgnoreCase(propertyName)) {
+                    return property;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Collection<String> getPersistentPropertyNames() {
+            return properties.stream().map(PersistentProperty::getName).toList();
+        }
+
+        @Override
+        public boolean isOwningEntity(PersistentEntity owner) {
+            return false;
+        }
+
+        @Override
+        public PersistentEntity getParentEntity() {
+            return null;
+        }
+    }
+
+    static class TestProperty implements PersistentProperty {
+
+        private final String name;
+        private final AnnotationMetadata annotationMetadata;
+        private TestEntity owner;
+
+        TestProperty(String name) {
+            this(name, AnnotationMetadata.EMPTY_METADATA);
+        }
+
+        TestProperty(String name, AnnotationMetadata annotationMetadata) {
+            this.name = name;
+            this.annotationMetadata = annotationMetadata;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getTypeName() {
+            return String.class.getName();
+        }
+
+        @Override
+        public PersistentEntity getOwner() {
+            return owner;
+        }
+
+        @Override
+        public boolean isAssignable(String type) {
+            return String.class.getName().equals(type);
+        }
+
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return annotationMetadata;
+        }
+
+        @Override
+        public String getPersistedName() {
+            return name;
+        }
+    }
+
+    static class TestAssociation extends TestProperty implements Association {
+
+        private final TestEntity associatedEntity;
+        private final boolean foreignKey;
+
+        TestAssociation(String name, TestEntity associatedEntity, boolean foreignKey) {
+            this(name, associatedEntity, foreignKey, AnnotationMetadata.EMPTY_METADATA);
+        }
+
+        TestAssociation(String name, TestEntity associatedEntity, boolean foreignKey, AnnotationMetadata annotationMetadata) {
+            super(name, annotationMetadata);
+            this.associatedEntity = associatedEntity;
+            this.foreignKey = foreignKey;
+        }
+
+        @Override
+        public PersistentEntity getAssociatedEntity() {
+            return associatedEntity;
+        }
+
+        @Override
+        public boolean isForeignKey() {
+            return foreignKey;
+        }
+    }
+
+    static final class TestEmbedded extends TestAssociation implements Embedded {
+
+        TestEmbedded(String name, TestEntity associatedEntity) {
+            super(name, associatedEntity, false);
+        }
+    }
+}

--- a/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
+++ b/data-processor/src/test/groovy/io/micronaut/data/processor/sql/CompositePrimaryKeySpec.groovy
@@ -259,4 +259,116 @@ interface EntityWithIdClassRepository extends CrudRepository<EntityWithIdClass, 
         then:
         sql2.startsWith('SELECT project_."department_id",project_."project_id"')
     }
+
+    void "test nested embedded id property of an association resolves to the owning table"() {
+        given:"an association whose target has an embedded id containing a further embedded"
+        def repository = buildRepository('test.ParcelRepository', """
+import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+class Shipment {
+    @EmbeddedId
+    private ShipmentId shipmentId;
+    private String name;
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+
+    public void setShipmentId(ShipmentId shipmentId) {
+        this.shipmentId = shipmentId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+@Embeddable
+class ShipmentId {
+    @Embedded
+    private ShipmentRegion region;
+    private int number;
+
+    public ShipmentRegion getRegion() {
+        return region;
+    }
+
+    public void setRegion(ShipmentRegion region) {
+        this.region = region;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+}
+
+@Embeddable
+class ShipmentRegion {
+    private String country;
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+}
+
+@Entity
+class Parcel {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @ManyToOne
+    private Shipment shipment;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Shipment getShipment() {
+        return shipment;
+    }
+
+    public void setShipment(Shipment shipment) {
+        this.shipment = shipment;
+    }
+}
+
+@Repository
+@RepositoryConfiguration(queryBuilder=SqlQueryBuilder.class, implicitQueries = false, namedParameters = false)
+@io.micronaut.context.annotation.Executable
+interface ParcelRepository extends GenericRepository<Parcel, Long> {
+
+    List<Parcel> findByShipmentShipmentIdRegionCountry(String country);
+}
+""")
+
+        when:"the query filters on the nested leaf of that embedded id"
+        def method = repository.findPossibleMethods("findByShipmentShipmentIdRegionCountry").findFirst().get()
+        def query = getQuery(method)
+
+        then:"the leaf resolves to the foreign key column on the owning table, not to the join alias"
+        // The predicate has to read the owning table's FK columns, not the joined alias
+        query == 'SELECT parcel_."id",parcel_."shipment_country",parcel_."shipment_number" FROM "parcel" parcel_ INNER JOIN "shipment" parcel_shipment_ ON parcel_."shipment_country"=parcel_shipment_."country" AND parcel_."shipment_number"=parcel_shipment_."number" WHERE (parcel_."shipment_country" = ?)'
+    }
 }


### PR DESCRIPTION
Split out of #4027, which targets 5.2.x. This part applies to 5.1.x on its own and does not depend on the other split PR.

## Problem

Navigating a property path into an association whose target has a composite identity, or no identity at all, resolved the leaf against the owning entity. `traversePersistentProperties` demanded a single identity property and threw `IllegalStateException: Identity cannot be missing` otherwise, and `isAccessibleWithoutJoin` matched only the top level of an embedded identity, so a nested component looked unreachable and forced a needless join.

## Changes

- `traversePersistentProperties` recurses through composite identity properties, and through the properties of an identity-less association target, which a document store stores inline.
- A single `@JoinColumn` no longer substitutes for a composite identity, since one referenced column cannot stand in for several.
- `isAccessibleWithoutJoin` recurses through embedded properties, so a nested embedded identity component is recognised as reachable via the owning table's foreign key columns.
- Both traversals carry a cycle guard, so a self-referential embeddable or identity-less association terminates instead of overflowing the stack.
- Recursing through an association carries `traverseEmbedded` instead of defaulting it to `true`. This also corrects a pre-existing site, the branch where an identity property is itself an association.

## Tests

New `PersistentEntityUtilsTest` covers each traversal shape, the accessibility contract, the cycle guards, and both `traverseEmbedded` sites. `CompositePrimaryKeySpec` gains a case asserting the generated SQL for a nested embedded id, which previously read the joined alias instead of the owning table's foreign key columns.

Verified on 5.1.x: `:micronaut-data-model:test` 188 passed, `:micronaut-data-processor:test` 1086 passed, `:micronaut-data-runtime:test` 366 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)