### PR TITLE
Navigate through an association in criteria without demanding an explicit join

### DIFF
--- a/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/SourcePersistentPropertyPathImpl.java
+++ b/data-processor/src/main/java/io/micronaut/data/processor/model/criteria/impl/SourcePersistentPropertyPathImpl.java
@@ -17,11 +17,17 @@ package io.micronaut.data.processor.model.criteria.impl;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.Association;
+import io.micronaut.data.model.PersistentEntityUtils;
+import io.micronaut.data.model.jpa.criteria.PersistentAssociationPath;
+import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
+import io.micronaut.data.model.jpa.criteria.impl.AbstractPersistentEntityFrom;
 import io.micronaut.data.model.jpa.criteria.impl.DefaultPersistentPropertyPath;
+import io.micronaut.data.processor.model.SourceAssociation;
 import io.micronaut.data.processor.model.SourcePersistentProperty;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -36,11 +42,13 @@ final class SourcePersistentPropertyPathImpl<T> extends DefaultPersistentPropert
 
     private final Path<?> parentPath;
     private final SourcePersistentProperty sourcePersistentProperty;
+    private final CriteriaBuilder criteriaBuilder;
 
     public SourcePersistentPropertyPathImpl(Path<?> parentPath, List<Association> path, SourcePersistentProperty persistentProperty, CriteriaBuilder criteriaBuilder) {
         super(persistentProperty, path, criteriaBuilder);
         this.parentPath = parentPath;
         this.sourcePersistentProperty = persistentProperty;
+        this.criteriaBuilder = criteriaBuilder;
     }
 
     @Override
@@ -51,6 +59,22 @@ final class SourcePersistentPropertyPathImpl<T> extends DefaultPersistentPropert
     @Override
     public SourcePersistentProperty getProperty() {
         return sourcePersistentProperty;
+    }
+
+    @Override
+    public <Y> PersistentPropertyPath<Y> get(String attributeName) {
+        if (sourcePersistentProperty instanceof SourceAssociation association
+            && parentPath instanceof AbstractPersistentEntityFrom<?, ?> from) {
+            SourcePersistentProperty target = association.getAssociatedEntity().getPropertyByNameIgnoreCase(attributeName);
+            if (target != null && PersistentEntityUtils.isAccessibleWithoutJoin(association, target)) {
+                List<Association> associations = new ArrayList<>(getAssociations());
+                associations.add(association);
+                return new SourcePersistentPropertyPathImpl<>(parentPath, associations, target, criteriaBuilder);
+            }
+            PersistentAssociationPath<?, ?> join = from.join(association.getName());
+            return join.get(attributeName);
+        }
+        return super.get(attributeName);
     }
 
     @Override

--- a/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/RuntimePersistentPropertyPathImpl.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/criteria/RuntimePersistentPropertyPathImpl.java
@@ -17,11 +17,17 @@ package io.micronaut.data.runtime.criteria;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.Association;
+import io.micronaut.data.model.PersistentEntityUtils;
+import io.micronaut.data.model.jpa.criteria.PersistentAssociationPath;
+import io.micronaut.data.model.jpa.criteria.PersistentPropertyPath;
+import io.micronaut.data.model.jpa.criteria.impl.AbstractPersistentEntityFrom;
 import io.micronaut.data.model.jpa.criteria.impl.DefaultPersistentPropertyPath;
+import io.micronaut.data.model.runtime.RuntimeAssociation;
 import io.micronaut.data.model.runtime.RuntimePersistentProperty;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Path;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,6 +43,7 @@ final class RuntimePersistentPropertyPathImpl<I, T> extends DefaultPersistentPro
 
     private final Path<?> parentPath;
     private final RuntimePersistentProperty<I> runtimePersistentProperty;
+    private final CriteriaBuilder criteriaBuilder;
 
     RuntimePersistentPropertyPathImpl(Path<?> parentPath,
                                              List<Association> path,
@@ -45,11 +52,28 @@ final class RuntimePersistentPropertyPathImpl<I, T> extends DefaultPersistentPro
         super(persistentProperty, path, criteriaBuilder);
         this.parentPath = parentPath;
         this.runtimePersistentProperty = persistentProperty;
+        this.criteriaBuilder = criteriaBuilder;
     }
 
     @Override
     public Path<?> getParentPath() {
         return parentPath;
+    }
+
+    @Override
+    public <Y> PersistentPropertyPath<Y> get(String attributeName) {
+        if (runtimePersistentProperty instanceof RuntimeAssociation<?> association
+            && parentPath instanceof AbstractPersistentEntityFrom<?, ?> from) {
+            RuntimePersistentProperty<?> target = association.getAssociatedEntity().getPropertyByNameIgnoreCase(attributeName);
+            if (target != null && PersistentEntityUtils.isAccessibleWithoutJoin(association, target)) {
+                List<Association> associations = new ArrayList<>(getAssociations());
+                associations.add(association);
+                return new RuntimePersistentPropertyPathImpl<>(parentPath, associations, (RuntimePersistentProperty) target, criteriaBuilder);
+            }
+            PersistentAssociationPath<?, ?> join = from.join(association.getName());
+            return join.get(attributeName);
+        }
+        return super.get(attributeName);
     }
 
     @Override

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
@@ -43,7 +43,17 @@ class CriteriaSpec extends AbstractCriteriaSpec {
 
             @Override
              <T> RuntimePersistentEntity<T> getEntity(Class<T> type) {
-                return map.computeIfAbsent(type, RuntimePersistentEntity::new)
+                RuntimeEntityRegistry entityRegistry = this
+                // Properties are compared by identity, so every lookup for a type has to return
+                // the same entity instance, including entities reached through an association.
+                return map.computeIfAbsent(type, { Class entityType ->
+                    new RuntimePersistentEntity<Object>(entityType) {
+                        @Override
+                        protected RuntimePersistentEntity<Object> getEntity(Class<Object> nestedType) {
+                            return entityRegistry.getEntity(nestedType)
+                        }
+                    }
+                })
             }
 
             @Override
@@ -96,7 +106,7 @@ class CriteriaSpec extends AbstractCriteriaSpec {
             String query = getSqlQuery(criteriaQuery)
 
         expect:
-            query == '''SELECT book_."id",book_."author_id",book_."title",book_."pages",book_."publisher_id" FROM "book" book_ WHERE (book_."id" IN (SELECT book_book_."id" FROM "book" book_book_ INNER JOIN "author" book_book_author_ ON book_book_."author_id"=book_book_author_."id" WHERE (book_book_author_."id" = book_book_author_."id"))) ORDER BY book_."title" ASC'''
+            query == '''SELECT book_."id",book_."author_id",book_."title",book_."pages",book_."publisher_id" FROM "book" book_ WHERE (book_."id" IN (SELECT book_book_."id" FROM "book" book_book_ WHERE (book_book_."author_id" = book_book_."author_id"))) ORDER BY book_."title" ASC'''
     }
 
     void "test subquery IN with JOIN"() {
@@ -395,6 +405,44 @@ class CriteriaSpec extends AbstractCriteriaSpec {
             "amount"  | BigDecimal.valueOf(100) | "ge"                   | '(NOT(test_."amount" >= ?))'
             "amount"  | BigDecimal.valueOf(100) | "lt"                   | '(NOT(test_."amount" < ?))'
             "amount"  | BigDecimal.valueOf(100) | "le"                   | '(NOT(test_."amount" <= ?))'
+    }
+
+    void "test criteria navigation across MANY_TO_ONE association creates an implicit join for a non-FK leaf"() {
+        given:
+            def criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            def otherEntityRoot = criteriaQuery.from(OtherEntity)
+
+        when: "navigating to a property that lives on the associated table using chained get()"
+            criteriaQuery.where(criteriaBuilder.equal(otherEntityRoot.get("test").get("name"), "testValue"))
+            String query = getSqlQuery(criteriaQuery)
+
+        then:
+            query.contains('INNER JOIN "test"')
+            query.contains('test_."name"')
+
+        when: "navigating using the static metamodel"
+            criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            otherEntityRoot = criteriaQuery.from(OtherEntity)
+            criteriaQuery.where(criteriaBuilder.equal(otherEntityRoot.get(OtherEntity_.test).get(Test_.name), "testValue"))
+            String query2 = getSqlQuery(criteriaQuery)
+
+        then:
+            query2.contains('INNER JOIN "test"')
+            query2.contains('test_."name"')
+    }
+
+    void "test criteria navigation to the association's own identity does not require a join"() {
+        given:
+            def criteriaQuery = criteriaBuilder.createQuery(OtherEntity)
+            def otherEntityRoot = criteriaQuery.from(OtherEntity)
+
+        when: "navigating to the association's id, which the owning table already stores as a FK column"
+            criteriaQuery.where(criteriaBuilder.equal(otherEntityRoot.get("test").get("id"), 1L))
+            String query = getSqlQuery(criteriaQuery)
+
+        then: "the FK column is used directly instead of joining to the associated table"
+            !query.contains('JOIN')
+            query.contains('"test_id"')
     }
 
 }


### PR DESCRIPTION
Split out of #4027, which targets 5.2.x. This part applies to 5.1.x on its own and does not depend on the other split PR (#4031).

## Problem

Chaining `get()` through an association threw:

```
java.lang.IllegalStateException: An association: [test] needs to be joined before it can be accessed
  at io.micronaut.data.model.jpa.criteria.impl.DefaultPersistentPropertyPath.get(DefaultPersistentPropertyPath.java:136)
```

So a criteria query could not express what the equivalent derived query already supported.

## Changes

- Navigating to a leaf that lives on the associated table registers the join implicitly. Applied to both the runtime and the source property path implementations, so the API behaves the same at compile time.
- A leaf the owning table already stores, such as the association's own identity behind a foreign key column, is gated on `isAccessibleWithoutJoin` and creates no join. `findByTestId` and the equivalent criteria query now agree on the emitted SQL.

## Note on the changed assertion

`CriteriaSpec`'s entity registry returned a fresh `RuntimePersistentEntity` per lookup, while property paths are compared by identity. An association target's own identity therefore looked unreachable, and the expected subquery SQL had a join baked into it that the equivalent derived query never produced. The registry now caches one instance per type, and the `test subquery IN` expectation changes to the foreign key form to match.

## Tests

`CriteriaSpec` gains a case for navigating to a property on the associated table, covering both the string and the static metamodel form, and a case asserting that navigating to the association's own identity emits no join.

Verified on 5.1.x: `:micronaut-data-runtime:test` 368 passed, `:micronaut-data-processor:test` 1085 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)