### PR TITLE
Implement Expression.in on the criteria expression base class

### DIFF
--- a/data-model/build.gradle
+++ b/data-model/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testCompileOnly mnSerde.micronaut.serde.processor
     testImplementation mn.micronaut.inject.java.test
+    testImplementation mnSql.jakarta.persistence.api
     testImplementation mnSerde.micronaut.serde.jackson
     testImplementation mn.micronaut.jackson.databind
     testImplementation(mnTest.micronaut.test.junit5)

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/AbstractExpression.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/expression/AbstractExpression.java
@@ -18,6 +18,14 @@ package io.micronaut.data.model.jpa.criteria.impl.expression;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.jpa.criteria.ExpressionType;
 import io.micronaut.data.model.jpa.criteria.IExpression;
+import io.micronaut.data.model.jpa.criteria.impl.predicate.InPredicate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The abstract expression.
@@ -43,5 +51,31 @@ public abstract class AbstractExpression<E> implements IExpression<E> {
     @Override
     public final ExpressionType<E> getExpressionType() {
         return expressionType;
+    }
+
+    @Override
+    public Predicate in(Object... values) {
+        return in(Arrays.asList(Objects.requireNonNull(values)));
+    }
+
+    @Override
+    public Predicate in(Expression<?>... values) {
+        return new InPredicate<>(this, Arrays.asList(values), null);
+    }
+
+    @Override
+    public Predicate in(Collection<?> values) {
+        List<Expression<?>> expressions = Objects.requireNonNull(values).stream().map(value -> {
+            if (value instanceof Expression<?> expression) {
+                return expression;
+            }
+            return new LiteralExpression<>(value);
+        }).toList();
+        return new InPredicate<>(this, expressions, null);
+    }
+
+    @Override
+    public Predicate in(Expression<Collection<?>> values) {
+        return new InPredicate<>(this, List.of(Objects.requireNonNull(values)), null);
     }
 }

--- a/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/predicate/InPredicate.java
+++ b/data-model/src/main/java/io/micronaut/data/model/jpa/criteria/impl/predicate/InPredicate.java
@@ -17,8 +17,10 @@ package io.micronaut.data.model.jpa.criteria.impl.predicate;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.data.model.jpa.criteria.impl.PredicateVisitor;
+import io.micronaut.data.model.jpa.criteria.impl.expression.LiteralExpression;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,13 +39,13 @@ public final class InPredicate<T> extends AbstractPredicate implements CriteriaB
 
     private final Expression<T> expression;
     private final List<Expression<?>> values;
-    private final CriteriaBuilder criteriaBuilder;
+    private final @Nullable CriteriaBuilder criteriaBuilder;
 
     public InPredicate(Expression<T> expression, CriteriaBuilder criteriaBuilder) {
         this(expression, Collections.emptyList(), criteriaBuilder);
     }
 
-    public InPredicate(Expression<T> expression, Collection<Expression<?>> values, CriteriaBuilder criteriaBuilder) {
+    public InPredicate(Expression<T> expression, Collection<Expression<?>> values, @Nullable CriteriaBuilder criteriaBuilder) {
         this.expression = expression;
         this.values = new ArrayList<>(values);
         this.criteriaBuilder = criteriaBuilder;
@@ -60,7 +62,7 @@ public final class InPredicate<T> extends AbstractPredicate implements CriteriaB
 
     @Override
     public InPredicate<T> value(T value) {
-        values.add(criteriaBuilder.literal(value));
+        values.add(criteriaBuilder == null ? new LiteralExpression<>(value) : criteriaBuilder.literal(value));
         return this;
     }
 

--- a/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder.java
+++ b/data-model/src/main/java/io/micronaut/data/model/query/builder/sql/AbstractSqlLikeQueryBuilder.java
@@ -2708,7 +2708,6 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             if (values.isEmpty()) {
                 return;
             }
-            PersistentPropertyPath propertyPath = requireProperty(expression).getPropertyPath();
             appendExpression(expression);
             query.append(negated ? " NOT IN (" : " IN (");
             boolean hasOneParameter = values.stream().filter(v -> v instanceof ParameterExpression).count() == 1;
@@ -2716,6 +2715,7 @@ public abstract class AbstractSqlLikeQueryBuilder implements QueryBuilder {
             while (iterator.hasNext()) {
                 Object value = iterator.next();
                 if (value instanceof ParameterExpression) {
+                    PersistentPropertyPath propertyPath = requireProperty(expression).getPropertyPath();
                     BindingParameter.BindingContext bindingContext = newBindingContext(propertyPath);
                     if (hasOneParameter) {
                         bindingContext = bindingContext.expandable();

--- a/data-model/src/test/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaInTest.java
+++ b/data-model/src/test/java/io/micronaut/data/model/jpa/criteria/impl/CriteriaInTest.java
@@ -1,0 +1,98 @@
+package io.micronaut.data.model.jpa.criteria.impl;
+
+import io.micronaut.data.model.jpa.criteria.impl.expression.AbstractExpression;
+import io.micronaut.data.model.jpa.criteria.impl.expression.LiteralExpression;
+import io.micronaut.data.model.jpa.criteria.impl.predicate.InPredicate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CriteriaInTest {
+
+    private static AbstractExpression<Long> expression() {
+        return new LiteralExpression<>(Long.class);
+    }
+
+    private static List<?> literalValues(InPredicate<?> in) {
+        return in.getValues().stream().map(v -> ((LiteralExpression<?>) v).getValue()).toList();
+    }
+
+    @Test
+    void inObjectVarargsWrapsValuesAsLiterals() {
+        AbstractExpression<Long> expression = expression();
+
+        Predicate predicate = expression.in(1L, 2L);
+
+        assertInstanceOf(InPredicate.class, predicate);
+        InPredicate<?> in = (InPredicate<?>) predicate;
+        assertSame(expression, in.getExpression());
+        assertEquals(List.of(1L, 2L), literalValues(in));
+    }
+
+    @Test
+    void inNullObjectVarargsIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Object[]) null));
+    }
+
+    @Test
+    void inExpressionVarargsKeepsExpressions() {
+        AbstractExpression<Long> expression = expression();
+        LiteralExpression<Long> value = new LiteralExpression<>(5L);
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(value);
+
+        assertEquals(List.of(value), in.getValues());
+    }
+
+    @Test
+    void inCollectionWrapsLiteralsAndKeepsExpressions() {
+        AbstractExpression<Long> expression = expression();
+        LiteralExpression<Long> expressionValue = new LiteralExpression<>(5L);
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(List.of(1L, expressionValue));
+
+        List<Expression<?>> values = in.getValues();
+        assertEquals(2, values.size());
+        assertEquals(1L, ((LiteralExpression<?>) values.get(0)).getValue());
+        assertSame(expressionValue, values.get(1));
+    }
+
+    @Test
+    void inNullCollectionIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Collection<?>) null));
+    }
+
+    @Test
+    void inSubqueryExpressionIsWrappedAsSingleValue() {
+        AbstractExpression<Long> expression = expression();
+        Expression<Collection<?>> subquery = new LiteralExpression<>(Collections.<Object>emptyList());
+
+        InPredicate<?> in = (InPredicate<?>) expression.in(subquery);
+
+        assertEquals(List.of(subquery), in.getValues());
+    }
+
+    @Test
+    void inNullSubqueryExpressionIsRejected() {
+        assertThrows(NullPointerException.class, () -> expression().in((Expression<Collection<?>>) null));
+    }
+
+    @Test
+    void inPredicateValueWithoutCriteriaBuilderWrapsAsLiteral() {
+        AbstractExpression<Long> expression = expression();
+
+        InPredicate<Long> in = new InPredicate<>(expression, List.of(), null);
+        in.value(42L);
+
+        assertEquals(List.of(42L), literalValues(in));
+    }
+}

--- a/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
+++ b/data-runtime/src/test/groovy/io/micronaut/data/runtime/criteria/CriteriaSpec.groovy
@@ -397,4 +397,16 @@ class CriteriaSpec extends AbstractCriteriaSpec {
             "amount"  | BigDecimal.valueOf(100) | "le"                   | '(NOT(test_."amount" <= ?))'
     }
 
+    void "test IN on a non-property expression renders"() {
+        given:
+            def criteriaQuery = criteriaBuilder.createQuery(Test)
+            def testRoot = criteriaQuery.from(Test)
+
+        when: "the IN list hangs off an expression that is not a property path"
+            criteriaQuery.where(criteriaBuilder.upper(testRoot.get("name")).in("A", "B"))
+            String query = getSqlQuery(criteriaQuery)
+
+        then: "the expression renders in place of the property path the builder used to require"
+            query.endsWith('WHERE (UPPER(test_."name") IN (\'A\',\'B\'))')
+    }
 }


### PR DESCRIPTION
Backport of #4033 to 5.1.x.

## Problem

Calling `in()` on a criteria expression threw `UnsupportedOperationException`, so an IN list could only hang off a property path.

## Changes

- `AbstractExpression` implements the four `in()` overloads, wrapping plain values as literals and keeping expressions as they are.
- `InPredicate` rejects a null value list instead of failing later.
- `visitIn` resolves the property path only for a parameter value, which is the one case that needs a binding context. Previously it resolved unconditionally, so a literal-only IN list on a non-property expression threw `IllegalStateException: Expression is expected to be a property path!` at render time.
- `data-model` includes Jakarta Persistence on its test classpath so the criteria-expression regression tests compile on 5.1.x.

## Tests

`CriteriaInTest` covers the object graph each overload builds. `CriteriaSpec` adds a case that renders a query, since the object graph alone did not catch the render-time failure above:

```
criteriaBuilder.upper(root.get("name")).in("A", "B")
→ ... WHERE (UPPER(test_."name") IN ('A','B'))
```

Verified on 5.1.x: `:micronaut-data-model:test --tests io.micronaut.data.model.jpa.criteria.impl.CriteriaInTest` passes 8 tests, and `:micronaut-data-runtime:test --tests io.micronaut.data.runtime.criteria.CriteriaSpec` passes 132 tests.
