### PR TITLE
Pin MySQL test container image to 8.0 on 3.10.x

### DIFF
--- a/data-jdbc/src/test/resources/application.yml
+++ b/data-jdbc/src/test/resources/application.yml
@@ -7,6 +7,7 @@ test-resources:
       startup-timeout: 300s
     mysql:
       startup-timeout: 300s
+      image-name: mysql:8.0
     oracle:
       startup-timeout: 300s
       image-name: gvenzl/oracle-xe:latest-faststart

--- a/data-r2dbc/src/test/resources/application.yaml
+++ b/data-r2dbc/src/test/resources/application.yaml
@@ -7,6 +7,7 @@ test-resources:
       startup-timeout: 300s
     mysql:
       startup-timeout: 300s
+      image-name: mysql:8.0
     oracle:
       startup-timeout: 300s
       image-name: gvenzl/oracle-xe:latest-faststart


### PR DESCRIPTION
## Problem

[Java CI run 34401215053](https://github.com/micronaut-projects/micronaut-data/actions/runs/34401215053) on `3.10.x` was cancelled after all three JDK jobs (8, 11, 17) hit the 6h job limit.

`data-jdbc` and `data-r2dbc` don't set an image for the `mysql` test resource, so Test Resources pulls `mysql:latest`. That now resolves to **MySQL 26.7.0**, which aborts during init:

```
[ERROR] [MY-000068] [Server] unknown option '--skip-host-cache'.
[ERROR] [MY-013236] [Server] The designated data directory /var/lib/mysql/ is unusable.
[ERROR] [MY-010119] [Server] Aborting
```

Testcontainers retries the start 3 times (about 2 minutes each). Meanwhile the shared Test Resources server is blocked, so the MariaDB and MySQL specs fail with `ReadTimeoutException` after 5 minutes each. After that, `:data-jdbc:check` and `:data-r2dbc:check` never complete and the build sits idle until the runner cancels it.

## Fix

Pin `image-name: mysql:8.0` for the `mysql` test container in `data-jdbc` and `data-r2dbc`. This matches the `mysql-connector-java 8.0.31` driver used on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)