### PR TITLE
Fix NullAway errors from Reactor 3.8 nullable block()

### DIFF
--- a/data-connection/src/main/java/io/micronaut/data/connection/sync/SynchronousConnectionOperationsFromReactiveConnectionOperations.java
+++ b/data-connection/src/main/java/io/micronaut/data/connection/sync/SynchronousConnectionOperationsFromReactiveConnectionOperations.java
@@ -56,6 +56,8 @@ public final class SynchronousConnectionOperationsFromReactiveConnectionOperatio
     }
 
     @Override
+    // The callback may return null, which completes the Mono empty and is returned as null by block()
+    @SuppressWarnings("NullAway")
     public <R> R execute(ConnectionDefinition definition, Function<ConnectionStatus<T>, R> callback) {
         Mono<R> result = reactorConnectionOperations.withConnectionMono(definition, status -> Mono.deferContextual(contextView -> {
             PropagatedContext propagatedContext = ReactorPropagation.findPropagatedContext(contextView).orElseGet(PropagatedContext::getOrEmpty);

--- a/data-model/src/main/java/io/micronaut/data/operations/reactive/BlockingReactorRepositoryOperations.java
+++ b/data-model/src/main/java/io/micronaut/data/operations/reactive/BlockingReactorRepositoryOperations.java
@@ -32,6 +32,7 @@ import reactor.util.context.Context;
 import reactor.util.context.ContextView;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -68,7 +69,8 @@ public interface BlockingReactorRepositoryOperations extends RepositoryOperation
         return reactive().findAll(preparedQuery)
             .contextWrite(getContextView())
             .collectList()
-            .block();
+            .blockOptional()
+            .orElseGet(List::of);
     }
 
     @Override
@@ -133,7 +135,8 @@ public interface BlockingReactorRepositoryOperations extends RepositoryOperation
         return reactive().execute(preparedQuery)
             .contextWrite(getContextView())
             .collectList()
-            .block();
+            .blockOptional()
+            .orElseGet(List::of);
     }
 
     @Override
@@ -159,9 +162,9 @@ public interface BlockingReactorRepositoryOperations extends RepositoryOperation
 
     @Override
     default <R> Page<R> findPage(PagedQuery<R> query) {
-        return reactive().findPage(query)
+        return Objects.requireNonNull(reactive().findPage(query)
             .contextWrite(getContextView())
-            .block();
+            .block(), "The reactive findPage operation completed without emitting a page");
     }
 
     @Override


### PR DESCRIPTION
Unblocks the core 5.2 bump in #4035, part of the core 5.2 rollout tracked in micronaut-projects/micronaut-core#13110.

Core 5.2 manages Reactor 3.8, which annotates `Mono.block()` as JSpecify `@Nullable`. NullAway runs as an error in this build, so `compileJava` fails wherever a `block()` result is returned from a non-null method. Only two modules fail, but the first compile stops before the others; with this change `compileJava` passes for every module.

- `BlockingReactorRepositoryOperations.findAll(PreparedQuery)` and `execute`: `collectList()` always emits, so they now use `blockOptional().orElseGet(List::of)`, the pattern the other list methods in the interface already use.
- `BlockingReactorRepositoryOperations.findPage`: every reactive `findPage` implementation maps a collected list to a page, so an empty result is a bug. It is now `Objects.requireNonNull` with a message instead of a silent `null`.
- `SynchronousConnectionOperationsFromReactiveConnectionOperations.execute`: a `null` result is legitimate here, because the callback may return `null` and `Mono.justOrEmpty` turns that into an empty `Mono`. `ConnectionOperations.execute` declares a plain `<R> R`, and NullAway without JSpecify mode cannot express a nullable type variable, so the method carries `@SuppressWarnings("NullAway")`. `SynchronousTransactionOperationsFromReactiveTransactionOperations.execute` already does the same. Scope: that one method, not the module.

Verification:
- `./gradlew compileJava` passes for all modules on core 5.2.0 (Reactor 3.8) with #4035's catalog, and on this branch's core 5.1.12 (Reactor 3.7.12), so this can merge before the bump.
- On core 5.2.0, `:micronaut-data-model:check` (179 tests) and `:micronaut-data-connection:check` (17 tests) pass, as does `:micronaut-data-r2dbc:test --tests '*H2*'` (275 tests).
- On core 5.2.0, `:micronaut-data-jdbc:test --tests 'io.micronaut.data.jdbc.h2.*'` fails 4 of 753 tests, all `JdbcRepositorySpec` static metamodel tests with `Column "TIER" not found`. That failure is unrelated to this change: two `@MappedEntity` classes map to table `client` (the TCK `Client` and the one in `EmbeddedAssociationJoinSpec`). Which table H2 creates depends on the order introspections are found, and that order varies between runs on core 5.2. The same spec passes with this change on core 5.1.12 (27 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
